### PR TITLE
[FE] feature: 헤더 메뉴 개편 및 사용자 프로필 추가

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,14 +1,25 @@
+import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 
 export default function Header() {
   const navigate = useNavigate();
 
-  const handleLogoClick = () => {
+  // 로그인 상태 관리 (임시)
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
+
+  const handleLogoClick = () => navigate("/");
+  const handlePlanClick = () => navigate("/mytrips");
+
+  // 로그인/로그아웃 핸들러
+  const handleLogin = () => setIsLoggedIn(true);
+  const handleLogout = () => {
+    setIsLoggedIn(false);
     navigate("/");
   };
 
-  const handleLoginClick = () => {
-    // 원본 동작 없음 (유지)
+  // 설정 버튼 클릭 시 알림창
+  const handleSettingsClick = () => {
+    alert("준비 중인 기능입니다.");
   };
 
   return (
@@ -19,6 +30,18 @@ export default function Header() {
 
       <nav>
         <ul>
+          {/* 1. MY PLAN (순서 변경 & 단일 버튼) */}
+          <li className="nav-group">
+            <button
+              className="nav-item"
+              type="button"
+              onClick={handlePlanClick}
+            >
+              MY PLAN ❯
+            </button>
+          </li>
+
+          {/* 2. COMMUNITY (드롭다운) */}
           <li className="nav-group">
             <button className="nav-item" type="button">
               COMMUNITY ▼
@@ -29,20 +52,35 @@ export default function Header() {
             </div>
           </li>
 
+          {/* 3. LOGIN / PROFILE SECTION */}
           <li className="nav-group">
-            <button className="nav-item" type="button">
-              MY PLAN ▼
-            </button>
-            <div className="dropdown-menu">
-              <a href="/mytrips">{">>"} ALL</a>
-            </div>
+            {!isLoggedIn ? (
+              <button className="btn-login" type="button" onClick={handleLogin}>
+                LOGIN
+              </button>
+            ) : (
+              <>
+                <button className="nav-item btn-profile" type="button">
+                  <div className="profile-circle"></div>
+                </button>
+                {/* 오른쪽 정렬 클래스 적용 */}
+                <div className="dropdown-menu dropdown-right">
+                  {/* 페이지 이동 대신 함수 호출 */}
+                  <button
+                    onClick={handleSettingsClick}
+                    className="dropdown-item-btn"
+                  >
+                    {">>"} SETTINGS
+                  </button>
+                  <button onClick={handleLogout} className="dropdown-item-btn">
+                    {">>"} LOGOUT
+                  </button>
+                </div>
+              </>
+            )}
           </li>
         </ul>
       </nav>
-
-      <button className="btn-login" type="button" onClick={handleLoginClick}>
-        LOGIN
-      </button>
     </header>
   );
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -7,10 +7,6 @@ export default function Header() {
     navigate("/");
   };
 
-  const handlePlanClick = () => {
-    navigate("/mytrips"); // My Plan 클릭 시 바로 이동
-  };
-
   const handleLoginClick = () => {
     // 원본 동작 없음 (유지)
   };
@@ -23,18 +19,6 @@ export default function Header() {
 
       <nav>
         <ul>
-          {/* 순서 변경 1: MY PLAN (토글 제거) */}
-          <li className="nav-group">
-            <button
-              className="nav-item"
-              type="button"
-              onClick={handlePlanClick}
-            >
-              MY PLAN ❯
-            </button>
-          </li>
-
-          {/* 순서 변경 2: COMMUNITY (드롭다운 유지) */}
           <li className="nav-group">
             <button className="nav-item" type="button">
               COMMUNITY ▼
@@ -42,6 +26,15 @@ export default function Header() {
             <div className="dropdown-menu">
               <a href="/community">{">>"} DATA LOGS</a>
               <a href="/mate">{">>"} MATE FINDER</a>
+            </div>
+          </li>
+
+          <li className="nav-group">
+            <button className="nav-item" type="button">
+              MY PLAN ▼
+            </button>
+            <div className="dropdown-menu">
+              <a href="/mytrips">{">>"} ALL</a>
             </div>
           </li>
         </ul>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -7,6 +7,10 @@ export default function Header() {
     navigate("/");
   };
 
+  const handlePlanClick = () => {
+    navigate("/mytrips"); // My Plan 클릭 시 바로 이동
+  };
+
   const handleLoginClick = () => {
     // 원본 동작 없음 (유지)
   };
@@ -19,6 +23,18 @@ export default function Header() {
 
       <nav>
         <ul>
+          {/* 순서 변경 1: MY PLAN (토글 제거) */}
+          <li className="nav-group">
+            <button
+              className="nav-item"
+              type="button"
+              onClick={handlePlanClick}
+            >
+              MY PLAN ❯
+            </button>
+          </li>
+
+          {/* 순서 변경 2: COMMUNITY (드롭다운 유지) */}
           <li className="nav-group">
             <button className="nav-item" type="button">
               COMMUNITY ▼
@@ -26,15 +42,6 @@ export default function Header() {
             <div className="dropdown-menu">
               <a href="/community">{">>"} DATA LOGS</a>
               <a href="/mate">{">>"} MATE FINDER</a>
-            </div>
-          </li>
-
-          <li className="nav-group">
-            <button className="nav-item" type="button">
-              MY PLAN ▼
-            </button>
-            <div className="dropdown-menu">
-              <a href="/mytrips">{">>"} ALL</a>
             </div>
           </li>
         </ul>

--- a/src/styles/Header.css
+++ b/src/styles/Header.css
@@ -49,13 +49,6 @@ nav ul {
   height: 100%;
 }
 
-.nav-group {
-  position: relative;
-  height: 100%;
-  display: flex;
-  align-items: center;
-}
-
 .nav-item {
   height: 100%;
   display: flex;
@@ -126,4 +119,79 @@ nav ul {
 .btn-login:hover {
   transform: translate(2px, 2px);
   box-shadow: none;
+}
+
+/* 마이페이지 */
+.nav-group {
+  position: relative;
+  height: 100%;
+  display: flex;
+  align-items: center;
+}
+
+/* 드롭다운 공통: 네비바 선 바로 아래(top: 100%) 위치 */
+.dropdown-menu {
+  display: none;
+  position: absolute;
+  top: 100%;
+  left: 0;
+  background: #fff;
+  border: 2px solid #000;
+  min-width: 180px;
+  box-shadow: 4px 4px 0px #000;
+  z-index: 9999;
+  flex-direction: column;
+}
+
+.nav-group:hover .dropdown-menu {
+  display: flex;
+}
+
+/* 오른쪽 정렬: 프로필 버튼이 벽 쪽에 있을 때 사용 */
+.dropdown-right {
+  left: auto;
+  right: 0;
+}
+
+.dropdown-menu a,
+.dropdown-item-btn {
+  display: block;
+  width: 100%;
+  padding: 12px 15px;
+  font-family: var(--font-mono);
+  font-weight: 700;
+  font-size: 14px;
+  color: #555;
+  text-align: left;
+  text-decoration: none;
+  transition: 0.2s;
+  border: none;
+  background: none;
+  border-bottom: 1px dashed #ddd;
+  cursor: pointer;
+}
+
+.dropdown-menu a:last-child,
+.dropdown-item-btn:last-child {
+  border-bottom: none;
+}
+
+.dropdown-menu a:hover,
+.dropdown-item-btn:hover {
+  background: #000;
+  color: #fff;
+}
+
+/* 프로필 버튼 디자인 */
+.profile-circle {
+  width: 35px;
+  height: 35px;
+  background-color: #000;
+  border-radius: 50%;
+  border: 2px solid #000;
+  transition: transform 0.2s;
+}
+
+.btn-profile:hover .profile-circle {
+  transform: scale(1.1);
 }


### PR DESCRIPTION
## 🎨 작업 내용 (What)

- 헤더 네비게이션 메뉴 순서 변경 (MY PLAN - COMMUNITY)
- MY PLAN 드롭다운 제거 및 /mytrips 페이지 직접 이동 적용
- 로그인 상태에 따른 사용자 프로필 버튼 및 드롭다운(SETTINGS, LOGOUT) 구현
- 디자인 가이드에 맞춰 MY PLAN 옆 흑백 기호(❯) 추가 및 CSS 정렬 최적화
- 아직 미구현된 SETTINGS 메뉴 클릭 시 안내 알림창(alert) 로직 추가

---

## 🧭 작업 목적 (Why)

- 서비스 핵심 메뉴인 '내 계획'의 접근 단계를 줄여 사용자 경험 개선
- 로그인 이후 개인화된 기능을 제공할 수 있는 UI 영역 확보
- 프로젝트의 미니멀한 흑백 디자인 톤 유지

---

## 🧩 변경 범위
- [x] UI / Layout
- [x] 컴포넌트
- [ ] 상태 관리
- [ ] API 연동
- [x] 스타일(CSS/Styled)

---

## 🧪 테스트 방법
- [x] 로컬 실행 확인
- [x] 주요 화면 렌더링 확인
- [x] 에러 콘솔 확인

---

## ⚠️ 참고 사항

- 현재 로그인 여부를 판단하는 isLoggedIn은 기능 확인용 임시 상태로 구현되었습니다.
- SETTINGS 메뉴는 현재 페이지 연결 대신 alert 창으로 안내를 대체합니다.

---

## ✅ 체크리스트
- [x] main 브랜치 직접 push 하지 않음
- [x] feature 브랜치에서 작업함
- [x] 불필요한 console.log 제거
- [x] PR 단위가 과도하게 크지 않음
