### PR TITLE
[FE] feature: Workspace 일정 상태 흐름 구현 및 DayAll·DayDetail 구성

### DIFF
--- a/src/components/workspace/DayAllView.tsx
+++ b/src/components/workspace/DayAllView.tsx
@@ -1,0 +1,644 @@
+import React, { useState, useEffect } from "react";
+import AddPlaceModal from "./AddPlaceModal";
+import AiScheduleModal from "./AiScheduleModal";
+import { useWorkspaceCore } from "../../hooks/useWorkspaceCore";
+import "../../styles/workspace/center.css";
+import "../../styles/workspace/modals.css";
+
+interface Place {
+  id: string;
+  name: string;
+  category: string;
+  address: string;
+  imageUrl?: string;
+  rating?: number;
+  description?: string;
+  lat?: number;
+  lng?: number;
+  memo?: string;
+}
+
+interface DayAllViewProps {
+  tripTitle: string;
+  startDate: string;
+  endDate: string;
+}
+
+const DayAllView: React.FC<DayAllViewProps> = ({
+  tripTitle,
+  startDate,
+  endDate,
+}) => {
+  const { selectTab } = useWorkspaceCore();
+  
+  // 한국 여행지 기본 데이터
+  const defaultKoreaPlaces: Place[] = [
+    {
+      id: "korea_1",
+      name: "경복궁",
+      category: "관광",
+      address: "서울특별시 종로구 사직로 161",
+      imageUrl: "https://www.kh.or.kr/jnrepo/namo/img/images/000045/20230405103334542_MPZHA77B.jpg",
+      rating: 4.7,
+      description: "조선시대 대표 궁궐, 한복 입고 관람 추천",
+      memo: "한복 대여 가능, 오전 방문 추천"
+    },
+    {
+      id: "korea_2",
+      name: "광장시장",
+      category: "맛집",
+      address: "서울특별시 종로구 창경궁로 88",
+      imageUrl: "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTf1w8-0coGKyUXGRJdiV0oRCkLJEKaHfFeww&s",
+      rating: 4.6,
+      description: "서울의 대표 전통 시장, 빈대떡과 마약김밥 필수",
+      memo: "빈대떡, 마약김밥, 육회 꼭 먹기"
+    },
+    {
+      id: "korea_3",
+      name: "북촌한옥마을",
+      category: "관광",
+      address: "서울특별시 종로구 계동길 37",
+      imageUrl: "https://i.namu.wiki/i/DEvKxYg-TEz6O53jeZyS9kndJSgSQnFysm3T-R70yXIyWi9-HknJZXoK1ghHFMwB365TyyMj7MlIebAKMrLSFA.webp",
+      rating: 4.5,
+      description: "전통 한옥이 보존된 마을, 사진 명소",
+      memo: ""
+    },
+    {
+      id: "korea_4",
+      name: "을지로 원조노가리",
+      category: "맛집",
+      address: "서울특별시 중구 을지로13길 12",
+      imageUrl: "https://pds.joongang.co.kr/news/component/htmlphoto_mmdata/201904/20/72822356-9226-428d-bd7b-c449f49de69c.jpg",
+      rating: 4.5,
+      description: "노가리와 맥주로 유명한 을지로 대표 포장마차 거리 맛집",
+      memo: "저녁 시간대 방문 추천, 웨이팅 잦음"
+    },
+    {
+      id: "korea_5",
+      name: "테일러커피 연남점",
+      category: "카페",
+      address: "서울특별시 마포구 연남로1길 17",
+      imageUrl: "https://d12zq4w4guyljn.cloudfront.net/750_750_20251128083337890_photo_16116f4f550e.webp",
+      rating: 4.8,
+      description: "스페셜티 커피로 유명한 연남동 대표 카페, 원두 선택 가능",
+      memo: "오후 시간대 방문 추천, 디저트도 괜찮음"
+    },
+    {
+      id: "korea_6",
+      name: "명동 쇼핑거리",
+      category: "쇼핑",
+      address: "서울특별시 중구 명동길",
+      imageUrl: "https://upload.wikimedia.org/wikipedia/commons/thumb/3/32/%EB%AA%85%EB%8F%998%EA%B8%B8_%EA%B1%B0%EB%A6%AC_%282020.03%29.jpg/1200px-%EB%AA%85%EB%8F%998%EA%B8%B8_%EA%B1%B0%EB%A6%AC_%282020.03%29.jpg",
+      rating: 4.3,
+      description: "한국 화장품과 패션 쇼핑의 메카",
+      memo: "화장품 세일 많음"
+    },
+    {
+      id: "korea_7",
+      name: "N서울타워",
+      category: "관광",
+      address: "서울특별시 용산구 남산공원길 105",
+      imageUrl: "https://i.namu.wiki/i/DK-BcaE6wDCM-N9UJbeQTn0SD9eWgsX9YKWK827rqjbrzDz0-CxW-JFOCiAsUL3CBZ4zE0UDR-p4sLaYPiUjww.webp",
+      rating: 4.6,
+      description: "서울 야경 명소, 남산케이블카 탑승 가능",
+      memo: "석양 시간대 방문 추천"
+    }
+  ];
+
+  const [savedPlaces, setSavedPlaces] = useState<Place[]>([]);
+  const [isAddModalOpen, setIsAddModalOpen] = useState(false);
+  const [isAiModalOpen, setIsAiModalOpen] = useState(false);
+  const [category, setCategory] = useState("all");
+
+  // LocalStorage에서 저장된 장소 불러오기 (없으면 기본값 사용)
+  useEffect(() => {
+    const saved = localStorage.getItem("saved_places");
+    if (saved) {
+      try {
+        const parsed = JSON.parse(saved);
+        // 빈 배열이면 기본값 사용
+        if (Array.isArray(parsed) && parsed.length > 0) {
+          setSavedPlaces(parsed);
+        } else {
+          setSavedPlaces(defaultKoreaPlaces);
+          localStorage.setItem("saved_places", JSON.stringify(defaultKoreaPlaces));
+        }
+      } catch (e) {
+        console.error("Failed to load saved places:", e);
+        setSavedPlaces(defaultKoreaPlaces);
+        localStorage.setItem("saved_places", JSON.stringify(defaultKoreaPlaces));
+      }
+    } else {
+      // localStorage에 아무것도 없으면 기본값 설정
+      setSavedPlaces(defaultKoreaPlaces);
+      localStorage.setItem("saved_places", JSON.stringify(defaultKoreaPlaces));
+    }
+  }, []);
+
+  // 저장된 장소 변경 시 LocalStorage 업데이트
+  useEffect(() => {
+    localStorage.setItem("saved_places", JSON.stringify(savedPlaces));
+  }, [savedPlaces]);
+
+  // 장소 추가 (모달에서 호출)
+  const handleAddPlace = (place: Place) => {
+    if (savedPlaces.some((p) => p.id === place.id)) {
+      alert("이미 추가된 장소입니다!");
+      return;
+    }
+    setSavedPlaces([...savedPlaces, place]);
+  };
+
+  // 장소 삭제
+  const removePlace = (placeId: string) => {
+    if (confirm("이 장소를 삭제하시겠습니까?")) {
+      setSavedPlaces(savedPlaces.filter((p) => p.id !== placeId));
+    }
+  };
+
+  // 메모 수정
+  const updateMemo = (placeId: string, memo: string) => {
+    setSavedPlaces(
+      savedPlaces.map((p) => (p.id === placeId ? { ...p, memo } : p))
+    );
+  };
+
+  // AI 일정 생성 버튼 클릭
+  const handleOpenAiModal = () => {
+    if (savedPlaces.length === 0) {
+      alert("장소를 먼저 추가해주세요!");
+      return;
+    }
+    setIsAiModalOpen(true);
+  };
+
+  // AI 일정 생성 실행
+  const handleGenerateSchedule = (settings: any) => {
+    console.log("AI 일정 생성 설정:", settings);
+    console.log("선택된 장소:", savedPlaces);
+    
+    // 타임라인 노드 타입 (장소 정보 포함)
+    interface TimelineNode {
+      time: string;
+      title: string;
+      desc: string;
+      placeInfo?: {
+        name: string;
+        imageUrl?: string;
+        address?: string;
+        rating?: number;
+        category?: string;
+        description?: string;
+        memo?: string;
+      };
+    }
+    
+    // 임시로 AI 생성된 일정 데이터 (실제로는 API에서 받아옴)
+    const generatedSchedule: Record<string, TimelineNode[]> = {
+      "DAY 1": [
+        { 
+          time: "09:00", 
+          title: savedPlaces[0]?.name || "경복궁", 
+          desc: savedPlaces[0]?.description || "조선시대 대표 궁궐 관람",
+          placeInfo: savedPlaces[0] ? {
+            name: savedPlaces[0].name,
+            imageUrl: savedPlaces[0].imageUrl,
+            address: savedPlaces[0].address,
+            rating: savedPlaces[0].rating,
+            category: savedPlaces[0].category,
+            description: savedPlaces[0].description,
+            memo: savedPlaces[0].memo,
+          } : undefined
+        },
+        { 
+          time: "11:30", 
+          title: savedPlaces[1]?.name || "광장시장", 
+          desc: savedPlaces[1]?.description || "빈대떡과 마약김밥 점심",
+          placeInfo: savedPlaces[1] ? {
+            name: savedPlaces[1].name,
+            imageUrl: savedPlaces[1].imageUrl,
+            address: savedPlaces[1].address,
+            rating: savedPlaces[1].rating,
+            category: savedPlaces[1].category,
+            description: savedPlaces[1].description,
+            memo: savedPlaces[1].memo,
+          } : undefined
+        },
+        { 
+          time: "14:00", 
+          title: savedPlaces[2]?.name || "북촌한옥마을", 
+          desc: savedPlaces[2]?.description || "전통 한옥 마을 산책",
+          placeInfo: savedPlaces[2] ? {
+            name: savedPlaces[2].name,
+            imageUrl: savedPlaces[2].imageUrl,
+            address: savedPlaces[2].address,
+            rating: savedPlaces[2].rating,
+            category: savedPlaces[2].category,
+            description: savedPlaces[2].description,
+            memo: savedPlaces[2].memo,
+          } : undefined
+        },
+        { 
+          time: "16:00", 
+          title: savedPlaces[4]?.name || "카페 온지음", 
+          desc: savedPlaces[4]?.description || "한옥 카페에서 휴식",
+          placeInfo: savedPlaces[4] ? {
+            name: savedPlaces[4].name,
+            imageUrl: savedPlaces[4].imageUrl,
+            address: savedPlaces[4].address,
+            rating: savedPlaces[4].rating,
+            category: savedPlaces[4].category,
+            description: savedPlaces[4].description,
+            memo: savedPlaces[4].memo,
+          } : undefined
+        },
+        { 
+          time: "18:30", 
+          title: "저녁 식사", 
+          desc: "명동에서 맛집 탐방" 
+        },
+      ],
+      "DAY 2": [
+        { 
+          time: "10:00", 
+          title: savedPlaces[3]?.name || "통인시장", 
+          desc: savedPlaces[3]?.description || "도시락카페에서 아침",
+          placeInfo: savedPlaces[3] ? {
+            name: savedPlaces[3].name,
+            imageUrl: savedPlaces[3].imageUrl,
+            address: savedPlaces[3].address,
+            rating: savedPlaces[3].rating,
+            category: savedPlaces[3].category,
+            description: savedPlaces[3].description,
+            memo: savedPlaces[3].memo,
+          } : undefined
+        },
+        { 
+          time: "12:30", 
+          title: savedPlaces[5]?.name || "명동 쇼핑거리", 
+          desc: savedPlaces[5]?.description || "화장품 쇼핑",
+          placeInfo: savedPlaces[5] ? {
+            name: savedPlaces[5].name,
+            imageUrl: savedPlaces[5].imageUrl,
+            address: savedPlaces[5].address,
+            rating: savedPlaces[5].rating,
+            category: savedPlaces[5].category,
+            description: savedPlaces[5].description,
+            memo: savedPlaces[5].memo,
+          } : undefined
+        },
+        { 
+          time: "15:00", 
+          title: "카페 타임", 
+          desc: "명동 주변 카페에서 휴식" 
+        },
+        { 
+          time: "17:30", 
+          title: savedPlaces[6]?.name || "N서울타워", 
+          desc: savedPlaces[6]?.description || "석양과 야경 감상",
+          placeInfo: savedPlaces[6] ? {
+            name: savedPlaces[6].name,
+            imageUrl: savedPlaces[6].imageUrl,
+            address: savedPlaces[6].address,
+            rating: savedPlaces[6].rating,
+            category: savedPlaces[6].category,
+            description: savedPlaces[6].description,
+            memo: savedPlaces[6].memo,
+          } : undefined
+        },
+        { 
+          time: "20:00", 
+          title: "여행 마무리", 
+          desc: "남산 근처에서 저녁 식사" 
+        },
+      ]
+    };
+    
+    // localStorage의 timeline 데이터 가져오기
+    const existingData = localStorage.getItem("tripmoa_timeline_data");
+    let timelineData: Record<string, TimelineNode[]> = existingData ? JSON.parse(existingData) : {};
+    
+    // 생성된 일정을 localStorage에 저장
+    Object.keys(generatedSchedule).forEach(dayKey => {
+      timelineData[dayKey] = generatedSchedule[dayKey];
+    });
+    
+    localStorage.setItem("tripmoa_timeline_data", JSON.stringify(timelineData));
+    
+    // dateLogs에 DAY 1, DAY 2가 없으면 추가
+    const existingDateLogs = localStorage.getItem("tripmoa_date_logs");
+    let dateLogs = existingDateLogs ? JSON.parse(existingDateLogs) : [];
+    
+    ["DAY 1", "DAY 2"].forEach(day => {
+      if (!dateLogs.includes(day)) {
+        dateLogs.push(day);
+      }
+    });
+    
+    localStorage.setItem("tripmoa_date_logs", JSON.stringify(dateLogs));
+    
+    alert("AI 일정이 생성되었습니다! DAY 1 탭에서 확인하세요.");
+    setIsAiModalOpen(false);
+    
+    // 페이지 새로고침하여 사이드바에 DAY 1, DAY 2 표시
+    window.location.reload();
+  };
+
+  // 카테고리 필터링
+  const filteredPlaces =
+    category === "all"
+      ? savedPlaces
+      : savedPlaces.filter((p) => p.category === category);
+
+  // 카테고리별 아이콘
+  const getCategoryIcon = (cat: string) => {
+    const icons: { [key: string]: string } = {
+      맛집: "🍴",
+      카페: "☕",
+      관광: "🏛️",
+      쇼핑: "🛍️",
+      숙소: "🏨",
+    };
+    return icons[cat] || "📍";
+  };
+
+  return (
+    <>
+      <div className="my-places-view">
+        {/* 헤더 */}
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+            marginBottom: "20px",
+          }}
+        >
+          <div>
+            <h2 style={{ fontSize: "24px", fontWeight: 800, margin: 0 }}>
+              MY SAVED PLACES ({savedPlaces.length})
+            </h2>
+            <p
+              style={{
+                color: "#666",
+                marginTop: "5px",
+                fontFamily: "var(--font-mono)",
+                fontSize: "14px",
+              }}
+            >
+              {startDate} - {endDate}
+            </p>
+          </div>
+
+          {/* 버튼 그룹 */}
+          <div style={{ display: "flex", gap: "15px", alignItems: "center" }}>
+            <button
+              style={{
+                padding: "10px 20px",
+                background: "#fff",
+                color: "#000",
+                border: "2px solid #000",
+                fontWeight: "bold",
+                fontSize: "14px",
+                cursor: "pointer",
+                transition: "0.2s",
+                borderRadius: "4px",
+              }}
+              onClick={() => setIsAddModalOpen(true)}
+            >
+              + 새 장소 추가
+            </button>
+
+            {savedPlaces.length > 0 && (
+              <button
+                className="btn-generate-schedule"
+                onClick={handleOpenAiModal}
+                style={{
+                  padding: "10px 20px",
+                  background: "#000",
+                  color: "#fff",
+                  border: "2px solid #000",
+                  borderRadius: "4px",
+                  fontWeight: "bold",
+                  fontSize: "14px",
+                  cursor: "pointer",
+                  transition: "0.2s",
+                }}
+              >
+                ✨ AI 일정 생성
+              </button>
+            )}
+          </div>
+        </div>
+
+        {/* 카테고리 필터 */}
+        <div
+          className="filter-group"
+          style={{ marginBottom: "20px", gap: "8px" }}
+        >
+          {["all", "맛집", "카페", "관광", "쇼핑", "숙소"].map((cat) => (
+            <button
+              key={cat}
+              className={`filter-tag ${category === cat ? "active" : ""}`}
+              onClick={() => setCategory(cat)}
+            >
+              {cat === "all" ? "전체" : cat}
+            </button>
+          ))}
+        </div>
+
+        {/* 장소 리스트 */}
+        {filteredPlaces.length === 0 ? (
+          <div
+            style={{
+              textAlign: "center",
+              padding: "60px 20px",
+              color: "#999",
+            }}
+          >
+            <p style={{ fontSize: "16px", marginBottom: "10px" }}>
+              📍 아직 추가된 장소가 없습니다
+            </p>
+            <p style={{ fontSize: "14px" }}>
+              '새 장소 추가' 버튼을 눌러 여행지를 추가해보세요!
+            </p>
+          </div>
+        ) : (
+          <div style={{ display: "flex", flexDirection: "column", gap: "15px" }}>
+            {filteredPlaces.map((place) => (
+              <div
+                key={place.id}
+                className="tl-box"
+                style={{
+                  padding: "20px",
+                  display: "flex",
+                  gap: "15px",
+                  alignItems: "flex-start",
+                }}
+              >
+                {/* 이미지 */}
+                {place.imageUrl && (
+                  <div
+                    style={{
+                      width: "100px",
+                      height: "100px",
+                      borderRadius: "8px",
+                      overflow: "hidden",
+                      flexShrink: 0,
+                      background: "#eee",
+                    }}
+                  >
+                    <img
+                      src={place.imageUrl}
+                      alt={place.name}
+                      style={{
+                        width: "100%",
+                        height: "100%",
+                        objectFit: "cover",
+                      }}
+                    />
+                  </div>
+                )}
+
+                {/* 정보 */}
+                <div style={{ flex: 1 }}>
+                  <div
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: "10px",
+                      marginBottom: "8px",
+                    }}
+                  >
+                    <span
+                      style={{
+                        background: "#000",
+                        color: "#fff",
+                        padding: "3px 10px",
+                        fontSize: "12px",
+                        fontWeight: "bold",
+                        borderRadius: "4px",
+                      }}
+                    >
+                      {getCategoryIcon(place.category)} {place.category}
+                    </span>
+                    {place.rating && (
+                      <span
+                        style={{
+                          fontSize: "13px",
+                          color: "#ff9800",
+                          fontWeight: "bold",
+                        }}
+                      >
+                        ⭐ {place.rating}
+                      </span>
+                    )}
+                  </div>
+
+                  <h3
+                    style={{
+                      fontSize: "18px",
+                      fontWeight: "bold",
+                      margin: "0 0 6px 0",
+                    }}
+                  >
+                    {place.name}
+                  </h3>
+
+                  <p
+                    style={{
+                      fontSize: "13px",
+                      color: "#666",
+                      margin: "0 0 10px 0",
+                    }}
+                  >
+                    📍 {place.address}
+                  </p>
+
+                  {place.description && (
+                    <p
+                      style={{
+                        fontSize: "13px",
+                        color: "#888",
+                        margin: "0 0 10px 0",
+                      }}
+                    >
+                      {place.description}
+                    </p>
+                  )}
+
+                  {/* 메모 영역 */}
+                  <div style={{ marginTop: "10px" }}>
+                    <textarea
+                      placeholder="💭 메모를 작성하세요..."
+                      value={place.memo || ""}
+                      onChange={(e) => updateMemo(place.id, e.target.value)}
+                      style={{
+                        width: "100%",
+                        minHeight: "60px",
+                        padding: "10px",
+                        border: "2px solid #eee",
+                        borderRadius: "6px",
+                        fontSize: "13px",
+                        resize: "vertical",
+                        fontFamily: "inherit",
+                      }}
+                    />
+                  </div>
+                </div>
+
+                {/* 삭제 버튼 */}
+                <button
+                  onClick={() => removePlace(place.id)}
+                  style={{
+                    padding: "8px 15px",
+                    background: "#fff",
+                    color: "#ff5252",
+                    border: "2px solid #ff5252",
+                    borderRadius: "6px",
+                    fontWeight: "bold",
+                    fontSize: "13px",
+                    cursor: "pointer",
+                    transition: "0.2s",
+                  }}
+                  onMouseOver={(e) => {
+                    e.currentTarget.style.background = "#ff5252";
+                    e.currentTarget.style.color = "#fff";
+                  }}
+                  onMouseOut={(e) => {
+                    e.currentTarget.style.background = "#fff";
+                    e.currentTarget.style.color = "#ff5252";
+                  }}
+                >
+                  삭제
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* 장소 추가 모달 */}
+      {isAddModalOpen && (
+        <AddPlaceModal
+          onClose={() => setIsAddModalOpen(false)}
+          onAddPlace={handleAddPlace}
+          existingPlaces={savedPlaces}
+        />
+      )}
+
+      {/* AI 일정 생성 모달 */}
+      {isAiModalOpen && (
+        <AiScheduleModal
+          onClose={() => setIsAiModalOpen(false)}
+          onGenerate={handleGenerateSchedule}
+          savedPlaces={savedPlaces}
+          startDate={startDate}
+          endDate={endDate}
+        />
+      )}
+    </>
+  );
+};
+
+export default DayAllView;

--- a/src/components/workspace/DayDetailView.tsx
+++ b/src/components/workspace/DayDetailView.tsx
@@ -1,0 +1,196 @@
+import React, { useMemo, useState } from "react";
+import PlaceDetailModal from "./PlaceDetailModal";
+
+interface PlaceInfo {
+  name: string;
+  time?: string;
+  imageUrl?: string;
+  address?: string;
+  rating?: number;
+  category?: string;
+  description?: string;
+  memo?: string;
+}
+
+interface TimelineNode {
+  time: string;
+  title: string;
+  desc: string;
+  placeInfo?: PlaceInfo;
+}
+
+interface DayDetailViewProps {
+  dayTitle: string;
+  tripTitle: string;
+  startDate: string;
+  endDate: string;
+  nodes: TimelineNode[];
+  addNode: () => void;
+  updateNode: (idx: number, field: string, value: string) => void;
+  rightOpen?: boolean;
+  setRightOpen?: (open: boolean) => void;
+}
+
+const DayDetailView: React.FC<DayDetailViewProps> = ({
+  dayTitle,
+  tripTitle,
+  startDate,
+  endDate,
+  nodes,
+  addNode,
+  updateNode,
+  rightOpen,
+  setRightOpen,
+}) => {
+  const [selectedPlace, setSelectedPlace] = useState<PlaceInfo | null>(null);
+
+  // DAY 1, DAY 2 등에서 숫자 추출하여 해당 날짜 계산
+  const currentDate = useMemo(() => {
+    const dayMatch = dayTitle.match(/DAY\s*(\d+)/i);
+    if (!dayMatch) return startDate;
+    
+    const dayNumber = parseInt(dayMatch[1], 10);
+    const start = new Date(startDate);
+    
+    // dayNumber - 1일을 더함 (DAY 1 = 첫날, DAY 2 = 둘째날)
+    start.setDate(start.getDate() + (dayNumber - 1));
+    
+    return start.toISOString().split('T')[0];
+  }, [dayTitle, startDate]);
+
+  // 노드 클릭 핸들러
+  const handleNodeClick = (node: TimelineNode) => {
+    if (node.placeInfo) {
+      setSelectedPlace({
+        ...node.placeInfo,
+        time: node.time,
+      });
+    }
+  };
+
+  return (
+    <div>
+      {/* 헤더 영역 */}
+      <div style={{ 
+        display: "flex", 
+        justifyContent: "space-between", 
+        alignItems: "center",
+        marginBottom: "10px" 
+      }}>
+        <h2 style={{ fontSize: "24px", fontWeight: 800, margin: 0 }}>
+          {dayTitle}
+        </h2>
+
+        {/* 오른쪽 사이드바 토글 버튼 */}
+        {setRightOpen && (
+          <button
+            onClick={() => setRightOpen(!rightOpen)}
+            style={{
+              padding: "8px 16px",
+              background: rightOpen ? "#000" : "#fff",
+              color: rightOpen ? "#fff" : "#000",
+              border: "2px solid #000",
+              borderRadius: "6px",
+              fontWeight: "bold",
+              fontSize: "13px",
+              cursor: "pointer",
+              transition: "all 0.2s",
+            }}
+            onMouseEnter={(e) => {
+              if (!rightOpen) {
+                e.currentTarget.style.background = "#f0f0f0";
+              }
+            }}
+            onMouseLeave={(e) => {
+              if (!rightOpen) {
+                e.currentTarget.style.background = "#fff";
+              }
+            }}
+          >
+            {/* {rightOpen ? "🗂️ 사이드바 닫기" : "🗂️ 사이드바 열기"} */}
+            {rightOpen ? "🗺️ 지도 · 체크리스트 닫기" : "🗺️ 지도 · 체크리스트 열기"}
+
+          </button>
+        )}
+      </div>
+
+      <p
+        style={{
+          color: "#666",
+          marginBottom: "30px",
+          fontFamily: "var(--font-mono)",
+        }}
+      >
+        {currentDate}
+      </p>
+
+      <div className="timeline">
+        {nodes.map((n, idx) => (
+          <div className="tl-item" key={idx}>
+            <div className="tl-dot"></div>
+
+            <div className="tl-time">
+              {n.time}
+            </div>
+
+            <div 
+              className="tl-box"
+              onClick={() => handleNodeClick(n)}
+              style={{
+                cursor: "pointer",
+                transition: "all 0.2s",
+              }}
+              onMouseEnter={(e) => {
+                e.currentTarget.style.transform = "translateX(5px)";
+                e.currentTarget.style.boxShadow = "4px 4px 0px rgba(0, 0, 0, 0.1)";
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.transform = "translateX(0)";
+                e.currentTarget.style.boxShadow = "none";
+              }}
+            >
+              <div style={{ fontWeight: "bold", fontSize: "16px" }}>
+                {n.title}
+              </div>
+
+              <div
+                style={{
+                  fontSize: "13px",
+                  color: "#555",
+                  marginTop: "5px",
+                }}
+              >
+                {n.desc}
+              </div>
+            </div>
+          </div>
+        ))}
+
+        <button
+          style={{
+            width: "100%",
+            border: "2px dashed #ccc",
+            padding: "15px",
+            fontWeight: "bold",
+            color: "#999",
+            cursor: "pointer",
+            background: "transparent",
+          }}
+          onClick={addNode}
+        >
+          + ADD NODE
+        </button>
+      </div>
+
+      {/* 장소 상세 정보 모달 */}
+      {selectedPlace && (
+        <PlaceDetailModal
+          placeInfo={selectedPlace}
+          onClose={() => setSelectedPlace(null)}
+        />
+      )}
+    </div>
+  );
+};
+
+export default DayDetailView;

--- a/src/components/workspace/WorkspaceCenter.tsx
+++ b/src/components/workspace/WorkspaceCenter.tsx
@@ -11,6 +11,8 @@ import type { ExpenseMember } from "../../hooks/useExpenses";
 
 import ExpenseView from "./ExpenseView";
 import VoucherView from "./VoucherView";
+import DayAllView from "./DayAllView";
+import DayDetailView from "./DayDetailView";
 
 import WorkspaceModals from "./WorkspaceModals";
 import NoticeModal from "./NoticeItemModal";
@@ -34,6 +36,8 @@ const WorkspaceCenter: React.FC<Props> = ({
   setRightOpen,
 }) => {
   const { activeView, currentDay } = useWorkspaceCore();
+
+  // currentDay에 따라 useTimeline 호출
   const { nodes, addNode, updateNode } = useTimeline(currentDay);
 
   // Notice 관련 openEdit은 openNoticeEdit으로 변경
@@ -51,7 +55,7 @@ const WorkspaceCenter: React.FC<Props> = ({
     isPrivate,
     isEditOpen,
     toggle,
-    openEdit: openTripEdit, // 이름 변경
+    openEdit: openTripEdit,
     closeEdit,
     downloadPDF,
     togglePrivacy,
@@ -132,15 +136,7 @@ const WorkspaceCenter: React.FC<Props> = ({
 
       {/* BODY */}
       <div className="ws-body">
-        {/* 오른쪽 패널 토글 버튼 */}
-        {activeView === "timeline" && (
-          <button
-            className="ws-toggle-right"
-            onClick={() => setRightOpen(!rightOpen)}
-          >
-            {rightOpen ? "⮜" : "📍"}
-          </button>
-        )}
+        {/* ✅ 오른쪽 패널 토글 버튼 제거 (timeline에서는 사용 안함) */}
 
         {/* ================= TIMELINE VIEW ================= */}
         <div
@@ -149,84 +145,25 @@ const WorkspaceCenter: React.FC<Props> = ({
             activeView === "timeline" ? "active" : ""
           }`}
         >
-          <h2
-            id="day-title"
-            style={{ fontSize: "24px", fontWeight: 800, marginBottom: "10px" }}
-          >
-            {currentDay === "DAY ALL" ? "DAY ALL" : currentDay}
-          </h2>
-
-          <p
-            style={{
-              color: "#666",
-              marginBottom: "30px",
-              fontFamily: "var(--font-mono)",
-            }}
-          >
-            {trip.startDate} - {trip.endDate}
-          </p>
-
-          <div className="timeline">
-            {nodes.map((n, idx) => (
-              <div className="tl-item" key={idx}>
-                <div className="tl-dot"></div>
-
-                <div
-                  className="tl-time"
-                  contentEditable
-                  suppressContentEditableWarning
-                  onBlur={(e) =>
-                    updateNode(idx, "time", e.currentTarget.innerText)
-                  }
-                >
-                  {n.time}
-                </div>
-
-                <div className="tl-box">
-                  <div
-                    style={{ fontWeight: "bold", fontSize: "16px" }}
-                    contentEditable
-                    suppressContentEditableWarning
-                    onBlur={(e) =>
-                      updateNode(idx, "title", e.currentTarget.innerText)
-                    }
-                  >
-                    {n.title}
-                  </div>
-
-                  <div
-                    style={{
-                      fontSize: "13px",
-                      color: "#555",
-                      marginTop: "5px",
-                    }}
-                    contentEditable
-                    suppressContentEditableWarning
-                    onBlur={(e) =>
-                      updateNode(idx, "desc", e.currentTarget.innerText)
-                    }
-                  >
-                    {n.desc}
-                  </div>
-                </div>
-              </div>
-            ))}
-
-            <button
-              style={{
-                width: "100%",
-                border: "2px dashed #ccc",
-                padding: "15px",
-                fontWeight: "bold",
-                color: "#999",
-                cursor: "pointer",
-                background: "transparent",
-              }}
-              onClick={addNode}
-            >
-              + ADD NODE
-            </button>
-          </div>
+          {currentDay === "DAY ALL" ? (
+            <DayAllView
+              tripTitle={trip.title}
+              startDate={trip.startDate}
+              endDate={trip.endDate}
+            />
+          ) : (
+            <DayDetailView
+              dayTitle={currentDay}
+              tripTitle={trip.title}
+              startDate={trip.startDate}
+              endDate={trip.endDate}
+              nodes={nodes}
+              addNode={addNode}
+              updateNode={updateNode}
+              rightOpen={rightOpen}
+              setRightOpen={setRightOpen}
+            />
+          )}
         </div>
 
         {/* ===== EXPENSE ===== */}
@@ -305,7 +242,7 @@ const WorkspaceCenter: React.FC<Props> = ({
             <button
               className="btn-sm"
               style={{ padding: "8px 15px" }}
-              onClick={openAdd} // ✅ 여기
+              onClick={openAdd}
             >
               + NEW NOTICE
             </button>

--- a/src/pages/Workspace.tsx
+++ b/src/pages/Workspace.tsx
@@ -15,12 +15,14 @@ import { useNotices } from "../hooks/useNotices";
    Provider 내부 실제 UI
 ========================= */
 const WorkspaceContent: React.FC = () => {
-  const { activeView } = useWorkspaceCore();
+  const { activeView, currentDay } = useWorkspaceCore();
   const [rightOpen, setRightOpen] = useState(true);
 
   // 2열로 써야 하는 화면
+  // timeline은 DAY ALL일 때만 2열, DAY 1/DAY 2 등은 rightOpen 상태에 따라
   const isTwoColumn =
     !rightOpen ||
+    (activeView === "timeline" && currentDay === "DAY ALL") ||  // ✅ DAY ALL만 무조건 2열
     activeView === "expenses" ||
     activeView === "voucher" ||
     activeView === "notice";

--- a/src/styles/workspace/places.css
+++ b/src/styles/workspace/places.css
@@ -1,0 +1,512 @@
+/* ===================================
+   Place Search Page Styles
+=================================== */
+
+.place-search-container {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+}
+
+/* ===================================
+   검색 헤더
+=================================== */
+.search-header {
+  padding: 20px;
+  border-bottom: 2px solid #eee;
+  background: #fff;
+}
+
+.search-input-wrapper {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 15px;
+}
+
+.search-input {
+  flex: 1;
+  height: 45px;
+  padding: 0 20px;
+  border: 2px solid #ddd;
+  border-radius: 8px;
+  font-size: 15px;
+  font-weight: 500;
+  transition: border-color 0.2s;
+}
+
+.search-input:focus {
+  outline: none;
+  border-color: #000;
+}
+
+.btn-search {
+  width: 100px;
+  height: 45px;
+  background: #000;
+  color: #fff;
+  border: 2px solid #000;
+  border-radius: 8px;
+  font-weight: bold;
+  font-size: 14px;
+  cursor: pointer;
+  transition: 0.2s;
+}
+
+.btn-search:hover {
+  background: #333;
+}
+
+/* 카테고리 필터 */
+.category-filters {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.filter-btn {
+  padding: 8px 16px;
+  border: 2px solid #ddd;
+  background: #fff;
+  color: #666;
+  font-family: var(--font-mono);
+  font-weight: bold;
+  font-size: 13px;
+  border-radius: 20px;
+  cursor: pointer;
+  transition: 0.2s;
+}
+
+.filter-btn:hover {
+  border-color: #999;
+  color: #333;
+}
+
+.filter-btn.active {
+  background: #000;
+  color: #fff;
+  border-color: #000;
+}
+
+/* ===================================
+   메인 콘텐츠 (리스트 + 지도)
+=================================== */
+.search-body {
+  flex: 1;
+  display: grid;
+  grid-template-columns: 400px 1fr;
+  gap: 0;
+  overflow: hidden;
+}
+
+/* 왼쪽: 검색 결과 패널 */
+.results-panel {
+  display: flex;
+  flex-direction: column;
+  border-right: 2px solid #eee;
+  background: #fafafa;
+  overflow: hidden;
+}
+
+.results-header {
+  padding: 15px 20px;
+  background: #fff;
+  border-bottom: 1px solid #eee;
+  font-family: var(--font-mono);
+  font-weight: bold;
+  font-size: 14px;
+  color: #666;
+}
+
+.place-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 15px;
+}
+
+/* 빈 상태 */
+.empty-state {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 300px;
+  color: #999;
+  font-size: 15px;
+  text-align: center;
+}
+
+/* 장소 카드 */
+.place-card {
+  display: flex;
+  gap: 15px;
+  background: #fff;
+  border: 2px solid #ddd;
+  border-radius: 8px;
+  padding: 15px;
+  margin-bottom: 12px;
+  transition: 0.2s;
+  cursor: pointer;
+}
+
+.place-card:hover {
+  border-color: #000;
+  box-shadow: 4px 4px 0px rgba(0, 0, 0, 0.1);
+  transform: translateY(-2px);
+}
+
+.place-image {
+  width: 80px;
+  height: 80px;
+  border-radius: 6px;
+  overflow: hidden;
+  flex-shrink: 0;
+  background: #eee;
+}
+
+.place-image img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.place-info {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.place-category {
+  display: inline-block;
+  padding: 2px 8px;
+  background: #000;
+  color: #fff;
+  font-size: 11px;
+  font-weight: bold;
+  border-radius: 4px;
+  width: fit-content;
+}
+
+.place-name {
+  font-size: 16px;
+  font-weight: 800;
+  color: #000;
+  margin: 0;
+  line-height: 1.3;
+}
+
+.place-address {
+  font-size: 12px;
+  color: #666;
+  margin: 0;
+  line-height: 1.4;
+}
+
+.place-desc {
+  font-size: 13px;
+  color: #888;
+  margin: 4px 0 0 0;
+  line-height: 1.4;
+}
+
+.place-meta {
+  display: flex;
+  gap: 10px;
+  margin-top: 4px;
+}
+
+.rating {
+  font-size: 12px;
+  font-weight: bold;
+  color: #ff9800;
+}
+
+.btn-add-place {
+  align-self: flex-start;
+  padding: 8px 16px;
+  background: #000;
+  color: #fff;
+  border: 2px solid #000;
+  border-radius: 6px;
+  font-weight: bold;
+  font-size: 13px;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: 0.2s;
+}
+
+.btn-add-place:hover {
+  background: #333;
+}
+
+.btn-add-place:disabled {
+  background: #4caf50;
+  border-color: #4caf50;
+  cursor: not-allowed;
+}
+
+/* ===================================
+   오른쪽: 지도 패널
+=================================== */
+.map-panel {
+  display: flex;
+  flex-direction: column;
+  background: #f5f5f5;
+  position: relative;
+}
+
+.map-controls {
+  position: absolute;
+  top: 20px;
+  right: 20px;
+  z-index: 10;
+  display: flex;
+  gap: 8px;
+}
+
+.map-btn {
+  padding: 10px 15px;
+  background: #fff;
+  border: 2px solid #ddd;
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: bold;
+  cursor: pointer;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  transition: 0.2s;
+}
+
+.map-btn:hover {
+  border-color: #000;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+.map-container {
+  flex: 1;
+  width: 100%;
+  height: 100%;
+  background: #e0e0e0;
+}
+
+/* 지도 플레이스홀더 (실제 지도 연동 전) */
+.map-placeholder {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  color: #999;
+  font-size: 18px;
+  font-weight: bold;
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  color: #fff;
+}
+
+/* ===================================
+   하단: 담은 장소 바
+=================================== */
+.saved-places-bar {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 20px;
+  background: #fff;
+  border-top: 2px solid #eee;
+}
+
+.saved-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.saved-title {
+  font-family: var(--font-mono);
+  font-weight: 800;
+  font-size: 15px;
+  color: #000;
+}
+
+.saved-content {
+  display: flex;
+  gap: 15px;
+  align-items: center;
+}
+
+.saved-chips {
+  flex: 1;
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.empty-message {
+  color: #999;
+  font-size: 13px;
+}
+
+.place-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  background: #f0f0f0;
+  border: 2px solid #ddd;
+  border-radius: 20px;
+  font-size: 13px;
+  font-weight: 600;
+  color: #333;
+  transition: 0.2s;
+}
+
+.place-chip:hover {
+  border-color: #999;
+}
+
+.place-chip.more {
+  background: #fff;
+  color: #666;
+  border-style: dashed;
+  cursor: pointer;
+}
+
+.chip-remove {
+  background: none;
+  border: none;
+  color: #999;
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0;
+  margin-left: 2px;
+  transition: 0.2s;
+}
+
+.chip-remove:hover {
+  color: #ff0000;
+  transform: scale(1.2);
+}
+
+/* AI 일정 생성 버튼 - 검정색 스타일 */
+.btn-generate-schedule {
+  padding: 10px 20px;
+  background-color: #000 !important;
+  color: #fff !important;
+  border: 2px solid #000;
+  border-radius: 4px;
+  font-family: var(--font-mono);
+  font-weight: bold;
+  font-size: 14px;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: all 0.2s;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  position: relative;
+  overflow: hidden;
+}
+
+.btn-generate-schedule::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: -100%;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.2), transparent);
+  transition: left 0.5s;
+}
+
+.btn-generate-schedule:hover::before {
+  left: 100%;
+}
+
+.btn-generate-schedule:hover {
+  background-color: #222 !important;
+  border-color: #222;
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
+}
+
+.btn-generate-schedule:disabled {
+  background-color: #ccc !important;
+  border-color: #ccc;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+/* ===================================
+   반응형
+=================================== */
+@media (max-width: 1200px) {
+  .search-body {
+    grid-template-columns: 350px 1fr;
+  }
+}
+
+@media (max-width: 900px) {
+  .search-body {
+    grid-template-columns: 1fr;
+    grid-template-rows: 400px 1fr;
+  }
+
+  .results-panel {
+    border-right: none;
+    border-bottom: 2px solid #eee;
+  }
+
+  .saved-content {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .btn-generate-schedule {
+    width: 100%;
+  }
+}
+
+@media (max-width: 600px) {
+  .search-header {
+    padding: 15px;
+  }
+
+  .search-input-wrapper {
+    flex-direction: column;
+  }
+
+  .btn-search {
+    width: 100%;
+  }
+
+  .place-card {
+    flex-direction: column;
+  }
+
+  .place-image {
+    width: 100%;
+    height: 150px;
+  }
+
+  .btn-add-place {
+    width: 100%;
+  }
+}
+
+/* 스크롤바 스타일 */
+.place-list::-webkit-scrollbar {
+  width: 8px;
+}
+
+.place-list::-webkit-scrollbar-track {
+  background: #f1f1f1;
+}
+
+.place-list::-webkit-scrollbar-thumb {
+  background: #ccc;
+  border-radius: 4px;
+}
+
+.place-list::-webkit-scrollbar-thumb:hover {
+  background: #999;
+}


### PR DESCRIPTION
## 🎨 작업 내용 (What)

- Workspace 내 Day All 일정 관리 화면 구현
- Day All 화면과 Day Detail(날짜별 일정) 화면 간 전환 플로우 구성
- Day별 일정 데이터를 타임라인 형태로 표시하도록 구조 설계
- 일정 및 장소 데이터가 Workspace 레이아웃과 자연스럽게 연동되도록 연결

---

## 🧭 작업 목적 (Why)

- 여행 일정을 날짜 단위가 아닌 전체 여행 관점(Day All)에서 시작할 수 있는 구조를 제공하기 위함
- Day All → Day Detail로 이어지는 일정 관리 흐름을 명확히 정의하여 Workspace 내 일정 플로우의 기준을 마련
- 이후 AI 일정 생성 및 협업 기능 확장을 고려한 기본 일정 구조를 선행 구축하기 위함

---

## 🧩 변경 범위
- [x] UI / Layout
- [x] 컴포넌트
- [x] 상태 관리
- [ ] API 연동
- [x] 스타일(CSS/Styled)

---

## 🧪 테스트 방법
- [x] 로컬 실행 확인
- [x] 주요 화면 렌더링 확인
  - Workspace 진입 시 Day All 화면 정상 노출
  - Day All ↔ Day Detail 전환 확인
- [x] 에러 콘솔 확인

---

## ⚠️ 참고 사항
- 장소 추가/상세/AI 일정 생성 모달은 다음 PR에서 분리 예정
- 일정 데이터는 현재 로컬 상태 기반으로 관리되며, 이후 서버 연동 및 AI 일정 생성 로직과 연결될 예정
- 이번 PR은 일정 플로우와 화면 구조 확립에 초점을 둠

---

## ✅ 체크리스트
- [x] main 브랜치 직접 push 하지 않음
- [x] feature 브랜치에서 작업함
- [x] 불필요한 console.log 제거
- [x] PR 단위가 과도하게 크지 않음
