### PR TITLE
[FE] feature: 소셜 로그인 UI 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,10 +7,15 @@ import Community from "./pages/Community";
 import Mate from "./pages/Mate";
 import Workspace from "./pages/Workspace";
 import TravelStory from './pages/TravelStory';
+import Login from "./pages/Login";
+import UserSettings from "./components/user/UserSetting";
 
 export default function App() {
   return (
     <Routes>
+      <Route path="/login" element={<Login />} />
+      <Route path="/setting" element={<UserSettings />} />
+
       <Route element={<Layout />}>
         <Route path="/" element={<Home />} />
         <Route path="/mytrips" element={<MyTrips />} />

--- a/src/components/user/LoginForm.tsx
+++ b/src/components/user/LoginForm.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import styles from '../../styles/user/LoginForm.module.css';
+
+export const LoginForm: React.FC = () => {
+  const lastLoginProvider: 'google' | 'kakao' | null = 'google'; // UI용 가짜 값
+
+  return (
+    <div className={styles.formContainer}>
+      <div className={styles.form}>
+        <p className={styles.hintText}>
+          소셜 계정으로 간편하게 시작하세요
+        </p>
+
+        <div className={styles.socialColumn}>
+          {/* Google */}
+          <div className={styles.socialButtonWrapper}>
+            {lastLoginProvider === 'google' && (
+              <div className={styles.recentBadge}>
+                최근 로그인
+              </div>
+            )}
+            <button type="button" className={styles.socialButton}>
+              <span className={styles.icon}>
+                <svg viewBox="0 0 24 24" aria-hidden>
+                  <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
+                  <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
+                  <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/>
+                  <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
+                </svg>
+              </span>
+              Google로 계속하기
+            </button>
+
+          </div>
+
+          {/* Kakao */}
+          <div className={styles.socialButtonWrapper}>
+            {lastLoginProvider === 'kakao' && (
+              <div className={styles.recentBadge}>
+                최근 로그인
+              </div>
+            )}
+            <button
+              type="button"
+              className={`${styles.socialButton} ${styles.kakao}`}
+            >
+              <span className={styles.icon}>
+                <svg viewBox="0 0 24 24" fill="#000000" aria-hidden>
+                  <path d="M12 3c5.799 0 10.5 3.664 10.5 8.185 0 4.52-4.701 8.184-10.5 8.184a13.5 13.5 0 0 1-1.727-.11l-4.408 2.883c-.501.265-.678.236-.472-.413l.892-3.678c-2.88-1.46-4.785-3.99-4.785-6.866C1.5 6.665 6.201 3 12 3z"/>
+                </svg>
+              </span>
+              카카오로 계속하기
+            </button>
+
+          </div>
+        </div>
+      </div>
+
+    </div>
+  );
+};

--- a/src/components/user/common/TicketInfo.module.css
+++ b/src/components/user/common/TicketInfo.module.css
@@ -1,0 +1,87 @@
+.logo {
+  font-size: 3rem;
+  font-weight: 900;
+  color: var(--text-main);
+  margin: 0;
+  font-family: var(--font-mono);
+  letter-spacing: 0.1em;
+  text-align: center;
+}
+
+.customContent {
+  width: 100%;
+}
+
+.flightInfo {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+  align-items: center;
+}
+
+.route {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  width: 100%;
+}
+
+.city {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.3rem;
+}
+
+.label {
+  font-size: 0.65rem;
+  font-weight: 600;
+  font-family: var(--font-mono);
+  color: var(--text-sub);
+  letter-spacing: 0.05em;
+}
+
+.code {
+  font-size: 1.6rem;
+  font-weight: 900;
+  font-family: var(--font-mono);
+  color: var(--text-main);
+  line-height: 1;
+}
+
+.name {
+  font-size: 0.65rem;
+  color: var(--text-sub);
+  font-family: var(--font-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.plane {
+  font-size: 3.5rem;
+  color: var(--text-sub);
+  line-height: 1;
+}
+
+.tagline {
+  font-size: 0.75rem;
+  color: var(--text-sub);
+  font-family: var(--font-mono);
+  text-align: center;
+  padding: 0.75rem 1rem;
+  border-top: var(--border-width) solid var(--border-color);
+  width: 100%;
+}
+
+@media (max-width: 768px) {
+  .logo {
+    font-size: 2rem;
+  }
+  
+  .plane {
+    font-size: 2.5rem;
+  }
+}

--- a/src/components/user/common/TicketInfo.tsx
+++ b/src/components/user/common/TicketInfo.tsx
@@ -1,0 +1,56 @@
+import React, { ReactNode } from 'react';
+import styles from './TicketInfo.module.css';
+
+interface TicketInfoProps {
+  title?: string;
+  fromLabel?: string;
+  fromCode?: string;
+  fromName?: string;
+  toLabel?: string;
+  toCode?: string;
+  toName?: string;
+  tagline?: string;
+  customContent?: ReactNode;
+}
+
+export const TicketInfo: React.FC<TicketInfoProps> = ({
+  title = 'TripMoa',
+  fromLabel,
+  fromCode,
+  fromName,
+  toLabel,
+  toCode,
+  toName,
+  tagline,
+  customContent
+}) => {
+  return (
+    <>
+      <h1 className={styles.logo}>{title}</h1>
+      {customContent ? (
+        <div className={styles.customContent}>{customContent}</div>
+      ) : (
+        <div className={styles.flightInfo}>
+          {fromCode && toCode ? (
+            <>
+              <div className={styles.route}>
+                <div className={styles.city}>
+                  {fromLabel && <span className={styles.label}>{fromLabel}</span>}
+                  <span className={styles.code}>{fromCode}</span>
+                  {fromName && <span className={styles.name}>{fromName}</span>}
+                </div>
+                <div className={styles.plane}>✈</div>
+                <div className={styles.city}>
+                  {toLabel && <span className={styles.label}>{toLabel}</span>}
+                  <span className={styles.code}>{toCode}</span>
+                  {toName && <span className={styles.name}>{toName}</span>}
+                </div>
+              </div>
+              {tagline && <div className={styles.tagline}>{tagline}</div>}
+            </>
+          ) : null}
+        </div>
+      )}
+    </>
+  );
+};

--- a/src/components/user/common/TicketLayout.module.css
+++ b/src/components/user/common/TicketLayout.module.css
@@ -1,0 +1,141 @@
+.container {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  position: relative;
+  overflow: hidden;
+}
+
+.ticketWrapper {
+  display: flex;
+  width: 100%;
+  max-width: 900px;
+  background: var(--surface);
+  border: var(--border-width) solid var(--border-color);
+  box-shadow: var(--shadow-hard);
+  position: relative;
+  z-index: 10;
+}
+
+/* 왼쪽 티켓 정보 */
+.ticketLeft {
+  flex: 1;
+  padding: 3rem 2rem;
+  border-right: 2px dashed var(--border-color);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 2rem;
+  position: relative;
+  background: linear-gradient(135deg, #f8f9fa 0%, #ffffff 100%);
+}
+
+/* 펀치홀 */
+.ticketLeft::before,
+.ticketLeft::after {
+  content: '';
+  position: absolute;
+  right: -11px;
+  width: 20px;
+  height: 20px;
+  background: var(--bg-color);
+  border-radius: 50%;
+  border: var(--border-width) solid var(--border-color);
+  z-index: 100;
+}
+
+.ticketLeft::before {
+  top: -11px;
+}
+
+.ticketLeft::after {
+  bottom: -11px;
+}
+
+/* 오른쪽 폼 영역 */
+.ticketRight {
+  flex: 1.5;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  position: relative;
+  z-index: 1;
+}
+
+/* 뭉실뭉실 구름 1 */
+.cloud1 {
+  position: absolute;
+  top: 12%;
+  left: 3%;
+  width: 240px;
+  height: auto;
+  z-index: 1;
+  pointer-events: none;
+  filter: drop-shadow(4px 4px 0 var(--border-color));
+  animation: float 8s ease-in-out infinite;
+}
+
+/* 뭉실뭉실 구름 2 */
+.cloud2 {
+  position: absolute;
+  bottom: 18%;
+  right: 5%;
+  width: 210px;
+  height: auto;
+  z-index: 1;
+  pointer-events: none;
+  filter: drop-shadow(4px 4px 0 var(--border-color));
+  animation: float 10s ease-in-out infinite reverse;
+}
+
+@keyframes float {
+  0%, 100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-20px);
+  }
+}
+
+@media (max-width: 768px) {
+  .ticketWrapper {
+    flex-direction: column;
+    height: auto !important;
+    max-height: 90vh;
+  }
+  
+  .ticketLeft {
+    border-right: none;
+    border-bottom: 2px dashed var(--border-color);
+    padding: 2rem;
+  }
+  
+  .ticketLeft::before,
+  .ticketLeft::after {
+    right: auto;
+    bottom: -11px;
+  }
+  
+  .ticketLeft::before {
+    left: -11px;
+    top: auto;
+  }
+  
+  .ticketLeft::after {
+    right: -11px;
+    top: auto;
+  }
+  
+  .ticketRight {
+    overflow-y: auto;
+    max-height: 60vh;
+  }
+  
+  .cloud1,
+  .cloud2 {
+    display: none;
+  }
+}

--- a/src/components/user/common/TicketLayout.tsx
+++ b/src/components/user/common/TicketLayout.tsx
@@ -1,0 +1,69 @@
+import React, { ReactNode } from 'react';
+import styles from './TicketLayout.module.css';
+
+interface TicketLayoutProps {
+  leftContent: ReactNode;
+  rightContent: ReactNode;
+  height?: string;
+}
+
+export const TicketLayout: React.FC<TicketLayoutProps> = ({ 
+  leftContent, 
+  rightContent,
+  height = '440px'
+}) => {
+  return (
+    <div className={styles.container}>
+      <div className={styles.ticketWrapper} style={{ height }}>
+        <div className={styles.ticketLeft}>
+          {leftContent}
+        </div>
+        <div className={styles.ticketRight}>
+          {rightContent}
+        </div>
+      </div>
+      
+      {/* 뭉실뭉실 구름 1 */}
+      <svg className={styles.cloud1} viewBox="0 0 250 120" xmlns="http://www.w3.org/2000/svg">
+        <path d="M 35,70 
+                 Q 30,50 45,45
+                 Q 50,30 70,28
+                 Q 85,26 95,35
+                 Q 110,20 130,22
+                 Q 145,24 155,35
+                 Q 175,30 190,42
+                 Q 205,42 210,58
+                 Q 215,70 205,82
+                 Q 195,90 180,90
+                 L 50,90
+                 Q 35,90 30,78
+                 Q 28,70 35,70 Z"
+              fill="white"
+              stroke="var(--border-color)"
+              strokeWidth="2"
+        />
+      </svg>
+
+      {/* 뭉실뭉실 구름 2 */}
+      <svg className={styles.cloud2} viewBox="0 0 220 110" xmlns="http://www.w3.org/2000/svg">
+        <path d="M 30,65
+                 Q 25,48 40,42
+                 Q 48,28 65,26
+                 Q 78,25 88,32
+                 Q 100,20 118,22
+                 Q 135,24 145,35
+                 Q 160,28 175,38
+                 Q 190,42 192,55
+                 Q 195,68 185,78
+                 Q 175,85 160,85
+                 L 45,85
+                 Q 30,85 27,72
+                 Q 25,65 30,65 Z"
+              fill="white"
+              stroke="var(--border-color)"
+              strokeWidth="2"
+        />
+      </svg>
+    </div>
+  );
+};

--- a/src/components/user/common/index.ts
+++ b/src/components/user/common/index.ts
@@ -1,0 +1,2 @@
+export { TicketLayout } from './TicketLayout';
+export { TicketInfo } from './TicketInfo';

--- a/src/components/user/index.ts
+++ b/src/components/user/index.ts
@@ -1,0 +1,2 @@
+export { LoginForm } from './LoginForm';
+export { TicketLayout, TicketInfo } from './common';

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { TicketLayout, TicketInfo, LoginForm } from '../components/user';
+
+const Login: React.FC = () => {
+  return (
+    <TicketLayout
+      leftContent={
+        <TicketInfo
+          fromCode="OUT"
+          fromName="Offline"
+          toCode="IN"
+          toName="Online"
+          tagline="Social login only"
+        />
+      }
+      rightContent={
+        <LoginForm socialOnly />
+      }
+    />
+  );
+};
+
+export default Login;

--- a/src/styles/user/Login.module.css
+++ b/src/styles/user/Login.module.css
@@ -1,0 +1,199 @@
+.container {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  position: relative;
+  overflow: hidden;
+}
+
+.ticketWrapper {
+  display: flex;
+  width: 100%;
+  max-width: 900px;
+  height: 440px;
+  background: var(--surface);
+  border: var(--border-width) solid var(--border-color);
+  box-shadow: var(--shadow-hard);
+  position: relative;
+  z-index: 10;
+}
+
+/* 왼쪽 티켓 정보 */
+.ticketLeft {
+  flex: 1;
+  padding: 3rem 2rem;
+  border-right: 2px dashed var(--border-color);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 2rem;
+  position: relative;
+  background: linear-gradient(135deg, #f8f9fa 0%, #ffffff 100%);
+}
+
+/* 펀치홀 */
+.ticketLeft::before,
+.ticketLeft::after {
+  content: '';
+  position: absolute;
+  right: -11px;
+  width: 20px;
+  height: 20px;
+  background: var(--bg-color);
+  border-radius: 50%;
+  border: var(--border-width) solid var(--border-color);
+  z-index: 100;
+}
+
+.ticketLeft::before {
+  top: -11px;
+}
+
+.ticketLeft::after {
+  bottom: -11px;
+}
+
+.logo {
+  font-size: 3rem;
+  font-weight: 900;
+  color: var(--text-main);
+  margin: 0;
+  font-family: var(--font-mono);
+  letter-spacing: 0.1em;
+  text-align: center;
+}
+
+.flightInfo {
+  width: 100%;
+}
+
+.route {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.city {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.code {
+  font-size: 1.5rem;
+  font-weight: 900;
+  font-family: var(--font-mono);
+  color: var(--text-main);
+}
+
+.name {
+  font-size: 0.75rem;
+  color: var(--text-sub);
+  font-family: var(--font-mono);
+  text-transform: uppercase;
+}
+
+.plane {
+  font-size: 3.5rem;
+  color: var(--text-sub);
+  line-height: 1;
+}
+
+/* 오른쪽 폼 영역 */
+.ticketRight {
+  flex: 1.5;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  position: relative;
+  z-index: 1;
+}
+
+/* 뭉실뭉실 구름 1 */
+.cloud1 {
+  position: absolute;
+  top: 12%;
+  left: 3%;
+  width: 240px;
+  height: auto;
+  z-index: 1;
+  pointer-events: none;
+  filter: drop-shadow(4px 4px 0 var(--border-color));
+  animation: float 8s ease-in-out infinite;
+}
+
+/* 뭉실뭉실 구름 2 */
+.cloud2 {
+  position: absolute;
+  bottom: 18%;
+  right: 5%;
+  width: 210px;
+  height: auto;
+  z-index: 1;
+  pointer-events: none;
+  filter: drop-shadow(4px 4px 0 var(--border-color));
+  animation: float 10s ease-in-out infinite reverse;
+}
+
+@keyframes float {
+  0%, 100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-20px);
+  }
+}
+
+@media (max-width: 768px) {
+  .ticketWrapper {
+    flex-direction: column;
+    height: auto;
+    max-height: 90vh;
+  }
+  
+  .ticketLeft {
+    border-right: none;
+    border-bottom: 2px dashed var(--border-color);
+    padding: 2rem;
+  }
+  
+  .ticketLeft::before,
+  .ticketLeft::after {
+    right: auto;
+    bottom: -11px;
+  }
+  
+  .ticketLeft::before {
+    left: -11px;
+    top: auto;
+  }
+  
+  .ticketLeft::after {
+    right: -11px;
+    top: auto;
+  }
+  
+  .ticketRight {
+    overflow-y: auto;
+    max-height: 60vh;
+  }
+  
+  .logo {
+    font-size: 2rem;
+  }
+  
+  .plane {
+    font-size: 2.5rem;
+  }
+  
+  .cloud1,
+  .cloud2 {
+    display: none;
+  }
+}

--- a/src/styles/user/LoginForm.module.css
+++ b/src/styles/user/LoginForm.module.css
@@ -1,0 +1,121 @@
+.formContainer {
+  width: 100%;
+  height: 100%;
+  background: var(--surface);
+  padding: 2rem 2.2rem;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+}
+
+/* 메인 폼 */
+.form {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  height: 100%;
+  gap: 1.4rem;
+}
+
+/* 안내 문구 */
+.hintText {
+  text-align: center;
+  font-size: 0.72rem;
+  color: var(--text-sub);
+  font-family: var(--font-mono);
+  line-height: 1.4;
+}
+
+/* 소셜 버튼 컬럼 */
+.socialColumn {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  margin-top: 0.4rem;
+}
+
+/* 버튼 래퍼 (말풍선 기준점) */
+.socialButtonWrapper {
+  position: relative;
+  width: 100%;
+}
+
+/* 공통 소셜 버튼 */
+.socialButton {
+  width: 100%;
+  padding: 0.95rem 1rem;
+  border: var(--border-width) solid var(--border-color) !important;
+  font-size: 0.78rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.55rem;
+  background: var(--surface) !important;
+  color: var(--text-main);
+  font-family: var(--font-mono);
+}
+
+.socialButton svg {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+}
+
+.socialButton:hover {
+  box-shadow: var(--shadow-hover);
+  transform: translate(-1px, -1px);
+}
+
+/* Kakao 전용 */
+.kakao {
+  background: #FEE500 !important;
+  color: #000000 !important;
+}
+
+/* 최근 로그인 말풍선 */
+.recentBadge {
+  position: absolute;
+  top: -10px;
+  left: 1rem;
+  background: var(--primary);
+  color: var(--surface);
+  font-size: 0.6rem;
+  font-weight: 700;
+  padding: 0.22rem 0.45rem;
+  border-radius: 999px;
+  white-space: nowrap;
+  font-family: var(--font-mono);
+  box-shadow: var(--shadow-hard);
+  z-index: 2;
+}
+
+/* 말풍선 꼬리 */
+.recentBadge::after {
+  content: '';
+  position: absolute;
+  bottom: -4px;
+  left: 14px;
+  border-width: 4px 4px 0 4px;
+  border-style: solid;
+  border-color: var(--primary) transparent transparent transparent;
+}
+
+/* 모바일 대응 */
+@media (max-width: 768px) {
+  .formContainer {
+    padding: 1.5rem;
+    height: auto;
+  }
+
+  .form {
+    gap: 1.2rem;
+  }
+
+  .socialButton {
+    font-size: 0.75rem;
+    padding: 0.9rem;
+  }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #35 

---

## 🎨 작업 내용 (What)

- 소셜 로그인 전용 로그인 화면 UI 구현
- Google / Kakao 로그인 버튼 디자인 적용
- 최근 로그인한 소셜 계정을 말풍선 UI로 표시
- 티켓 레이아웃과 어울리도록 로그인 폼 비율 및 정렬 조정
- 소셜 로그인 전용 UX를 고려한 레이아웃 구조 정리

---

## 🧭 작업 목적 (Why)

- 아이디/비밀번호 입력 없이 소셜 로그인만 제공하는 서비스 구조를 명확히 표현하기 위함
- 로그인 화면에서 사용자가 선택해야 할 행동을 단순화하여 진입 장벽을 낮추기 위함
- 재방문 사용자가 최근 사용한 로그인 방식을 빠르게 인지할 수 있도록 UX 개선

---

## 🧩 변경 범위
- [x] UI / Layout
- [x] 컴포넌트 구조
- [ ] 상태 관리 로직
- [ ] API 연동
- [x] 스타일

---

## 🧪 테스트 방법
- [x] 로컬 실행 확인
- [x] 주요 화면 렌더링 확인
- [x] 에러 콘솔 확인

---

## ⚠️ 참고 사항

- 본 PR은 UI/UX 구현만 포함하며 실제 소셜 로그인 기능은 추후 연동 예정
- 최근 로그인 표시 상태는 임시 더미 값으로 처리되어 있음
- 로그인 티켓 레이아웃 높이 및 정렬은 디자인 기준에 맞게 조정함

---

## ✅ 체크리스트
- [x] main 브랜치 직접 push 하지 않음
- [x] feature 브랜치에서 작업함
- [x] 불필요한 console.log 제거
- [x] PR 단위가 과도하게 크지 않음
