### PR TITLE
[FE] feature: 사용자 초기 설정 UI 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,7 @@ import Mate from "./pages/Mate";
 import Workspace from "./pages/Workspace";
 import TravelStory from './pages/TravelStory';
 import Login from "./pages/Login";
-import UserSettings from "./components/user/UserSetting";
+import UserSettings from "./pages/UserSetting";
 
 export default function App() {
   return (

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -19,7 +19,7 @@ export default function Header() {
 
   // 설정 버튼 클릭 시 알림창
   const handleSettingsClick = () => {
-    alert("준비 중인 기능입니다.");
+    navigate("/setting");
   };
 
   return (

--- a/src/components/user/User.constant.ts
+++ b/src/components/user/User.constant.ts
@@ -1,0 +1,88 @@
+// constants/user.constants.ts
+
+export const STORAGE_KEYS = {
+  USER_PROFILE: 'tripmoa_user_profile',
+} as const;
+
+export const GENDERS = ['남성', '여성', '기타'] as const;
+
+export const MBTI_TYPES = [
+  'INTJ', 'INTP', 'ENTJ', 'ENTP',
+  'INFJ', 'INFP', 'ENFJ', 'ENFP',
+  'ISTJ', 'ISFJ', 'ESTJ', 'ESFJ',
+  'ISTP', 'ISFP', 'ESTP', 'ESFP'
+] as const;
+
+export const TRAVEL_STYLES = [
+  '맛집탐방',
+  '액티비티', 
+  '힐링',
+  '문화탐방',
+  '쇼핑',
+  '자연',
+  '사진',
+  '야경',
+  '로컬체험',
+  '카페투어',
+  '축제',
+  '역사탐방',
+  '야외활동',
+  '미식투어',
+  '럭셔리',
+  '배낭여행'
+] as const;
+
+// 랜덤 아바타용 이모지
+export const AVATAR_EMOJIS = [
+  '😊', '🎉', '✈️', '🌍', '📸', '🎒', '🗺️', '🌟',
+  '🎨', '🎭', '🎪', '🎯', '🎸', '🎺', '🎬', '🎮',
+  '⚽', '🏀', '🎾', '🏐', '🏈', '⚾', '🥎', '🏉',
+  '🌸', '🌺', '🌻', '🌷', '🌹', '🌼', '🌿', '🍀',
+  '⭐', '🌙', '☀️', '🌈', '⚡', '❄️', '🔥', '💎'
+] as const;
+
+// 랜덤 아바타용 배경색
+export const AVATAR_COLORS = [
+  '#FFE5E5', '#FFE5CC', '#FFF4CC', '#E5F5E5', 
+  '#E5F0FF', '#F0E5FF', '#FFE5F5', '#FFEBE5',
+  '#FFD4D4', '#FFD4B8', '#FFEAB8', '#D4F0D4',
+  '#D4E5FF', '#E5D4FF', '#FFD4F0', '#FFD9C8',
+  '#FEC6C6', '#FEC6A3', '#FFDEA3', '#C6E8C6',
+  '#C6DAFF', '#DAC6FF', '#FFC6E8', '#FFC8B8'
+] as const;
+
+export const DEFAULT_PROFILE = {
+  photo: '',
+  nickname: '',
+  name: '',
+  birthDate: '',
+  gender: '',
+  mbti: '',
+  travelStyles: [] as string[],
+  isVerified: false,
+} as const;
+
+export const MODAL_MESSAGES = {
+  VERIFY: {
+    TITLE: '본인 인증',
+    DESCRIPTION: '실제 서비스에서는 휴대폰 인증, 아이핀 인증 등이 진행됩니다.\n데모에서는 바로 인증이 완료됩니다.',
+    BUTTON: '인증하기',
+    SUCCESS: '✅ 본인 인증이 완료되었습니다!',
+  },
+  DELETE: {
+    TITLE: '계정을 탈퇴하시겠습니까?',
+    DESCRIPTION: '모든 여행 기록, 메이트 정보, 채팅 내역이 영구적으로 삭제됩니다.\n이 작업은 되돌릴 수 없습니다.',
+    BUTTON: '탈퇴하기',
+    SUCCESS: '계정이 탈퇴되었습니다. 그동안 이용해주셔서 감사합니다.',
+  },
+  SAVE: {
+    SUCCESS: '✅ 프로필이 저장되었습니다!',
+  },
+} as const;
+
+// 랜덤 아바타 생성 함수
+export function generateRandomAvatar(): { emoji: string; color: string } {
+  const randomEmoji = AVATAR_EMOJIS[Math.floor(Math.random() * AVATAR_EMOJIS.length)];
+  const randomColor = AVATAR_COLORS[Math.floor(Math.random() * AVATAR_COLORS.length)];
+  return { emoji: randomEmoji, color: randomColor };
+}

--- a/src/hooks/useUserSetting.ts
+++ b/src/hooks/useUserSetting.ts
@@ -1,0 +1,169 @@
+// hooks/useUserProfile.ts
+
+import { useState, useEffect, useRef } from 'react';
+import { STORAGE_KEYS, DEFAULT_PROFILE, generateRandomAvatar } from '../components/user/User.constant';
+
+export interface UserProfile {
+  photo: string;
+  nickname: string;
+  name: string;
+  birthDate: string; // YYYY-MM-DD 형식
+  gender: string;
+  mbti: string;
+  travelStyles: string[];
+  isVerified: boolean;
+  avatarEmoji?: string; // 기본 아바타용
+  avatarColor?: string; // 기본 아바타용
+}
+
+export function useUserProfile() {
+  const [profile, setProfile] = useState<UserProfile>(() => {
+    const { emoji, color } = generateRandomAvatar();
+    return { 
+      ...DEFAULT_PROFILE, 
+      travelStyles: [],
+      avatarEmoji: emoji,
+      avatarColor: color
+    };
+  });
+  
+  const [hasChanges, setHasChanges] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // 로컬스토리지에서 불러오기
+  useEffect(() => {
+    const saved = localStorage.getItem(STORAGE_KEYS.USER_PROFILE);
+    if (saved) {
+      try {
+        const parsedProfile = JSON.parse(saved);
+        // 기존 프로필에 avatarEmoji/Color가 없으면 생성
+        if (!parsedProfile.avatarEmoji || !parsedProfile.avatarColor) {
+          const { emoji, color } = generateRandomAvatar();
+          parsedProfile.avatarEmoji = emoji;
+          parsedProfile.avatarColor = color;
+        }
+        setProfile(parsedProfile);
+      } catch (error) {
+        console.error('프로필 불러오기 실패:', error);
+      }
+    }
+  }, []);
+
+  // 변경사항 감지
+  useEffect(() => {
+    const saved = localStorage.getItem(STORAGE_KEYS.USER_PROFILE);
+    const current = JSON.stringify(profile);
+    setHasChanges(saved !== current);
+  }, [profile]);
+
+  // 프로필 업데이트
+  const updateProfile = (updates: Partial<UserProfile>) => {
+    setProfile(prev => ({ ...prev, ...updates }));
+  };
+
+  // 프로필 저장
+  const saveProfile = async (): Promise<void> => {
+    setIsSaving(true);
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        localStorage.setItem(STORAGE_KEYS.USER_PROFILE, JSON.stringify(profile));
+        setHasChanges(false);
+        setIsSaving(false);
+        resolve();
+      }, 500);
+    });
+  };
+
+  // 사진 변경
+  const handlePhotoChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      const reader = new FileReader();
+      reader.onload = (event) => {
+        updateProfile({ photo: event.target?.result as string });
+      };
+      reader.readAsDataURL(file);
+    }
+  };
+
+  // 사진 업로드 트리거
+  const triggerPhotoUpload = () => {
+    fileInputRef.current?.click();
+  };
+
+  // 여행 스타일 토글
+  const toggleTravelStyle = (style: string) => {
+    const styles = profile.travelStyles || [];
+    if (styles.includes(style)) {
+      updateProfile({ travelStyles: styles.filter(s => s !== style) });
+    } else {
+      updateProfile({ travelStyles: [...styles, style] });
+    }
+  };
+
+  // 본인 인증
+  const verify = async (): Promise<void> => {
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        updateProfile({ isVerified: true });
+        resolve();
+      }, 1000);
+    });
+  };
+
+  // 계정 탈퇴
+  const deleteAccount = () => {
+    localStorage.removeItem(STORAGE_KEYS.USER_PROFILE);
+    const { emoji, color } = generateRandomAvatar();
+    setProfile({ 
+      ...DEFAULT_PROFILE, 
+      travelStyles: [],
+      avatarEmoji: emoji,
+      avatarColor: color
+    });
+  };
+
+  // 나이 계산
+  const calculateAge = (birthDate: string): number => {
+    if (!birthDate) return 0;
+    const today = new Date();
+    const birth = new Date(birthDate);
+    let age = today.getFullYear() - birth.getFullYear();
+    const monthDiff = today.getMonth() - birth.getMonth();
+    if (monthDiff < 0 || (monthDiff === 0 && today.getDate() < birth.getDate())) {
+      age--;
+    }
+    return age;
+  };
+
+  // 폼 유효성 검사
+  const isFormValid = !!(
+    profile.nickname && 
+    profile.name && 
+    profile.birthDate && 
+    profile.gender
+  );
+
+  const age = calculateAge(profile.birthDate);
+
+  return {
+    // State
+    profile,
+    hasChanges,
+    isSaving,
+    isFormValid,
+    fileInputRef,
+    age,
+
+    // Actions
+    updateProfile,
+    saveProfile,
+    handlePhotoChange,
+    triggerPhotoUpload,
+    toggleTravelStyle,
+    verify,
+    deleteAccount,
+    calculateAge,
+  };
+}

--- a/src/pages/UserSetting.tsx
+++ b/src/pages/UserSetting.tsx
@@ -1,0 +1,355 @@
+// pages/user/UserSettings.tsx
+
+import React, { useState } from 'react';
+import { Shield, Camera, X, AlertTriangle, Home, ArrowLeft } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { useUserProfile } from '../hooks/useUserSetting';
+import { 
+  GENDERS, 
+  MBTI_TYPES,
+  TRAVEL_STYLES,
+  MODAL_MESSAGES 
+} from '../components/user/User.constant';
+import styles from '../styles/user/UserSetting.module.css';
+
+export default function UserSettings() {
+  const navigate = useNavigate();
+  
+  const {
+    profile,
+    hasChanges,
+    isSaving,
+    isFormValid,
+    fileInputRef,
+    age,
+    updateProfile,
+    saveProfile,
+    handlePhotoChange,
+    triggerPhotoUpload,
+    toggleTravelStyle,
+    verify,
+    deleteAccount,
+  } = useUserProfile();
+
+  const [showVerifyModal, setShowVerifyModal] = useState(false);
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+
+  // 홈으로 이동
+  const handleGoHome = () => {
+    navigate('/');
+  };
+
+  // 저장 핸들러
+  const handleSave = async () => {
+    await saveProfile();
+    alert(MODAL_MESSAGES.SAVE.SUCCESS);
+  };
+
+  // 본인 인증 핸들러
+  const handleVerify = async () => {
+    await verify();
+    setShowVerifyModal(false);
+    alert(MODAL_MESSAGES.VERIFY.SUCCESS);
+  };
+
+  // 계정 탈퇴 핸들러
+  const handleDeleteAccount = () => {
+    deleteAccount();
+    alert(MODAL_MESSAGES.DELETE.SUCCESS);
+    setShowDeleteModal(false);
+  };
+
+  return (
+    <div className={styles.page}>
+      <div className={styles.ticket}>
+        {/* Header */}
+        <div className={styles.header}>
+          <button 
+            className={styles.homeButton}
+            onClick={handleGoHome}
+            title="홈으로"
+          >
+            <Home size={20} />
+          </button>
+          
+          <div className={styles.headerContent}>
+            <h1 className={styles.title}>MY PAGE</h1>
+            <p className={styles.subtitle}>프로필 및 계정 설정</p>
+            {profile.isVerified && (
+              <div className={styles.verifiedBadge}>
+                <Shield size={14} />
+                <span>인증 완료</span>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Profile Section */}
+        <section className={styles.section}>
+          <h2 className={styles.sectionTitle}>프로필 정보</h2>
+
+          {/* Profile Photo */}
+          <div className={styles.profileRow}>
+            <div 
+              className={styles.avatar}
+              onClick={triggerPhotoUpload}
+              style={{
+                background: profile.photo ? 'transparent' : profile.avatarColor
+              }}
+            >
+              {profile.photo ? (
+                <img src={profile.photo} alt="Profile" />
+              ) : (
+                <span className={styles.avatarEmoji}>{profile.avatarEmoji}</span>
+              )}
+              <div className={styles.avatarOverlay}>
+                <Camera size={20} />
+              </div>
+            </div>
+            
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="image/*"
+              onChange={handlePhotoChange}
+              style={{ display: 'none' }}
+            />
+            
+            <div className={styles.avatarInfo}>
+              <button 
+                className={styles.secondaryButton}
+                style={{ marginTop: '20px' }}
+                onClick={triggerPhotoUpload}
+              >
+                사진 업로드
+              </button>
+              <p className={styles.avatarDesc}>
+                프로필 사진을 업로드하지 않으면 랜덤 아바타가 표시됩니다
+              </p>
+            </div>
+          </div>
+
+          {/* Basic Info */}
+          <div className={styles.grid}>
+            <div className={styles.field}>
+              <label className={styles.label}>
+                닉네임<span className={styles.required}>*</span>
+              </label>
+              <input 
+                className={styles.input} 
+                placeholder="닉네임 입력"
+                value={profile.nickname}
+                onChange={(e) => updateProfile({ nickname: e.target.value })}
+              />
+            </div>
+
+            <div className={styles.field}>
+              <label className={styles.label}>
+                이름<span className={styles.required}>*</span>
+              </label>
+              <input 
+                className={styles.input} 
+                placeholder="이름 입력"
+                value={profile.name}
+                onChange={(e) => updateProfile({ name: e.target.value })}
+              />
+            </div>
+
+            <div className={styles.field}>
+              <label className={styles.label}>
+                생년월일<span className={styles.required}>*</span>
+              </label>
+              <input 
+                className={styles.input}
+                type="date"
+                value={profile.birthDate}
+                onChange={(e) => updateProfile({ birthDate: e.target.value })}
+                max={new Date().toISOString().split('T')[0]}
+              />
+              {age > 0 && (
+                <span className={styles.ageDisplay}>만 {age}세</span>
+              )}
+            </div>
+
+            <div className={styles.field}>
+              <label className={styles.label}>
+                성별<span className={styles.required}>*</span>
+              </label>
+              <select 
+                className={styles.input}
+                value={profile.gender}
+                onChange={(e) => updateProfile({ gender: e.target.value })}
+              >
+                <option value="">성별 선택</option>
+                {GENDERS.map((gender) => (
+                  <option key={gender} value={gender}>
+                    {gender}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className={styles.field}>
+              <label className={styles.label}>MBTI</label>
+              <select 
+                className={styles.input}
+                value={profile.mbti}
+                onChange={(e) => updateProfile({ mbti: e.target.value })}
+              >
+                <option value="">MBTI 선택</option>
+                {MBTI_TYPES.map((mbti) => (
+                  <option key={mbti} value={mbti}>
+                    {mbti}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+
+          {/* Travel Styles */}
+          <div className={styles.travelStyleSection}>
+            <label className={styles.label}>여행 스타일</label>
+            <p className={styles.desc}>관심있는 여행 스타일을 선택해주세요 (복수 선택 가능)</p>
+            <div className={styles.travelStyleGrid}>
+              {TRAVEL_STYLES.map((style) => (
+                <button
+                  key={style}
+                  className={`${styles.travelStyleBtn} ${
+                    profile.travelStyles?.includes(style) ? styles.active : ''
+                  }`}
+                  onClick={() => toggleTravelStyle(style)}
+                  type="button"
+                >
+                  {style}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Save Button */}
+          {hasChanges && (
+            <button 
+              className={`${styles.saveButton} ${isSaving ? styles.saving : ''}`}
+              onClick={handleSave}
+              disabled={!isFormValid || isSaving}
+            >
+              {isSaving ? '저장 중...' : '변경사항 저장'}
+            </button>
+          )}
+        </section>
+
+        {/* Verification Section */}
+        <section className={styles.section}>
+          <h2 className={styles.sectionTitle}>본인 인증</h2>
+          <p className={styles.desc}>
+            {profile.isVerified 
+              ? '✅ 본인 인증이 완료되었습니다.'
+              : '커뮤니티 이용을 위해 본인 인증이 필요합니다.'
+            }
+          </p>
+          <button 
+            className={styles.primaryButton}
+            onClick={() => setShowVerifyModal(true)}
+            disabled={profile.isVerified || !isFormValid}
+          >
+            {profile.isVerified ? '인증 완료' : '본인 인증하기'}
+          </button>
+        </section>
+
+        {/* Account Section */}
+        <section className={`${styles.section} ${styles.danger}`}>
+          <h2 className={styles.sectionTitle}>계정</h2>
+          <p className={styles.desc}>
+            계정을 삭제하면 모든 데이터가 영구적으로 삭제됩니다.
+          </p>
+          <button 
+            className={styles.dangerButton}
+            onClick={() => setShowDeleteModal(true)}
+          >
+            계정 탈퇴
+          </button>
+        </section>
+      </div>
+
+      {/* Verify Modal */}
+      {showVerifyModal && (
+        <div className={styles.modalOverlay} onClick={() => setShowVerifyModal(false)}>
+          <div className={styles.modalContent} onClick={(e) => e.stopPropagation()}>
+            <button 
+              className={styles.modalCloseBtn} 
+              onClick={() => setShowVerifyModal(false)}
+            >
+              <X size={20} />
+            </button>
+            <div className={styles.modalIcon}>
+              <Shield size={48} />
+            </div>
+            <h2 className={styles.modalTitle}>{MODAL_MESSAGES.VERIFY.TITLE}</h2>
+            <p className={styles.modalText}>
+              {MODAL_MESSAGES.VERIFY.DESCRIPTION.split('\n').map((line, i) => (
+                <React.Fragment key={i}>
+                  {line}
+                  {i < MODAL_MESSAGES.VERIFY.DESCRIPTION.split('\n').length - 1 && <br />}
+                </React.Fragment>
+              ))}
+            </p>
+            <div className={styles.modalButtons}>
+              <button 
+                className={styles.modalCancelBtn}
+                onClick={() => setShowVerifyModal(false)}
+              >
+                취소
+              </button>
+              <button 
+                className={styles.modalConfirmBtn}
+                onClick={handleVerify}
+              >
+                {MODAL_MESSAGES.VERIFY.BUTTON}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Delete Account Modal */}
+      {showDeleteModal && (
+        <div className={styles.modalOverlay} onClick={() => setShowDeleteModal(false)}>
+          <div className={styles.modalContent} onClick={(e) => e.stopPropagation()}>
+            <button 
+              className={styles.modalCloseBtn} 
+              onClick={() => setShowDeleteModal(false)}
+            >
+              <X size={20} />
+            </button>
+            <div className={`${styles.modalIcon} ${styles.danger}`}>
+              <AlertTriangle size={48} />
+            </div>
+            <h2 className={styles.modalTitle}>{MODAL_MESSAGES.DELETE.TITLE}</h2>
+            <p className={styles.modalText}>
+              {MODAL_MESSAGES.DELETE.DESCRIPTION.split('\n').map((line, i) => (
+                <React.Fragment key={i}>
+                  {i === 1 ? <strong>{line}</strong> : line}
+                  {i < MODAL_MESSAGES.DELETE.DESCRIPTION.split('\n').length - 1 && <br />}
+                </React.Fragment>
+              ))}
+            </p>
+            <div className={styles.modalButtons}>
+              <button 
+                className={styles.modalCancelBtn}
+                onClick={() => setShowDeleteModal(false)}
+              >
+                취소
+              </button>
+              <button 
+                className={styles.modalDangerBtn}
+                onClick={handleDeleteAccount}
+              >
+                {MODAL_MESSAGES.DELETE.BUTTON}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/styles/user/UserSetting.module.css
+++ b/src/styles/user/UserSetting.module.css
@@ -1,0 +1,528 @@
+/* styles/user/UserSetting.module.css */
+
+/* === Page === */
+.page {
+  width: 100%;
+  min-height: 100vh;
+  background: #f5f5f5;
+  display: flex;
+  justify-content: center;
+  padding: 3rem 1rem;
+}
+
+.ticket {
+  width: 100%;
+  max-width: 700px;
+  background: white;
+  border: 3px solid black;
+  box-shadow: 8px 8px 0 0 black;
+  padding: 2.5rem;
+}
+
+/* === Header === */
+.header {
+  text-align: center;
+  margin-bottom: 2.5rem;
+  position: relative;
+}
+
+.homeButton {
+  position: absolute;
+  top: 0;
+  left: 0;
+  padding: 0.6rem;
+  background: white;
+  border: 2px solid black;
+  cursor: pointer;
+  transition: all 0.2s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: monospace;
+}
+
+.homeButton:hover {
+  background: #fbbf24;
+  transform: translate(-2px, -2px);
+  box-shadow: 3px 3px 0 0 black;
+}
+
+.headerContent {
+  width: 100%;
+}
+
+.title {
+  font-size: 2rem;
+  font-weight: 900;
+  font-family: monospace;
+  letter-spacing: 2px;
+}
+
+.subtitle {
+  font-size: 0.9rem;
+  color: #666;
+  margin-top: 0.5rem;
+}
+
+.verifiedBadge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 12px;
+  padding: 6px 12px;
+  background: #e8f5e9;
+  border: 2px solid #2e7d32;
+  border-radius: 20px;
+  color: #2e7d32;
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+/* === Section === */
+.section {
+  margin-bottom: 2.5rem;
+}
+
+.sectionTitle {
+  font-size: 1.1rem;
+  font-weight: 800;
+  margin-bottom: 1.2rem;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.sectionTitle::before {
+  content: '';
+  width: 4px;
+  height: 20px;
+  background: black;
+}
+
+/* === Profile Photo === */
+.profileRow {
+  display: flex;
+  align-items: flex-start;
+  gap: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.avatar {
+  width: 100px;
+  height: 100px;
+  border-radius: 50%;
+  border: 3px solid black;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 3rem;
+  position: relative;
+  cursor: pointer;
+  overflow: hidden;
+  flex-shrink: 0;
+  transition: all 0.2s;
+}
+
+.avatar:hover {
+  transform: translate(-2px, -2px);
+  box-shadow: 4px 4px 0 0 black;
+}
+
+.avatar:hover .avatarOverlay {
+  opacity: 1;
+}
+
+.avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.avatarEmoji {
+  font-size: 3rem;
+}
+
+.avatarOverlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: white;
+  opacity: 0;
+  transition: opacity 0.2s;
+}
+
+.avatarInfo {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  flex: 1;
+}
+
+.avatarDesc {
+  font-size: 0.75rem;
+  color: #999;
+  line-height: 1.4;
+  margin: 0;
+}
+
+/* === Grid === */
+.grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1.2rem;
+  margin-bottom: 1.5rem;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  position: relative;
+}
+
+.label {
+  font-size: 0.85rem;
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+  color: #333;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.required {
+  color: #d32f2f;
+}
+
+.input {
+  padding: 0.8rem;
+  font-size: 0.9rem;
+  border: 2px solid black;
+  background: white;
+  font-family: monospace;
+  font-weight: 600;
+  transition: all 0.2s;
+}
+
+.input:focus {
+  outline: none;
+  transform: translate(-2px, -2px);
+  box-shadow: 3px 3px 0 0 black;
+}
+
+.ageDisplay {
+  font-size: 0.75rem;
+  color: #666;
+  margin-top: 4px;
+  font-weight: 600;
+}
+
+.desc {
+  font-size: 0.85rem;
+  color: #666;
+  margin-bottom: 1rem;
+  line-height: 1.5;
+}
+
+/* === Travel Styles === */
+.travelStyleSection {
+  margin-top: 1.5rem;
+}
+
+.travelStyleGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  gap: 10px;
+  margin-top: 0.8rem;
+}
+
+.travelStyleBtn {
+  padding: 0.7rem 1rem;
+  border: 2px solid black;
+  background: white;
+  font-family: monospace;
+  font-weight: 700;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: all 0.2s;
+  text-align: center;
+}
+
+.travelStyleBtn:hover {
+  background: #f5f5f5;
+  transform: translate(-2px, -2px);
+  box-shadow: 3px 3px 0 0 black;
+}
+
+.travelStyleBtn.active {
+  background: #fbbf24;
+  color: black;
+  transform: translate(-2px, -2px);
+  box-shadow: 3px 3px 0 0 black;
+}
+
+/* === Buttons === */
+.primaryButton {
+  width: 100%;
+  padding: 1rem;
+  background: black;
+  color: white;
+  font-size: 0.95rem;
+  font-weight: 700;
+  border: 3px solid black;
+  cursor: pointer;
+  transition: all 0.2s;
+  font-family: monospace;
+  letter-spacing: 1px;
+}
+
+.primaryButton:hover:not(:disabled) {
+  background: #fbbf24;
+  color: black;
+  transform: translate(-3px, -3px);
+  box-shadow: 5px 5px 0 0 black;
+}
+
+.primaryButton:disabled {
+  background: #ddd;
+  color: #999;
+  border-color: #ddd;
+  cursor: not-allowed;
+}
+
+.secondaryButton {
+  padding: 0.7rem 1rem;
+  font-size: 0.85rem;
+  font-weight: 700;
+  border: 2px solid black;
+  background: white;
+  cursor: pointer;
+  transition: all 0.2s;
+  font-family: monospace;
+}
+
+.secondaryButton:hover {
+  background: black;
+  color: white;
+  transform: translate(-2px, -2px);
+  box-shadow: 3px 3px 0 0 black;
+}
+
+.saveButton {
+  width: 100%;
+  padding: 1rem;
+  margin-top: 1.5rem;
+  background: #10b981;
+  color: white;
+  font-size: 0.95rem;
+  font-weight: 700;
+  border: 3px solid black;
+  cursor: pointer;
+  transition: all 0.2s;
+  font-family: monospace;
+  letter-spacing: 1px;
+}
+
+.saveButton:hover:not(:disabled) {
+  transform: translate(-3px, -3px);
+  box-shadow: 5px 5px 0 0 black;
+}
+
+.saveButton:disabled {
+  background: #ddd;
+  color: #999;
+  cursor: not-allowed;
+}
+
+.saveButton.saving {
+  background: #fbbf24;
+  color: black;
+}
+
+/* === Danger Zone === */
+.danger {
+  border-top: 3px dashed black;
+  padding-top: 2rem;
+}
+
+.dangerButton {
+  width: 100%;
+  padding: 1rem;
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: #d32f2f;
+  border: 3px solid #d32f2f;
+  background: white;
+  cursor: pointer;
+  transition: all 0.2s;
+  font-family: monospace;
+  letter-spacing: 1px;
+}
+
+.dangerButton:hover {
+  background: #d32f2f;
+  color: white;
+  transform: translate(-3px, -3px);
+  box-shadow: 5px 5px 0 0 #d32f2f;
+}
+
+/* === Modal === */
+.modalOverlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
+}
+
+.modalContent {
+  background: white;
+  padding: 2.5rem;
+  border: 3px solid black;
+  box-shadow: 8px 8px 0 0 black;
+  width: 90%;
+  max-width: 450px;
+  position: relative;
+}
+
+.modalCloseBtn {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px;
+  transition: transform 0.2s;
+}
+
+.modalCloseBtn:hover {
+  transform: rotate(90deg);
+}
+
+.modalIcon {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 1.5rem;
+}
+
+.modalIcon svg {
+  width: 64px;
+  height: 64px;
+  color: #10b981;
+}
+
+.modalIcon.danger svg {
+  color: #d32f2f;
+}
+
+.modalTitle {
+  font-size: 1.5rem;
+  font-weight: 900;
+  text-align: center;
+  margin-bottom: 1rem;
+  font-family: monospace;
+}
+
+.modalText {
+  font-size: 0.95rem;
+  color: #666;
+  text-align: center;
+  line-height: 1.6;
+  margin-bottom: 2rem;
+}
+
+.modalButtons {
+  display: flex;
+  gap: 12px;
+}
+
+.modalCancelBtn {
+  flex: 1;
+  padding: 0.9rem;
+  background: white;
+  border: 2px solid black;
+  font-weight: 700;
+  cursor: pointer;
+  font-family: monospace;
+  transition: all 0.2s;
+}
+
+.modalCancelBtn:hover {
+  background: #f5f5f5;
+  transform: translate(-2px, -2px);
+  box-shadow: 3px 3px 0 0 black;
+}
+
+.modalConfirmBtn {
+  flex: 2;
+  padding: 0.9rem;
+  background: black;
+  color: white;
+  border: 2px solid black;
+  font-weight: 700;
+  cursor: pointer;
+  font-family: monospace;
+  transition: all 0.2s;
+}
+
+.modalConfirmBtn:hover {
+  background: #fbbf24;
+  color: black;
+  transform: translate(-2px, -2px);
+  box-shadow: 3px 3px 0 0 black;
+}
+
+.modalDangerBtn {
+  flex: 2;
+  padding: 0.9rem;
+  background: #d32f2f;
+  color: white;
+  border: 2px solid #d32f2f;
+  font-weight: 700;
+  cursor: pointer;
+  font-family: monospace;
+  transition: all 0.2s;
+}
+
+.modalDangerBtn:hover {
+  background: #b71c1c;
+  transform: translate(-2px, -2px);
+  box-shadow: 3px 3px 0 0 #b71c1c;
+}
+
+/* === Responsive === */
+@media (max-width: 768px) {
+  .ticket {
+    padding: 1.5rem;
+  }
+
+  .grid {
+    grid-template-columns: 1fr;
+  }
+
+  .travelStyleGrid {
+    grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
+  }
+
+  .profileRow {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .avatarInfo {
+    width: 100%;
+    text-align: center;
+  }
+
+  .title {
+    font-size: 1.5rem;
+  }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #35 

---

## 🎨 작업 내용 (What)

- 사용자 마이페이지(User Settings) 화면 UI 구현
- 닉네임, 이름, 생년월일, 성별, MBTI 입력 폼 구성
- 프로필 사진 업로드 UI 및 기본 아바타 표시 처리
- 여행 스타일 선택 UI (복수 선택)
- 본인 인증 섹션 및 인증 완료 상태 UI 표시
- 계정 탈퇴(Danger Zone) UI 및 확인 모달 구현
- 저장 여부 및 유효성에 따른 버튼 활성/비활성 처리

---

## 🧭 작업 목적 (Why)

- 소셜 로그인 이후 사용자 기본 정보 설정을 위한 화면 제공
- 커뮤니티 이용 전 필수 정보 입력을 유도하기 위한 온보딩 단계 구성
- 사용자 프로필 정보를 일관된 UI에서 관리할 수 있도록 하기 위함
- 계정 관리(본인 인증, 탈퇴)를 명확한 UX로 제공하기 위함

---

## 🧩 변경 범위
- [x] UI / Layout
- [x] 컴포넌트 구조
- [ ] 상태 관리 로직
- [ ] API 연동
- [x] 스타일

---

## 🧪 테스트 방법
- [x] 로컬 실행 확인
- [x] 주요 화면 렌더링 확인
- [x] 에러 콘솔 확인

---

## ⚠️ 참고 사항

- 본 PR은 User Settings 화면 UI 및 상태 관리까지 포함하며, 실제 서버 API 연동은 추후 작업 예정
- 본인 인증 및 계정 탈퇴 동작은 현재 UI/플로우 확인용으로 구성되어 있음
- **커뮤니티 진입 가드 모달은 별도 PR에서 추가 예정**

---

## ✅ 체크리스트
- [x] main 브랜치 직접 push 하지 않음
- [x] feature 브랜치에서 작업함
- [x] 불필요한 console.log 제거
- [x] PR 단위가 과도하게 크지 않음
