### PR TITLE
[FE] feature: 워크페이스 상세 페이지 레이아웃 구축 및 기능 추가

### DIFF
--- a/src/components/workspace/VoucherView.tsx
+++ b/src/components/workspace/VoucherView.tsx
@@ -6,6 +6,7 @@ interface Props {
   onAdd: () => void;
   onDelete: (id: number) => void;
   onDownload: (id: number) => void;
+  onPreview: (id: number) => void;
 }
 
 /**
@@ -19,6 +20,7 @@ const VoucherView: React.FC<Props> = ({
   onAdd,
   onDelete,
   onDownload,
+  onPreview,
 }) => {
   return (
     <div id="view-voucher" className="content-view active">
@@ -43,10 +45,27 @@ const VoucherView: React.FC<Props> = ({
               <span>{v.type}</span>
             </div>
 
-            <div className="v-body">
-              <div className="v-title">{v.title}</div>
-              <div className="v-desc">{v.desc}</div>
-              <div className="v-meta">{v.meta}</div>
+            <div
+              className="v-body"
+              onClick={() => onPreview(v.id)}
+              style={{ cursor: "pointer", flex: 1, padding: "0 15px" }}
+              title="클릭하여 미리보기"
+            >
+              <div className="v-title" style={{ fontWeight: "bold" }}>
+                {v.title}
+              </div>
+              <div
+                className="v-desc"
+                style={{ fontSize: "12px", color: "#666" }}
+              >
+                {v.desc}
+              </div>
+              <div
+                className="v-meta"
+                style={{ fontSize: "10px", color: "#999", marginTop: "5px" }}
+              >
+                {v.meta}
+              </div>
             </div>
 
             <div style={{ display: "flex", flexDirection: "column" }}>

--- a/src/components/workspace/WorkspaceCenter.tsx
+++ b/src/components/workspace/WorkspaceCenter.tsx
@@ -42,6 +42,7 @@ const WorkspaceCenter: React.FC<Props> = ({
     openAdd,
     openEdit: openNoticeEdit,
     deleteNotice,
+    togglePin,
   } = noticeStore;
 
   // Trip 관련 openEdit은 openTripEdit으로 변경
@@ -266,6 +267,7 @@ const WorkspaceCenter: React.FC<Props> = ({
             onAdd={() => setIsVoucherModalOpen(true)}
             onDelete={voucherStore.deleteVoucher}
             onDownload={voucherStore.downloadVoucher}
+            onPreview={voucherStore.previewVoucher}
           />
 
           {isVoucherModalOpen && (
@@ -311,8 +313,21 @@ const WorkspaceCenter: React.FC<Props> = ({
 
           {/* ===== NOTICE LIST ===== */}
           <div className="notice-container" id="notice-list-container">
-            {notices.map((n, idx) => (
-              <div key={idx} className={`notice-card ${n.color}`}>
+            {notices.map((n) => (
+              <div
+                key={n.id}
+                className={`notice-card ${n.color} ${
+                  n.isPinned ? "pinned" : ""
+                }`}
+              >
+                {/* ✅ 고정 버튼 (id 전달) */}
+                <div
+                  className={`nc-pin-btn ${n.isPinned ? "active" : ""}`}
+                  onClick={() => togglePin(n.id)}
+                >
+                  <i className="fa-solid fa-thumbtack"></i>
+                </div>
+
                 <div className="nc-tag">{n.tag}</div>
 
                 <div className="nc-title">{n.title}</div>
@@ -322,13 +337,13 @@ const WorkspaceCenter: React.FC<Props> = ({
                 <div className="nc-controls">
                   <span
                     className="nc-btn edit"
-                    onClick={() => openNoticeEdit(idx)}
+                    onClick={() => openNoticeEdit(n.id)}
                   >
                     EDIT
                   </span>
                   <span
                     className="nc-btn del"
-                    onClick={() => deleteNotice(idx)}
+                    onClick={() => deleteNotice(n.id)}
                   >
                     DELETE
                   </span>

--- a/src/components/workspace/WorkspaceSidebar.tsx
+++ b/src/components/workspace/WorkspaceSidebar.tsx
@@ -88,7 +88,7 @@ const WorkspaceSidebar: React.FC = () => {
             className="ws-item"
             onClick={() => selectTab("EXPENSES", "expenses")}
           >
-            [ ] EXPENSES
+            EXPENSES
           </a>
         </div>
 
@@ -101,7 +101,7 @@ const WorkspaceSidebar: React.FC = () => {
             className="ws-item"
             onClick={() => selectTab("VOUCHER", "voucher")}
           >
-            [ ] VOUCHER
+            VOUCHER
           </a>
         </div>
 
@@ -120,21 +120,6 @@ const WorkspaceSidebar: React.FC = () => {
         </div>
 
         <div id="notice-log-list">
-          <div
-            className={`ws-item-wrapper ${
-              activeView === "notice" && currentNoticeGroup === "TRIP NOTICE"
-                ? "active"
-                : ""
-            }`}
-          >
-            <a
-              className="ws-item"
-              onClick={() => selectTab("TRIP NOTICE", "notice")}
-            >
-              [ ] TRIP NOTICE
-            </a>
-          </div>
-
           {noticeGroups.map((group, idx) => (
             <div
               key={`${group.name}-${idx}`}
@@ -148,13 +133,16 @@ const WorkspaceSidebar: React.FC = () => {
                 className="ws-item"
                 onClick={() => selectTab(group.name, "notice")}
               >
-                [ ] {group.name}
+                {group.name}
               </a>
 
-              <div className="ws-item-controls">
-                <span onClick={() => renameItem("notice", idx)}>✎</span>
-                <span onClick={() => deleteItem("notice", idx)}>🗑</span>
-              </div>
+              {/* 기본 TRIP NOTICE 는 수정/삭제 버튼 숨김 */}
+              {group.name !== "TRIP NOTICE" && (
+                <div className="ws-item-controls">
+                  <span onClick={() => renameItem("notice", idx)}>✎</span>
+                  <span onClick={() => deleteItem("notice", idx)}>🗑</span>
+                </div>
+              )}
             </div>
           ))}
         </div>

--- a/src/hooks/useVouchers.ts
+++ b/src/hooks/useVouchers.ts
@@ -63,10 +63,29 @@ export const useVouchers = () => {
     document.body.removeChild(link);
   };
 
+  const previewVoucher = (id: number) => {
+    const target = vouchers.find((v) => v.id === id);
+    if (!target || !target.fileData) {
+      alert("첨부된 파일이 없습니다.");
+      return;
+    }
+
+    const newTab = window.open();
+    if (newTab) {
+      newTab.document.write(
+        `<title>Preview: ${target.title}</title>` +
+          `<body style="margin:0; display:flex; align-items:center; justify-content:center; background:#333;">` +
+          `<iframe src="${target.fileData}" frameborder="0" style="width:100vw; height:100vh;" allowfullscreen></iframe>` +
+          `</body>`
+      );
+    }
+  };
+
   return {
     vouchers,
     addVoucher,
     deleteVoucher,
     downloadVoucher,
+    previewVoucher,
   };
 };

--- a/src/pages/MyTrips.tsx
+++ b/src/pages/MyTrips.tsx
@@ -116,7 +116,11 @@ export default function MyTrips() {
       {/* 모달 UI */}
       {isModalOpen && (
         <div className="modal-overlay" onClick={() => setIsModalOpen(false)}>
-          <div className="modal-content" onClick={(e) => e.stopPropagation()}>
+          <div
+            className="modal-content"
+            style={{ maxWidth: "500px" }}
+            onClick={(e) => e.stopPropagation()}
+          >
             <div className="modal-header">
               <h3 className="modal-title">CREATE NEW MISSION</h3>
               <button

--- a/src/styles/Home.css
+++ b/src/styles/Home.css
@@ -11,7 +11,7 @@
   border: 3px solid #000;
   background: #fff;
   padding: 40px;
-  margin-bottom: 50px;
+  margin-bottom: 100px;
   box-shadow: 10px 10px 0px rgba(0, 0, 0, 1);
   position: relative;
   text-align: left;
@@ -113,13 +113,39 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  transform: translateY(-15px);
 }
 
 .generate-btn:hover {
   background: #fff;
   color: #000;
   box-shadow: 4px 4px 0px rgba(0, 0, 0, 0.5);
-  transform: translate(-2px, -2px);
+  transform: translate(-2px, -7px);
+}
+.generate-btn {
+  background: #111;
+  color: #fff;
+  border: 3px solid #000;
+  padding: 0 30px;
+  font-size: 1.3rem;
+  cursor: pointer;
+  height: 60px;
+  transition: 0.2s;
+  font-weight: bold;
+  letter-spacing: 1px;
+  margin: 0;
+  border-radius: 0 !important;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transform: translateY(-15px);
+}
+
+.generate-btn:hover {
+  background: #fff;
+  color: #000;
+  box-shadow: 4px 4px 0px rgba(0, 0, 0, 0.5);
+  transform: translate(-2px, -7px);
 }
 
 /* Feature Rows (기능 소개) */

--- a/src/styles/MyTrips.css
+++ b/src/styles/MyTrips.css
@@ -175,7 +175,7 @@
   border: 3px solid #000;
   padding: 30px;
   width: 90%;
-  max-width: 450px;
+  max-width: 500px;
   box-shadow: 10px 10px 0px #000;
 }
 

--- a/src/styles/workspace/center.css
+++ b/src/styles/workspace/center.css
@@ -480,6 +480,8 @@
   display: flex;
   flex-direction: column;
   min-height: 250px;
+  position: relative;
+  transition: transform 0.2s;
 }
 .nc-tag {
   font-family: var(--font-mono);

--- a/src/styles/workspace/modals.css
+++ b/src/styles/workspace/modals.css
@@ -43,7 +43,6 @@
 .color-picker {
   display: flex;
   gap: 10px;
-  margin-top: 5px;
 }
 .color-radio {
   cursor: pointer;
@@ -244,7 +243,8 @@
   font-family: var(--font-mono);
   font-size: 12px;
   font-weight: bold;
-  margin-bottom: 4px;
+  margin-top: 15px;
+  margin-bottom: 2px;
 }
 .inp-row input,
 .inp-row select {
@@ -351,4 +351,198 @@
 .trip-window {
   width: 480px;
   max-width: 90%;
+}
+
+/* 검색창 스타일 드롭다운 */
+.search-dropdown {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  background: #fff;
+  border-radius: 12px; /* 둥근 모서리 */
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15); /* 부드러운 그림자 */
+  margin-top: 8px;
+  z-index: 1000;
+  overflow: hidden;
+  border: 1px solid #eee;
+}
+
+/* 상단 헤더 (최근 검색어 / 전체삭제) */
+.sd-header {
+  padding: 12px 16px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: #f9f9f9;
+  border-bottom: 1px solid #eee;
+}
+
+.sd-header span {
+  font-size: 13px;
+  font-weight: 600;
+  color: #666;
+}
+
+.sd-all-del {
+  font-size: 12px;
+  color: #999;
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+
+/* 리스트 아이템 */
+.sd-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 16px;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.sd-item:hover {
+  background: #f5f5f5;
+}
+
+.sd-item-left {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.sd-item-left i {
+  color: #ccc;
+  font-size: 14px;
+}
+
+.sd-text {
+  font-size: 14px;
+  color: #333;
+}
+
+/* 개별 삭제 버튼 */
+.sd-item-del {
+  background: none;
+  border: none;
+  color: #ccc;
+  cursor: pointer;
+  padding: 4px;
+}
+
+.sd-item-del:hover {
+  color: #ff4d4f;
+}
+
+/* 입력창과 목록을 감싸는 컨테이너 */
+.input-combo {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+}
+
+/* 목록이 열렸을 때 입력창의 하단 테두리를 직선으로 */
+.input-combo.open input {
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  border-bottom-color: #eee; /* 경계선을 부드럽게 */
+}
+
+/* 네이버 스타일 리스트 박스 */
+.naver-style-list {
+  position: absolute;
+  top: 100%; /* 입력창 바로 끝나는 지점 */
+  left: 0;
+  right: 0;
+  background: #fff;
+  border: 1px solid #ddd; /* 기존 input 테두리 색상과 맞춤 */
+  border-top: none; /* 입력창 테두리와 겹치지 않게 제거 */
+  border-radius: 0 0 8px 8px; /* 하단만 둥글게 */
+  z-index: 1000;
+  max-height: 200px;
+  overflow-y: auto;
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.1); /* 떠 있는 느낌만 살짝 */
+}
+
+/* 리스트 아이템 */
+.naver-style-item {
+  padding: 10px 15px;
+  display: flex;
+  justify-content: space-between; /* 양 끝 정렬 */
+  align-items: center;
+  cursor: pointer;
+}
+
+.ns-left {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.ns-left i {
+  color: #ccc;
+  font-size: 13px;
+}
+
+.naver-style-item:hover {
+  background: #f8f9fa;
+}
+
+.naver-style-item i {
+  color: #bbb;
+  font-size: 12px;
+}
+
+.naver-style-item span {
+  font-size: 14px;
+  color: #333;
+}
+
+/* 마지막 아이템의 바닥 곡률 맞춤 */
+.naver-style-item:last-child {
+  border-bottom-left-radius: 8px;
+  border-bottom-right-radius: 8px;
+}
+
+/* 개별 삭제 버튼 스타일 */
+.ns-del-btn {
+  background: none;
+  border: none;
+  color: #ddd;
+  padding: 5px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: color 0.2s;
+}
+
+.ns-del-btn:hover {
+  color: #999; /* 마우스 올리면 더 진하게 */
+}
+
+.ns-del-btn i {
+  font-size: 14px;
+}
+
+/* 고정 버튼 스타일 */
+.nc-pin-btn {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  cursor: pointer;
+  color: #ccc;
+  font-size: 14px;
+  transition: color 0.2s, transform 0.2s;
+}
+
+.nc-pin-btn:hover {
+  transform: scale(1.2);
+}
+
+/* 고정 활성화 상태 */
+.nc-pin-btn.active {
+  color: #ff4d4f; /* 붉은색 핀 */
+  transform: rotate(-45deg); /* 핀이 박힌 느낌 */
 }


### PR DESCRIPTION
## 🎨 작업 내용 (What)
워크페이스 상세 페이지의 핵심 레이아웃과 기능을 통합적으로 구축했습니다.

- 멀티 뷰 시스템 구축: WorkspaceCenter를 중심으로 Timeline, Expense, Voucher, Notice 4가지 뷰의 전환 및 렌더링 로직 구현
- 사이드바 기능 고도화: 일정/가계부/바우처/공지사항 그룹별 내비게이션 연동 및 항목 CRUD 인터페이스 연결
- 공지사항(Notice) 모달 시스템: CRUD, 태그 자동완성, 컬러 선택 기능이 포함된 NoticeItemModal 구현
- 바우처(Voucher) 기능 강화: 바우처 목록 렌더링 및 이미지 미리보기(Preview) 팝업 기능 추가
- UI/UX 미세 조정: MyTrips 페이지의 여행 생성 모달 너비 확장(Wide), 공지사항 고정(Pin) 버튼 활성화 상태 시각화(Red Color)
- 데이터 유지 로직: localStorage를 활용해 여행 기본 정보(tripData)가 새로고침 후에도 유지되도록 처리

---

## 🧭 작업 목적 (Why)

- 분산되어 있던 여행 관리 기능(일정, 가계부 등)을 하나의 워크페이스 상세 페이지에서 효율적으로 제어하기 위함
- 공지사항 고정 버튼이나 바우처 미리보기와 같은 실시간 피드백 요소를 통해 사용자 경험(UX)을 개선
- 모달 레이아웃 및 전체적인 CSS 수정을 통해 서비스 전반의 시인성과 통일성 확보

---

## 🧩 변경 범위
- [x] UI / Layout
- [x] 컴포넌트
- [x] 상태 관리
- [ ] API 연동
- [x] 스타일(CSS/Styled)

---

## 🧪 테스트 방법
- [x] 로컬 실행 확인
- [x] 주요 화면 렌더링 확인
- [x] 에러 콘솔 확인

---

## ⚠️ 참고 사항

- CSS 클래스 바인딩: 공지사항의 고정 버튼(nc-pin-btn)은 이제 isPinned 상태에 따라 .active 클래스가 조건부로 붙어 빨간색으로 표시됩니다.
- 로컬 스토리지: tripData라는 키값으로 여행 제목과 날짜가 저장되므로, 테스트 시 해당 데이터를 확인해 주세요.
- 모달 가로 너비: MyTrips.tsx에서 생성 모달의 너비를 넓혔으므로 기존 레이아웃과 비교해 확인이 필요합니다.

---

## ✅ 체크리스트
- [x] main 브랜치 직접 push 하지 않음
- [x] feature 브랜치에서 작업함
- [x] 불필요한 console.log 제거
- [x] PR 단위가 과도하게 크지 않음
