### PR TITLE
[FE] feature: mate 상세 페이지 UI 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import Workspace from "./pages/Workspace";
 import TravelStory from './pages/TravelStory';
 import Login from "./pages/Login";
 import UserSettings from "./pages/UserSetting";
+import MateDetail from "./pages/MateDetail";
 
 export default function App() {
   return (
@@ -21,6 +22,7 @@ export default function App() {
         <Route path="/mytrips" element={<MyTrips />} />
         <Route path="/community" element={<Community />} />
         <Route path="/mate" element={<Mate />} />
+        <Route path="/mate/:postId" element={<MateDetail />} />
         <Route path="/workspace" element={<Workspace />} />
         <Route path="/travelstory" element={<TravelStory />} />
         <Route path="*" element={<Navigate to="/" replace />} />

--- a/src/components/mate/chat/ChatModal.tsx
+++ b/src/components/mate/chat/ChatModal.tsx
@@ -3,8 +3,8 @@
 import { useState, useEffect, useRef } from "react";
 import { X, MessageSquare, Users, Send, Search } from "lucide-react";
 import type { OneOnOneChat, GroupChat } from "./chat/chat.types";
-import type { Post } from "./mate.types";
-import { CURRENT_USER } from "./mate.constants";
+import type { Post } from "../mate.types";
+import { CURRENT_USER } from "../mate.constants";
 import styles from "../../styles/mate/Mate.module.css";
 
 interface ChatModalProps {

--- a/src/pages/Mate.tsx
+++ b/src/pages/Mate.tsx
@@ -1,6 +1,7 @@
-// pages/Mate.tsx (슬라이드 채팅 버전)
+// pages/Mate.tsx (상세 페이지 이동 버전)
 
 import { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { ArrowUpDown, User, ChevronDown } from "lucide-react";
 import { useMate } from "../hooks/useMate";
 import { ChatFAB } from "../components/mate/chat/ChatFAB";
@@ -11,7 +12,6 @@ import {
   MateFilters,
   MatePostCard,
   MatePagination,
-  MateDetailModal,
   MateWriteModal,
   MateMySentModal,
   MateReceivedModal,
@@ -20,6 +20,7 @@ import {
 import styles from "../styles/mate/Mate.module.css";
 
 export default function Mate(): JSX.Element {
+  const navigate = useNavigate();
   const [showChatModal, setShowChatModal] = useState<boolean>(false);
   
   const {
@@ -44,13 +45,10 @@ export default function Mate(): JSX.Element {
     allPosts,
     
     // Modal States
-    selectedPost,
     showWriteModal, setShowWriteModal,
     showApplicantsModal, setShowApplicantsModal,
     showReceivedModal, setShowReceivedModal,
     selectedApplicant, setSelectedApplicant,
-    showApplyMessage,
-    applyMessage, setApplyMessage,
     showSortDropdown, setShowSortDropdown,
     
     // Write Modal States
@@ -72,14 +70,9 @@ export default function Mate(): JSX.Element {
     groupChats,
     
     // Handlers
-    handleCardClick,
     handleLike,
     handleRemove,
     handleRestore,
-    handleApply,
-    handleSendApplication,
-    handleCloseDetailModal,
-    handleCancelApply,
     handleResetAll,
     handlePostSubmit,
     handleApprove,
@@ -93,6 +86,11 @@ export default function Mate(): JSX.Element {
     leaveGroupChat,
     createGroupChat,
   } = useMate();
+
+  // 카드 클릭 시 상세 페이지로 이동
+  const handleCardClick = (post: any) => {
+    navigate(`/mate/${post.id}`);
+  };
 
   // 1:1 채팅 생성
   const handleCreateOneOnOneChat = (postId: string, otherUserId: string) => {
@@ -137,8 +135,10 @@ export default function Mate(): JSX.Element {
           onWriteClick={() => setShowWriteModal(true)}
           onMySentClick={() => setShowApplicantsModal(true)}
           onReceivedClick={() => setShowReceivedModal(true)}
+          onChatListClick={() => setShowChatModal(true)}
           mySentCount={myApplications.length}
           receivedPendingCount={receivedApplications.filter(app => getApplicantStatus(app.id) === "pending").length}
+          unreadChatCount={unreadCount}
         />
 
         {/* Filters */}
@@ -280,20 +280,6 @@ export default function Mate(): JSX.Element {
       </div>
 
       {/* Modals */}
-      {selectedPost && (
-        <MateDetailModal
-          post={selectedPost}
-          isLiked={likedPostIds.includes(selectedPost.id)}
-          showApplyMessage={showApplyMessage}
-          applyMessage={applyMessage}
-          onClose={handleCloseDetailModal}
-          onApply={handleApply}
-          onSendApplication={handleSendApplication}
-          onApplyMessageChange={setApplyMessage}
-          onCancelApply={handleCancelApply}
-        />
-      )}
-
       {showWriteModal && (
         <MateWriteModal
           onClose={() => setShowWriteModal(false)}

--- a/src/pages/MateDetail.tsx
+++ b/src/pages/MateDetail.tsx
@@ -1,0 +1,266 @@
+// pages/MateDetail.tsx (무한 루프 수정)
+
+import { useState, useEffect } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import {
+  ArrowLeft, Heart, Calendar, Users, Wallet, MapPin
+} from "lucide-react";
+import type { Post } from "../components/mate/mate.types";
+import { getAirportDisplay } from "../components/mate/mate.constants";
+import { useMate } from "../hooks/useMate";
+import "../styles/mate/MateDetail.css";
+
+export default function MateDetail(): JSX.Element {
+  const { postId } = useParams<{ postId: string }>();
+  const navigate = useNavigate();
+
+  const { allPosts, likedPostIds, handleLike: mateLike } = useMate();
+
+  const [post, setPost] = useState<Post | null>(null);
+  const [showApplyForm, setShowApplyForm] = useState(false);
+  const [applyMessage, setApplyMessage] = useState("");
+  const [isLoading, setIsLoading] = useState(true);
+  const [hasApplied, setHasApplied] = useState(false);
+
+  /** -------------------------------
+   *   POST LOAD (초기 1회만)
+   *  ------------------------------ */
+  useEffect(() => {
+    if (!postId) return;
+
+    const found = allPosts.find((p) => p.id === postId);
+    if (found) {
+      setPost(found);
+
+      const apps = JSON.parse(localStorage.getItem("myApplications") || "[]");
+      setHasApplied(apps.some((app: any) => app.postId === postId));
+    }
+
+    setIsLoading(false);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [postId]); // ← allPosts 제거해서 무한 루프 방지!
+
+  /** allPosts 변경 시 post 상태만 업데이트 (좋아요 반영) */
+  useEffect(() => {
+    if (!postId || !post) return;
+    
+    const updated = allPosts.find((p) => p.id === postId);
+    if (updated && updated.likes !== post.likes) {
+      setPost(updated);
+    }
+  }, [allPosts, postId, post]);
+
+  /** 좋아요 클릭 */
+  const onLikeClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    if (!postId) return;
+    mateLike(postId, e); // useMate가 allPosts 업데이트 → 위 useEffect가 자동으로 처리
+  };
+
+  /** 신청 메시지 제출 */
+  const handleApplySubmit = () => {
+    if (!postId || !applyMessage.trim() || !post) return;
+
+    const list = JSON.parse(localStorage.getItem("myApplications") || "[]");
+
+    list.push({
+      id: `APP_${Date.now()}`,
+      postId,
+      message: applyMessage,
+      appliedDate: new Date().toISOString(),
+      status: "pending",
+      applicant: {
+        name: "나",
+        email: "user@example.com",
+        age: 25,
+        gender: "성별무관",
+        avatar: "👤",
+      },
+    });
+
+    localStorage.setItem("myApplications", JSON.stringify(list));
+
+    setHasApplied(true);
+    setShowApplyForm(false);
+    setApplyMessage("");
+  };
+
+  /** Loading UI */
+  if (isLoading || !post) {
+    return (
+      <div className="mate-detail flex items-center justify-center h-[60vh]">
+        <div className="loading-spinner" />
+      </div>
+    );
+  }
+
+  const isLiked = likedPostIds.includes(post.id);
+
+  return (
+    <div className="mate-detail max-w-6xl mx-auto px-4 py-8">
+
+      {/* Back + Like */}
+      <div className="flex justify-between items-center mb-6">
+        <button
+          onClick={() => navigate(-1)}
+          className="btn-outline"
+        >
+          <ArrowLeft size={18} />
+          뒤로가기
+        </button>
+
+        <button
+          onClick={onLikeClick}
+          className={`btn-outline ${isLiked ? "btn-like" : ""}`}
+        >
+          <Heart size={18} fill={isLiked ? "currentColor" : "none"} />
+          {post.likes}
+        </button>
+      </div>
+
+      {/* WRAPPER */}
+      <div className="global-wrap">
+
+        {/* LEFT */}
+        <div className="left-col">
+
+          {/* ROUTE CARD */}
+          <div className="route-card">
+            <div className="flex items-center justify-between">
+              <div className="route-point">
+                <p className="route-code">{getAirportDisplay(post.from)}</p>
+                <p className="route-date">{post.dates.start}</p>
+              </div>
+
+              <div className="route-arrow">✈</div>
+
+              <div className="route-point">
+                <p className="route-code">{post.destination}</p>
+                <p className="route-date">{post.dates.end}</p>
+              </div>
+            </div>
+          </div>
+
+          {/* INFO GRID */}
+          <div className="info-grid">
+            <div className="info-card">
+              <Calendar size={20} />
+              <p className="info-value">{post.duration}</p>
+              <p className="info-label">여행 기간</p>
+            </div>
+
+            <div className="info-card">
+              <Wallet size={20} />
+              <p className="info-value">{post.budget}</p>
+              <p className="info-label">예산</p>
+            </div>
+
+            <div className="info-card">
+              <Users size={20} />
+              <p className="info-value">
+                {post.participants.current}/{post.participants.max}
+              </p>
+              <p className="info-label">참여 인원</p>
+            </div>
+
+            <div className="info-card">
+              <MapPin size={20} />
+              <p className="info-value">{post.views}</p>
+              <p className="info-label">조회수</p>
+            </div>
+          </div>
+
+          {/* DESCRIPTION */}
+          <div className="desc-box">
+            <p className="desc-title">여행 소개</p>
+            <p className="desc-text">{post.description}</p>
+
+            <div className="tag-wrap">
+              {post.tags.map((tag) => (
+                <span className="tag" key={tag}>
+                  #{tag}
+                </span>
+              ))}
+            </div>
+          </div>
+
+        </div>
+
+        {/* RIGHT */}
+        <div className="right-col">
+
+          {/* AUTHOR */}
+          <div className="author-card">
+            <p className="author-label">작성자</p>
+
+            <div className="flex gap-3">
+              <div className="author-avatar">{post.author.avatar}</div>
+
+              <div>
+                <p className="author-name">{post.author.name}</p>
+                <p className="author-email">{post.author.email}</p>
+                <p className="author-meta">
+                  {post.author.age}세 · {post.author.gender}
+                </p>
+              </div>
+            </div>
+          </div>
+
+          {/* APPLY */}
+          <div className="apply-card">
+
+            {!showApplyForm ? (
+              <button
+                disabled={
+                  hasApplied || post.participants.current >= post.participants.max
+                }
+                onClick={() => setShowApplyForm(true)}
+                className={`apply-btn w-full ${
+                  hasApplied || post.participants.current >= post.participants.max
+                    ? "disabled"
+                    : ""
+                }`}
+              >
+                {hasApplied
+                  ? "이미 신청함"
+                  : post.participants.current >= post.participants.max
+                  ? "모집 완료"
+                  : "신청하기"}
+              </button>
+
+            ) : (
+              <div className="apply-form">
+                <textarea
+                  className="apply-input"
+                  value={applyMessage}
+                  onChange={(e) => setApplyMessage(e.target.value)}
+                  placeholder="신청 메시지를 입력하세요..."
+                />
+
+                <div className="apply-actions">
+                  <button
+                    className="apply-cancel"
+                    onClick={() => {
+                      setShowApplyForm(false);
+                      setApplyMessage("");
+                    }}
+                  >
+                    취소
+                  </button>
+
+                  <button
+                    disabled={!applyMessage.trim()}
+                    className="apply-submit"
+                    onClick={handleApplySubmit}
+                  >
+                    보내기
+                  </button>
+                </div>
+              </div>
+            )}
+
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/styles/mate/MateDetail.css
+++ b/src/styles/mate/MateDetail.css
@@ -1,0 +1,248 @@
+/* --- MateDetail 전용 네임스페이스 --- */
+.mate-detail * {
+  box-sizing: border-box;
+  font-family: var(--font-mono);
+}
+
+/* 전체 래퍼 */
+.mate-detail .global-wrap {
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  gap: 1.5rem;
+}
+
+/* 버튼 공통 */
+.mate-detail .btn-outline {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 14px;
+  border: 2px solid #000;
+  background: #fff;
+  font-weight: 700;
+  cursor: pointer;
+  transition: 0.15s;
+}
+
+.mate-detail .btn-outline:hover {
+  background: #000;
+  color: #fff;
+}
+
+.mate-detail .btn-like {
+  background: #ef4444;
+  border-color: #ef4444;
+  color: #fff;
+}
+
+.mate-detail .btn-like:hover {
+  background: #dc2626;
+  border-color: #dc2626;
+}
+
+/* Left */
+.mate-detail .left-col {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+/* Route */
+.mate-detail .route-card {
+  background: #000;
+  padding: 1.5rem;
+  border-radius: 16px;
+  color: #fff;
+}
+
+.mate-detail .route-code {
+  font-size: 2rem;
+  font-weight: 900;
+}
+
+.mate-detail .route-date {
+  font-size: 0.75rem;
+  opacity: 0.6;
+}
+
+.mate-detail .route-arrow {
+  font-size: 2rem;
+}
+
+/* Info Grid */
+.mate-detail .info-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0.75rem;
+}
+
+.mate-detail .info-card {
+  background: #fff;
+  border: 2px solid #000;
+  border-radius: 12px;
+  padding: 1rem;
+  text-align: center;
+}
+
+.mate-detail .info-value {
+  font-size: 1.125rem;
+  font-weight: 700;
+}
+
+.mate-detail .info-label {
+  font-size: 0.75rem;
+  color: #666;
+}
+
+/* Description */
+.mate-detail .desc-box {
+  background: #fff;
+  border: 2px solid #000;
+  border-radius: 12px;
+  padding: 1.25rem;
+}
+
+.mate-detail .desc-title {
+  font-size: 0.875rem;
+  font-weight: 700;
+  margin-bottom: 0.75rem;
+}
+
+.mate-detail .desc-text {
+  white-space: pre-line;
+  color: #333;
+  margin-bottom: 1rem;
+}
+
+.mate-detail .tag-wrap {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.mate-detail .tag {
+  padding: 6px 12px;
+  border: 1px solid #000;
+  background: #fff;
+  border-radius: 999px;
+  font-size: 0.75rem;
+}
+
+/* Right */
+.mate-detail .right-col {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+/* Author */
+.mate-detail .author-card {
+  background: #fff;
+  border: 2px solid #000;
+  border-radius: 12px;
+  padding: 1.25rem;
+}
+
+.mate-detail .author-label {
+  font-size: 0.75rem;
+  font-weight: 700;
+  margin-bottom: 1rem;
+}
+
+.mate-detail .author-avatar {
+  width: 52px;
+  height: 52px;
+  background: #000;
+  color: #fff;
+  border-radius: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* Apply */
+.mate-detail .apply-card {
+  background: #fff;
+  border: 2px solid #000;
+  padding: 1.25rem;
+  border-radius: 12px;
+}
+
+.mate-detail .apply-btn {
+  padding: 14px;
+  font-weight: 900;
+  color: #fff;
+  background: #000;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: 0.15s;
+}
+
+.mate-detail .apply-btn.disabled {
+  background: #ccc;
+  color: #666;
+  cursor: not-allowed;
+}
+
+.mate-detail .apply-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.mate-detail .apply-input {
+  width: 100%;
+  padding: 10px;
+  border: 2px solid #000;
+  border-radius: 8px;
+  min-height: 100px;
+}
+
+.mate-detail .apply-actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.mate-detail .apply-cancel {
+  flex: 1;
+  background: #eee;
+  padding: 12px;
+  border-radius: 8px;
+}
+
+.mate-detail .apply-submit {
+  flex: 1;
+  background: #000;
+  color: #fff;
+  padding: 12px;
+  border-radius: 8px;
+}
+
+.mate-detail .apply-submit:disabled {
+  background: #ccc;
+  color: #888;
+}
+
+/* Loading */
+.mate-detail .loading-spinner {
+  width: 36px;
+  height: 36px;
+  border: 4px solid #eee;
+  border-top-color: #000;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* Responsive */
+@media (max-width: 1024px) {
+  .mate-detail .global-wrap {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #44 

---

## 🎨 작업 내용 (What)

- MateDetail 페이지 전체 신규 UI 구현
- 작성자 정보 카드/상세 정보/태그 영역 등 전체 구성 새로 제작
- 반응형 레이아웃(grid → 1열 전환) 적용

---

## 🧭 작업 목적 (Why)

- 기존 modal 형태에서 페이지로 세분화하여 사용성을 높이고자 함

---

## 🧩 변경 범위
- [x] UI / Layout
- [x] 컴포넌트 구조
- [x] 상태 관리 로직
- [ ] API 연동
- [x] 스타일

---

## 🧪 테스트 방법
- [x] 로컬 실행 확인
- [x] 주요 화면 렌더링 확인
- [x] 에러 콘솔 확인

---

## ⚠️ 참고 사항

---

## ✅ 체크리스트
- [x] main 브랜치 직접 push 하지 않음
- [x] feature 브랜치에서 작업함
- [x] 불필요한 console.log 제거
- [x] PR 단위가 과도하게 크지 않음
