### PR TITLE
[FE] refactor: 여행 목록 디자인 통일 및 CSS 최적화

### DIFF
--- a/src/pages/MyTrips.tsx
+++ b/src/pages/MyTrips.tsx
@@ -257,22 +257,24 @@ export default function MyTrips() {
       )}
 
       <div className="container" id="trip-list-ui">
-        <div className="section-header">
-          <div>
+        <div className="section-header-neob">
+          <div className="header-content">
             <h2 className="sec-title">MY PLAN BOARD</h2>
             <p className="sec-desc">수립된 여행 작전 목록입니다.</p>
           </div>
 
-          <div className="filter-tabs">
-            {(["all", "public", "private"] as Visibility[]).map((type) => (
-              <button
-                key={type}
-                className={`filter-btn ${filter === type ? "active" : ""}`}
-                onClick={() => setFilter(type)}
-              >
-                {type === "all" ? "ALL SECTORS" : type.toUpperCase()}
-              </button>
-            ))}
+          <div className="filter-wrapper-neob">
+            <div className="filter-tabs">
+              {(["all", "public", "private"] as Visibility[]).map((type) => (
+                <button
+                  key={type}
+                  className={`filter-btn ${filter === type ? "active" : ""}`}
+                  onClick={() => setFilter(type)}
+                >
+                  {type === "all" ? "ALL SECTORS" : type.toUpperCase()}
+                </button>
+              ))}
+            </div>
           </div>
         </div>
 
@@ -297,28 +299,27 @@ export default function MyTrips() {
                   }}
                   onClick={() => window.location.assign("/workspace")}
                 >
+                  {/* 왼쪽 사이드 영역 */}
                   <div
                     className="mt-side"
                     style={{
-                      background: isEnd ? "#ddd" : "#000",
-                      color: isEnd ? "#555" : "#fff",
-                      borderRight: "2px solid #000",
+                      background: isEnd ? "#eee" : "#000",
+                      color: isEnd ? "#999" : "#fff",
                     }}
                   >
-                    <span style={{ fontWeight: "bold" }}>
+                    <span style={{ fontSize: "12px", fontWeight: "bold" }}>
                       {isEnd ? "STATUS" : "D-DAY"}
                     </span>
-                    <span
-                      style={{
-                        fontSize: isEnd ? "20px" : "24px",
-                        fontWeight: "900",
-                      }}
-                    >
+                    <span style={{ fontSize: "24px", fontWeight: "900" }}>
                       {dDayText}
                     </span>
                   </div>
 
-                  <div className="mt-center">
+                  {/* 메인 정보 영역 */}
+                  <div
+                    className="mt-center"
+                    style={{ flex: 1, padding: "20px" }}
+                  >
                     <div
                       className="top-badges"
                       style={{ justifyContent: "space-between" }}

--- a/src/styles/MyTrips.css
+++ b/src/styles/MyTrips.css
@@ -1,41 +1,49 @@
-/* mytrips.css */
+/* MyTrips.css - 통합 최종본 */
 
-/* 플로팅 액션 버튼 (FAB) */
-.fab-btn {
-  position: fixed;
-  bottom: 30px; /* 40px -> 30px 더 구석으로 */
-  right: 30px;
+/* === [1. 헤더 및 필터 영역] === */
+.section-header-neob {
+  position: relative;
+  background: #fff;
+  border: 3px solid #000;
+  padding: 40px 30px 30px 30px;
+  margin-bottom: 50px;
+  box-shadow: 10px 10px 0px #000;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.sys-badge {
+  position: absolute;
+  top: -18px;
+  right: 25px;
   background: #000;
   color: #fff;
-  border: 2px solid #fff;
-  outline: 3px solid #000;
-  height: 50px; /* 60px -> 50px 축소 */
-  padding: 0 18px; /* 25px -> 18px 축소 */
-  display: flex;
-  align-items: center;
-  gap: 8px;
+  padding: 5px 15px;
   font-family: var(--font-mono);
-  font-weight: 800;
-  font-size: 14px; /* 18px -> 14px 축소 */
-  cursor: pointer;
-  z-index: 1500;
-  box-shadow: 4px 4px 0px rgba(0, 0, 0, 0.5); /* 그림자도 살짝 축소 */
-  transition: transform 0.2s, box-shadow 0.2s;
+  font-size: 12px;
+  font-weight: 900;
+  letter-spacing: 1px;
 }
 
-.fab-btn:hover {
-  transform: translate(-4px, -4px);
-  box-shadow: 10px 10px 0px rgba(0, 0, 0, 0.5);
-  background: var(--accent);
-  outline-color: var(--accent);
+.sec-title {
+  font-family: var(--font-mono);
+  font-size: 38px;
+  font-weight: 900;
+  margin-bottom: 5px;
 }
 
-.fab-btn:active {
-  transform: translate(2px, 2px);
-  box-shadow: 2px 2px 0px rgba(0, 0, 0, 0.5);
+.sec-desc {
+  font-family: var(--font-mono);
+  font-weight: 600;
+  color: #666;
 }
 
-/* 상단 필터 탭 */
+.filter-wrapper-neob {
+  border-top: 2px solid #000;
+  padding-top: 20px;
+}
+
 .filter-tabs {
   display: flex;
   gap: 10px;
@@ -43,33 +51,66 @@
 
 .filter-btn {
   font-family: var(--font-mono);
-  font-weight: bold;
-  font-size: 14px;
-  padding: 8px 16px;
-  border: 2px solid transparent;
-  background: transparent;
-  color: #999;
+  font-weight: 800;
+  border: 2px solid #000;
+  background: #fff;
+  color: #000;
+  padding: 8px 18px;
   cursor: pointer;
-  border-bottom: 2px solid transparent;
+  transition: all 0.1s;
 }
 
 .filter-btn:hover {
-  color: #000;
+  transform: translate(-3px, -3px);
+  box-shadow: 3px 3px 0px #000;
+  background: #f0f0f0;
 }
 
 .filter-btn.active {
-  color: #000;
-  border: 2px solid #000;
-  background: #fff;
-  box-shadow: 2px 2px 0px #000;
+  background: #000;
+  color: #fff;
+  box-shadow: none;
+  transform: none;
 }
 
+/* === [2. 여행 목록 그리드 및 카드] === */
 .trip-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr); /* 2열 배치 */
+  gap: 25px;
+}
+
+.trip-card {
+  display: flex;
+  background: #fff;
+  border: 3px solid #000; /* 테두리 강화 */
+  box-shadow: 8px 8px 0px #000; /* 강한 그림자 */
+  transition: all 0.2s;
+  height: 100%;
+}
+
+.trip-card:hover {
+  transform: translate(-4px, -4px);
+  box-shadow: 12px 12px 0px #000;
+}
+
+.trip-card.is-end {
+  opacity: 0.7;
+  filter: grayscale(0.5);
+}
+
+.mt-side {
+  width: 100px;
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  align-items: center;
+  justify-content: center;
+  border-right: 3px solid #000; /* 구분선 강화 */
+  font-family: var(--font-mono);
+  font-weight: 900;
 }
 
+/* === [3. 카드 내부 컴포넌트] === */
 .top-badges {
   display: flex;
   align-items: center;
@@ -79,19 +120,20 @@
 
 .sys-tag.private {
   background: #fff;
-  border: 1px solid #000;
+  border: 2px solid #000;
   color: #000;
 }
+
 .sys-tag.public {
   background: var(--accent);
   color: #fff;
-  border: 1px solid #000;
+  border: 2px solid #000;
 }
 
 .participants {
   margin-top: 15px;
   padding-top: 10px;
-  border-top: 1px dashed #ccc;
+  border-top: 2px solid #000;
   display: flex;
   align-items: center;
   gap: 10px;
@@ -106,53 +148,43 @@
 
 .p-avatars {
   display: flex;
-  gap: -5px;
 }
 
 .p-circle {
-  width: 28px;
-  height: 28px;
+  width: 32px;
+  height: 32px;
   border-radius: 50%;
   background: #eee;
-  border: 2px solid #fff;
-  box-shadow: 1px 1px 3px rgba(0, 0, 0, 0.2);
+  border: 2px solid #000;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 10px;
-  font-weight: bold;
+  font-size: 11px;
+  font-weight: 900;
   font-family: var(--font-mono);
-  color: #333;
-  margin-left: -8px;
+  margin-left: -10px;
 }
+
 .p-circle:first-child {
   margin-left: 0;
 }
 
-/* 여행 카드 삭제 버튼 */
 .delete-trip-btn {
   background: transparent;
   border: none;
   color: #999;
   cursor: pointer;
   padding: 5px;
-  font-size: 16px;
-  transition: color 0.2s, transform 0.2s;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  font-size: 18px;
+  transition: all 0.2s;
 }
 
 .delete-trip-btn:hover {
-  color: #ff4d4d; /* 삭제 강조색 */
+  color: #ff4d4d;
   transform: scale(1.1);
 }
 
-.delete-trip-btn:active {
-  transform: scale(0.9);
-}
-
-/* 모달 관련 스타일 */
+/* === [4. 모달 스타일] === */
 .modal-overlay {
   position: fixed;
   top: 0;
@@ -164,10 +196,6 @@
   justify-content: center;
   align-items: center;
   z-index: 9999;
-}
-
-.page-section .modal-overlay {
-  display: flex;
 }
 
 .modal-content {
@@ -259,89 +287,7 @@
   box-shadow: 4px 4px 0px #000;
 }
 
-.radio-group {
-  display: flex;
-  gap: 20px;
-  padding: 5px 0;
-}
-
-.radio-label {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  cursor: pointer;
-  font-family: var(--font-mono);
-  font-weight: bold;
-  font-size: 14px;
-}
-
-.radio-label input[type="radio"] {
-  appearance: none;
-  width: 18px;
-  height: 18px;
-  border: 2px solid #000;
-  border-radius: 50%;
-  cursor: pointer;
-  position: relative;
-}
-
-.radio-label input[type="radio"]:checked {
-  background-color: var(--accent);
-}
-
-.radio-label input[type="radio"]:checked::after {
-  content: "";
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  width: 8px;
-  height: 8px;
-  background: #000;
-  border-radius: 50%;
-}
-
-/* 초대 입력창 레이아웃 */
-.invite-input-wrapper {
-  display: flex;
-  gap: 10px;
-}
-
-.invite-input-wrapper input {
-  flex: 1;
-}
-
-.add-invite-btn {
-  background: #000;
-  color: #fff;
-  border: none;
-  padding: 0 15px;
-  font-family: var(--font-mono);
-  font-weight: bold;
-  cursor: pointer;
-}
-
-/* 추가된 에이전트 태그 목록 */
-.invitee-list {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  margin-top: 10px;
-  min-height: 30px;
-
-  max-height: 120px;
-  overflow-y: auto;
-  padding-right: 5px;
-}
-
-.invitee-list::-webkit-scrollbar {
-  width: 4px;
-}
-.invitee-list::-webkit-scrollbar-thumb {
-  background: #000;
-  border-radius: 10px;
-}
-
+/* 초대 에이전트 태그 */
 .invitee-tag {
   background: #f0f0f0;
   border: 2px solid #000;
@@ -352,33 +298,43 @@
   display: flex;
   align-items: center;
   gap: 6px;
-  animation: fadeIn 0.2s ease-out;
 }
 
-.invitee-tag button {
-  background: none;
-  border: none;
-  font-size: 16px;
-  cursor: pointer;
-  padding: 0;
+/* === [5. FAB 및 미디어 쿼리] === */
+.fab-btn {
+  position: fixed;
+  bottom: 30px;
+  right: 30px;
+  background: #000;
+  color: #fff;
+  border: 2px solid #fff;
+  outline: 3px solid #000;
+  height: 50px;
+  padding: 0 18px;
   display: flex;
   align-items: center;
-  color: #ff4d4d;
+  gap: 8px;
+  font-family: var(--font-mono);
+  font-weight: 800;
+  font-size: 14px;
+  cursor: pointer;
+  z-index: 1500;
+  box-shadow: 4px 4px 0px rgba(0, 0, 0, 0.5);
+  transition: transform 0.2s, box-shadow 0.2s;
 }
 
-@keyframes fadeIn {
-  from {
-    opacity: 0;
-    transform: translateY(5px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
+.fab-btn:hover {
+  transform: translate(-4px, -4px);
+  box-shadow: 10px 10px 0px rgba(0, 0, 0, 0.5);
+  background: var(--accent);
+  outline-color: var(--accent);
 }
 
-/* 모바일 대응 */
-@media (max-width: 900px) {
+@media (max-width: 850px) {
+  .trip-grid {
+    grid-template-columns: 1fr; /* 1열 전환 */
+  }
+
   .fab-btn {
     bottom: 20px;
     right: 20px;


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #36

---

## 🎨 작업 내용 (What)
- **2열 그리드 레이아웃 도입**: 기존 1열 리스트 형태에서 `grid`를 활용한 2열 카드로 구조를 변경했습니다.
- **스타일 코드 통합 및 최적화**: 중복 선언되었던 필터 버튼 및 카드 스타일을 네오 브루탈리즘 컨셉으로 통합하여 정리했습니다.
- **UI 디테일 강화**: 헤더 박스, 카드 테두리(3px), 하드 쉐도우(8px) 등을 적용하여 플랫폼 전체의 디자인 톤앤매너를 일치시켰습니다.
- **코드 클린업**: `MyTrips.tsx` 파일 내 산재해 있던 인라인 스타일을 CSS 클래스로 이관하여 가독성을 높였습니다.

---

## 🧭 작업 목적 (Why)
- **디자인 일관성**: 커뮤니티 및 동료 찾기 페이지와 동일한 네오 브루탈리즘 스타일을 적용하여 사용자 경험을 통일했습니다.
- **정보 밀도 개선**: 화면 공간을 효율적으로 사용하여 한눈에 더 많은 작전 현황을 파악할 수 있도록 개선했습니다.
- **유지보수 효율**: 코드 중복을 제거하여 향후 스타일 수정 시 발생할 수 있는 휴먼 에러를 방지하고자 합니다.

---

## 🧩 변경 범위
- [x] UI / Layout
- [x] 컴포넌트 구조
- [ ] 상태 관리 로직
- [ ] API 연동
- [x] 스타일

---

## 🧪 테스트 방법
- [x] 로컬 환경 실행 확인
- [x] 주요 화면 렌더링 확인 (2열 그리드 및 필터 동작 확인)
- [x] 개발자 도구 에러 콘솔 확인

---

## ⚠️ 참고 사항
- 화면 너비가 **850px 이하**로 줄어들 경우, 모바일 가독성을 위해 자동으로 **1열 레이아웃**으로 전환되도록 반응형 처리를 완료했습니다.

---

## ✅ 체크리스트
- [x] main 브랜치 직접 push 하지 않음
- [x] feature 브랜치에서 작업함
- [x] 불필요한 console.log 제거
- [x] PR 단위가 과도하게 크지 않음