### PR TITLE
[FE] feature: mate 조회수 증가, 포스트 삭제 및 정렬 항목 추가

### DIFF
--- a/src/components/mate/MatePostCard.tsx
+++ b/src/components/mate/MatePostCard.tsx
@@ -1,7 +1,7 @@
 import { MouseEvent } from "react";
-import { Heart, X, Eye, RotateCcw } from "lucide-react";
+import { Heart, X, Eye, RotateCcw, Trash2 } from "lucide-react";
 import type { Post } from "./mate.types";
-import { getAirportDisplay } from "./mate.constants";
+import { getAirportDisplay, CURRENT_USER } from "./mate.constants";
 import styles from "../../styles/mate/MatePostCard.module.css";
 
 interface MatePostCardProps {
@@ -13,6 +13,7 @@ interface MatePostCardProps {
   onLike: (postId: string, e: MouseEvent<HTMLButtonElement>) => void;
   onRemove: (postId: string, e: MouseEvent<HTMLButtonElement>) => void;
   onRestore: (postId: string, e: MouseEvent<HTMLButtonElement>) => void;
+  onDelete: (postId: string, e: MouseEvent<HTMLButtonElement>) => void;
 }
 
 export function MatePostCard({ 
@@ -23,8 +24,12 @@ export function MatePostCard({
   onCardClick, 
   onLike, 
   onRemove, 
-  onRestore 
+  onRestore,
+  onDelete 
 }: MatePostCardProps): JSX.Element {
+
+  const isAuthor = post.author.email === CURRENT_USER.email;
+
   return (
     <div className={`bg-white flex overflow-hidden relative group transition-all ${styles.card}`}>
       {/* Passed Badge */}
@@ -114,38 +119,56 @@ export function MatePostCard({
 
         {/* Action Buttons */}
         <div className="absolute inset-0 flex flex-col gap-4 items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity p-4">
-          {/* Pass / Unpass Toggle */}
-          {isRemoved ? (
+          
+          {isAuthor ? (
+            /* 1. 작성자 본인인 경우: 삭제 버튼만 표시 */
             <>
               <button 
-                onClick={(e) => onRestore(post.id, e)} 
-                className={`w-14 h-14 transition-colors flex items-center justify-center ${styles.actionButton} ${styles.bgBlackHoverable}`}
+                onClick={(e) => onDelete?.(post.id, e)} 
+                className={`w-14 h-14 bg-white transition-colors flex items-center justify-center ${styles.actionButton} group/del`}
+                title="삭제하기"
               >
-                <RotateCcw className="w-6 h-6" />
+                <Trash2 className="w-6 h-6 text-[#999] group-hover/del:text-[#ff4d4d] group-hover/del:scale-110 transition-all" />
               </button>
-              <div className="text-xs font-bold text-black">UNPASS</div>
+              <div className="text-xs font-bold text-[#ff4d4d]">DELETE</div>
             </>
           ) : (
+            /* 2. 작성자가 아닌 경우: 기존 PASS/LIKE 버튼 표시 */
             <>
+              {/* Pass / Unpass Toggle */}
+              {isRemoved ? (
+                <>
+                  <button 
+                    onClick={(e) => onRestore(post.id, e)} 
+                    className={`w-14 h-14 transition-colors flex items-center justify-center ${styles.actionButton} ${styles.bgBlackHoverable}`}
+                  >
+                    <RotateCcw className="w-6 h-6" />
+                  </button>
+                  <div className="text-xs font-bold text-black">UNPASS</div>
+                </>
+              ) : (
+                <>
+                  <button 
+                    onClick={(e) => onRemove(post.id, e)} 
+                    className={`w-14 h-14 bg-white hover:bg-[#eee] transition-colors flex items-center justify-center ${styles.actionButton}`}
+                  >
+                    <X className="w-6 h-6" />
+                  </button>
+                  <div className="text-xs font-bold text-black">PASS</div>
+                </>
+              )}
+
+              <div className="border-t-2 border-black/20 w-full my-2"></div>
+
               <button 
-                onClick={(e) => onRemove(post.id, e)} 
-                className={`w-14 h-14 bg-white hover:bg-[#eee] transition-colors flex items-center justify-center ${styles.actionButton}`}
+                onClick={(e) => onLike(post.id, e)} 
+                className={`w-14 h-14 transition-colors flex items-center justify-center ${styles.actionButton} ${isLiked ? styles.bgRed : styles.bgBlackHoverable}`}
               >
-                <X className="w-6 h-6" />
+                <Heart className={`w-6 h-6 ${isLiked ? "fill-current" : ""}`} />
               </button>
-              <div className="text-xs font-bold text-black">PASS</div>
+              <div className="text-xs font-bold text-black">{isLiked ? "UNLIKE" : "LIKE"}</div>
             </>
           )}
-
-          <div className="border-t-2 border-black/20 w-full my-2"></div>
-
-          <button 
-            onClick={(e) => onLike(post.id, e)} 
-            className={`w-14 h-14 transition-colors flex items-center justify-center ${styles.actionButton} ${isLiked ? styles.bgRed : styles.bgBlackHoverable}`}
-          >
-            <Heart className={`w-6 h-6 ${isLiked ? "fill-current" : ""}`} />
-          </button>
-          <div className="text-xs font-bold text-black">{isLiked ? "UNLIKE" : "LIKE"}</div>
         </div>
       </div>
     </div>

--- a/src/components/mate/mate.constants.ts
+++ b/src/components/mate/mate.constants.ts
@@ -71,6 +71,7 @@ export const SORT_OPTIONS = [
   ]},
   { group: "나의 활동", options: [
     { value: "liked-only", label: "좋아요 누른 항목" },
+    { value: "applied-only", label: "내가 신청한 항목" },
     { value: "removed-only", label: "패스한 항목" },
   ]},
 ];

--- a/src/components/mate/mate.types.ts
+++ b/src/components/mate/mate.types.ts
@@ -1,4 +1,4 @@
-// mate.types.ts
+// components/mate/mate.types.ts
 
 export interface Author {
   name: string;
@@ -9,22 +9,21 @@ export interface Author {
   travelStyle: string[];
 }
 
-export interface Applicant extends Author {
-  message: string;
-  preferredActivities: string[];
-  budget: string;
-  appliedDate: string;
-}
-
 export interface Post {
   id: string;
   author: Author;
   from: string;
   to: string;
   destination: string;
-  dates: { start: string; end: string };
+  dates: {
+    start: string;
+    end: string;
+  };
   duration: string;
-  participants: { current: number; max: number };
+  participants: {
+    current: number;
+    max: number;
+  };
   tags: string[];
   gender: string;
   ageGroup: string;
@@ -36,11 +35,27 @@ export interface Post {
   likes: number;
 }
 
+export interface Applicant {
+  name: string;
+  age: number;
+  gender: string;
+  email: string;
+  avatar: string;
+  travelStyle: string[];
+  message: string;
+  appliedDate: string;
+  preferredActivities?: string[];
+  budget?: string;
+}
+
 export interface MyApplication {
   id: string;
   postId: string;
   postDestination: string;
-  postDates: { start: string; end: string };
+  postDates: {
+    start: string;
+    end: string;
+  };
   postAuthor: Author;
   applicant: Applicant;
 }
@@ -48,16 +63,24 @@ export interface MyApplication {
 export interface ReceivedApplication {
   id: string;
   postId: string;
+  postAuthorEmail: string;
   postDestination: string;
-  postDates: { start: string; end: string };
+  postDates: {
+    start: string;
+    end: string;
+  };
   applicant: Applicant;
 }
 
 export interface PostStats {
-  [key: string]: { views: number; likes: number };
+  [postId: string]: {
+    views: number;
+    likes: number;
+  };
 }
 
 export interface SelectedApplicant {
+  id: string;
   postId: string;
   postDestination: string;
   applicant: Applicant;

--- a/src/hooks/useMate.ts
+++ b/src/hooks/useMate.ts
@@ -126,16 +126,17 @@ export function useMate() {
     };
   };
 
-  const incrementViews = (postId: string): void => {
+  const incrementViews = (postId: string) => {
     setPostStats(prev => ({
       ...prev,
       [postId]: {
         ...prev[postId],
-        views: (prev[postId]?.views ?? DEFAULT_POSTS.find(p => p.id === postId)?.views ?? 0) + 1,
-        likes: prev[postId]?.likes ?? DEFAULT_POSTS.find(p => p.id === postId)?.likes ?? 0,
+        views: (prev[postId]?.views ?? DEFAULT_POSTS.find(p => p.id === postId)?.views ?? 0) + 1
       }
     }));
   };
+
+
 
   const toggleLike = (postId: string): void => {
     const defaultLikes = DEFAULT_POSTS.find(p => p.id === postId)?.likes ?? 0;
@@ -624,6 +625,7 @@ export function useMate() {
     // Posts
     visiblePosts,
     filteredPosts,
+    incrementViews,
     totalPages,
     likedPostIds,
     removedPosts,

--- a/src/pages/Mate.tsx
+++ b/src/pages/Mate.tsx
@@ -41,6 +41,7 @@ export default function Mate(): JSX.Element {
     removedPosts,
     isLikedOnlyMode,
     isRemovedOnlyMode,
+    isAppliedOnlyMode,
     hasActiveFilters,
     allPosts,
     
@@ -62,6 +63,7 @@ export default function Mate(): JSX.Element {
     // Applications
     myApplications,
     receivedApplications,
+    allReceivedApplications,
     getApplicantStatus,
     approvedApplicants,
     
@@ -77,6 +79,7 @@ export default function Mate(): JSX.Element {
     handlePostSubmit,
     handleApprove,
     handleReject,
+    handleDeletePost,
     
     // Chat Handlers
     sendOneOnOneMessage,
@@ -84,6 +87,7 @@ export default function Mate(): JSX.Element {
     getOrCreateOneOnOneChat,
     leaveOneOnOneChat,
     leaveGroupChat,
+    createOneOnOneChat,
     createGroupChat,
   } = useMate();
 
@@ -203,6 +207,9 @@ export default function Mate(): JSX.Element {
                           {option.value === "removed-only" && removedPosts.length > 0 && (
                             <span className="ml-2 text-xs opacity-60">({removedPosts.length})</span>
                           )}
+                          {option.value === "applied-only" && myApplications.length > 0 && (
+                            <span className="ml-2 text-xs opacity-60">({myApplications.length})</span>
+                          )}
                         </button>
                       ))}
                     </div>
@@ -235,6 +242,11 @@ export default function Mate(): JSX.Element {
                 <p className="text-black/60 text-lg font-bold uppercase">NO PASSED POSTS</p>
                 <p className="text-black/40 text-sm mt-2">// 아직 패스한 게시물이 없습니다</p>
               </>
+            ) : isAppliedOnlyMode ? (
+              <>
+                <p className="text-black/60 text-lg font-bold uppercase">NO APPLIED POSTS</p>
+                <p className="text-black/40 text-sm mt-2">// 아직 신청한 게시물이 없습니다</p>
+              </>
             ) : (
               <>
                 <p className="text-black/60 text-lg font-bold uppercase">NO POSTS FOUND</p>
@@ -256,6 +268,7 @@ export default function Mate(): JSX.Element {
                 isLiked={likedPostIds.includes(post.id)}
                 isRemoved={removedPosts.includes(post.id)}
                 isRemovedMode={isRemovedOnlyMode}
+                onDelete={handleDeletePost}
                 onCardClick={handleCardClick}
                 onLike={handleLike}
                 onRemove={handleRemove}
@@ -339,12 +352,12 @@ export default function Mate(): JSX.Element {
         groupChats={groupChats}
         allPosts={allPosts}
         myApplications={myApplications}
-        receivedApplications={receivedApplications}
+        receivedApplications={allReceivedApplications}
         approvedApplicants={approvedApplicants}
         onSendOneOnOneMessage={sendOneOnOneMessage}
         onSendGroupMessage={sendGroupMessage}
-        onCreateOneOnOneChat={handleCreateOneOnOneChat}
-        onCreateGroupChat={handleCreateGroupChat}
+        onCreateOneOnOneChat={createOneOnOneChat}
+        onCreateGroupChat={createGroupChat}
         onLeaveOneOnOneChat={leaveOneOnOneChat}
         onLeaveGroupChat={leaveGroupChat}
       />

--- a/src/pages/MateDetail.tsx
+++ b/src/pages/MateDetail.tsx
@@ -1,4 +1,4 @@
-// pages/MateDetail.tsx (무한 루프 수정)
+// pages/MateDetail.tsx (수정 완료 - receivedApplications 연동)
 
 import { useState, useEffect } from "react";
 import { useParams, useNavigate } from "react-router-dom";
@@ -14,7 +14,8 @@ export default function MateDetail(): JSX.Element {
   const { postId } = useParams<{ postId: string }>();
   const navigate = useNavigate();
 
-  const { allPosts, likedPostIds, handleLike: mateLike } = useMate();
+  // ✅ handleSendApplication 추가
+  const { allPosts, likedPostIds, handleLike: mateLike, handleSendApplication } = useMate();
 
   const [post, setPost] = useState<Post | null>(null);
   const [showApplyForm, setShowApplyForm] = useState(false);
@@ -56,32 +57,18 @@ export default function MateDetail(): JSX.Element {
     mateLike(postId, e); // useMate가 allPosts 업데이트 → 위 useEffect가 자동으로 처리
   };
 
-  /** 신청 메시지 제출 */
+  /** 신청 메시지 제출 - ✅ 수정된 부분 */
   const handleApplySubmit = () => {
     if (!postId || !applyMessage.trim() || !post) return;
 
-    const list = JSON.parse(localStorage.getItem("myApplications") || "[]");
-
-    list.push({
-      id: `APP_${Date.now()}`,
-      postId,
-      message: applyMessage,
-      appliedDate: new Date().toISOString(),
-      status: "pending",
-      applicant: {
-        name: "나",
-        email: "user@example.com",
-        age: 25,
-        gender: "성별무관",
-        avatar: "👤",
-      },
-    });
-
-    localStorage.setItem("myApplications", JSON.stringify(list));
+    // ✅ useMate의 handleSendApplication 사용
+    // 이 함수가 myApplications와 receivedApplications 모두에 저장
+    handleSendApplication(post, applyMessage);
 
     setHasApplied(true);
     setShowApplyForm(false);
     setApplyMessage("");
+    navigate("/mate", { replace: true });
   };
 
   /** Loading UI */


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #46 

---

## 🎨 작업 내용 (What)

- Mate 삭제 기능 추가
- Mate 정렬: 내가 신청한 항목 추가
- Mate 상세 페이지 진입 시 조회수 증가 로직 수정
- useMate 훅과 상세 페이지 간 상태 동기화 로직 보완
- 신청 기능(handleSendApplication) 상세 페이지에 정상 연동
- 좋아요, 신청 여부, 조회수 등 변경 시 UI 자동 반영되도록 상태 관리 개선

---

## 🧭 작업 목적 (Why)

- 기존 Mate 게시글을 삭제할 수 없는 문제 해결
- 내가 신청한 항목만 볼 수 있는 정렬 탭 추가
- 같은 세션에서 상세페이지 재진입 시 조회수가 증가하지 않는 문제 해결
- 신청 기능이 myApplications / receivedApplications 양쪽에 정상 반영되도록 수정
- Mate 상세 페이지의 상태가 allPosts 변경과 일관되게 업데이트되도록 개선

---

## 🧩 변경 범위
- [x] UI / Layout
- [x] 컴포넌트 구조
- [x] 상태 관리 로직
- [ ] API 연동
- [x] 스타일

---

## 🧪 테스트 방법
- [x] 로컬 실행 확인
- [x] 주요 화면 렌더링 확인
- [x] 에러 콘솔 확인

---

## ⚠️ 참고 사항

---

## ✅ 체크리스트
- [x] main 브랜치 직접 push 하지 않음
- [x] feature 브랜치에서 작업함
- [x] 불필요한 console.log 제거
- [x] PR 단위가 과도하게 크지 않음
