### PR TITLE
[FE] feature: 설정 페이지 스타일 개선 및 항목 확장

### DIFF
--- a/src/components/user/User.constant.ts
+++ b/src/components/user/User.constant.ts
@@ -1,88 +1,158 @@
 // constants/user.constants.ts
 
 export const STORAGE_KEYS = {
-  USER_PROFILE: 'tripmoa_user_profile',
+  USER_PROFILE: "tripmoa_user_profile",
 } as const;
 
-export const GENDERS = ['남성', '여성', '기타'] as const;
+export const GENDERS = ["남성", "여성", "기타"] as const;
 
 export const MBTI_TYPES = [
-  'INTJ', 'INTP', 'ENTJ', 'ENTP',
-  'INFJ', 'INFP', 'ENFJ', 'ENFP',
-  'ISTJ', 'ISFJ', 'ESTJ', 'ESFJ',
-  'ISTP', 'ISFP', 'ESTP', 'ESFP'
+  "INTJ",
+  "INTP",
+  "ENTJ",
+  "ENTP",
+  "INFJ",
+  "INFP",
+  "ENFJ",
+  "ENFP",
+  "ISTJ",
+  "ISFJ",
+  "ESTJ",
+  "ESFJ",
+  "ISTP",
+  "ISFP",
+  "ESTP",
+  "ESFP",
 ] as const;
 
 export const TRAVEL_STYLES = [
-  '맛집탐방',
-  '액티비티', 
-  '힐링',
-  '문화탐방',
-  '쇼핑',
-  '자연',
-  '사진',
-  '야경',
-  '로컬체험',
-  '카페투어',
-  '축제',
-  '역사탐방',
-  '야외활동',
-  '미식투어',
-  '럭셔리',
-  '배낭여행'
+  "맛집탐방",
+  "액티비티",
+  "힐링",
+  "문화탐방",
+  "쇼핑",
+  "자연",
+  "사진",
+  "야경",
+  "로컬체험",
+  "카페투어",
+  "축제",
+  "역사탐방",
+  "야외활동",
+  "미식투어",
+  "럭셔리",
+  "배낭여행",
 ] as const;
 
 // 랜덤 아바타용 이모지
 export const AVATAR_EMOJIS = [
-  '😊', '🎉', '✈️', '🌍', '📸', '🎒', '🗺️', '🌟',
-  '🎨', '🎭', '🎪', '🎯', '🎸', '🎺', '🎬', '🎮',
-  '⚽', '🏀', '🎾', '🏐', '🏈', '⚾', '🥎', '🏉',
-  '🌸', '🌺', '🌻', '🌷', '🌹', '🌼', '🌿', '🍀',
-  '⭐', '🌙', '☀️', '🌈', '⚡', '❄️', '🔥', '💎'
+  "😊",
+  "🎉",
+  "✈️",
+  "🌍",
+  "📸",
+  "🎒",
+  "🗺️",
+  "🌟",
+  "🎨",
+  "🎭",
+  "🎪",
+  "🎯",
+  "🎸",
+  "🎺",
+  "🎬",
+  "🎮",
+  "⚽",
+  "🏀",
+  "🎾",
+  "🏐",
+  "🏈",
+  "⚾",
+  "🥎",
+  "🏉",
+  "🌸",
+  "🌺",
+  "🌻",
+  "🌷",
+  "🌹",
+  "🌼",
+  "🌿",
+  "🍀",
+  "⭐",
+  "🌙",
+  "☀️",
+  "🌈",
+  "⚡",
+  "❄️",
+  "🔥",
+  "💎",
 ] as const;
 
 // 랜덤 아바타용 배경색
 export const AVATAR_COLORS = [
-  '#FFE5E5', '#FFE5CC', '#FFF4CC', '#E5F5E5', 
-  '#E5F0FF', '#F0E5FF', '#FFE5F5', '#FFEBE5',
-  '#FFD4D4', '#FFD4B8', '#FFEAB8', '#D4F0D4',
-  '#D4E5FF', '#E5D4FF', '#FFD4F0', '#FFD9C8',
-  '#FEC6C6', '#FEC6A3', '#FFDEA3', '#C6E8C6',
-  '#C6DAFF', '#DAC6FF', '#FFC6E8', '#FFC8B8'
+  "#FFE5E5",
+  "#FFE5CC",
+  "#FFF4CC",
+  "#E5F5E5",
+  "#E5F0FF",
+  "#F0E5FF",
+  "#FFE5F5",
+  "#FFEBE5",
+  "#FFD4D4",
+  "#FFD4B8",
+  "#FFEAB8",
+  "#D4F0D4",
+  "#D4E5FF",
+  "#E5D4FF",
+  "#FFD4F0",
+  "#FFD9C8",
+  "#FEC6C6",
+  "#FEC6A3",
+  "#FFDEA3",
+  "#C6E8C6",
+  "#C6DAFF",
+  "#DAC6FF",
+  "#FFC6E8",
+  "#FFC8B8",
 ] as const;
 
 export const DEFAULT_PROFILE = {
-  photo: '',
-  nickname: '',
-  name: '',
-  birthDate: '',
-  gender: '',
-  mbti: '',
+  photo: "",
+  nickname: "",
+  name: "",
+  birthDate: "",
+  gender: "",
+  mbti: "",
   travelStyles: [] as string[],
   isVerified: false,
 } as const;
 
+// 모달 내용
 export const MODAL_MESSAGES = {
   VERIFY: {
-    TITLE: '본인 인증',
-    DESCRIPTION: '실제 서비스에서는 휴대폰 인증, 아이핀 인증 등이 진행됩니다.\n데모에서는 바로 인증이 완료됩니다.',
-    BUTTON: '인증하기',
-    SUCCESS: '✅ 본인 인증이 완료되었습니다!',
+    TITLE: "본인 인증",
+    DESCRIPTION:
+      "실제 서비스에서는 휴대폰 인증, 아이핀 인증 등이 진행됩니다.\n데모에서는 바로 인증이 완료됩니다.",
+    BUTTON: "인증하기",
+    SUCCESS: "✅ 본인 인증이 완료되었습니다!",
   },
   DELETE: {
-    TITLE: '계정을 탈퇴하시겠습니까?',
-    DESCRIPTION: '모든 여행 기록, 메이트 정보, 채팅 내역이 영구적으로 삭제됩니다.\n이 작업은 되돌릴 수 없습니다.',
-    BUTTON: '탈퇴하기',
-    SUCCESS: '계정이 탈퇴되었습니다. 그동안 이용해주셔서 감사합니다.',
+    TITLE: "계정을 탈퇴하시겠습니까?",
+    DESCRIPTION:
+      "모든 여행 기록, 채팅 내역이 영구적으로 삭제됩니다.\n이 작업은 되돌릴 수 없습니다.",
+    BUTTON: "탈퇴하기",
+    SUCCESS: "계정이 탈퇴되었습니다. 그동안 이용해주셔서 감사합니다.",
   },
   SAVE: {
-    SUCCESS: '✅ 프로필이 저장되었습니다!',
+    SUCCESS: "✅ 프로필이 저장되었습니다!",
   },
 } as const;
 
 // 랜덤 아바타 생성 함수
 export function generateRandomAvatar(): { emoji: string; color: string } {
-  const randomEmoji = AVATAR_EMOJIS[Math.floor(Math.random() * AVATAR_EMOJIS.length)];
-  const randomColor = AVATAR_COLORS[Math.floor(Math.random() * AVATAR_COLORS.length)];
+  const randomEmoji =
+    AVATAR_EMOJIS[Math.floor(Math.random() * AVATAR_EMOJIS.length)];
+  const randomColor =
+    AVATAR_COLORS[Math.floor(Math.random() * AVATAR_COLORS.length)];
   return { emoji: randomEmoji, color: randomColor };
 }

--- a/src/hooks/useUserSetting.ts
+++ b/src/hooks/useUserSetting.ts
@@ -1,54 +1,93 @@
-// hooks/useUserProfile.ts
+import { useState, useEffect, useRef } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  STORAGE_KEYS,
+  DEFAULT_PROFILE,
+  generateRandomAvatar,
+} from "../components/user/User.constant";
 
-import { useState, useEffect, useRef } from 'react';
-import { STORAGE_KEYS, DEFAULT_PROFILE, generateRandomAvatar } from '../components/user/User.constant';
+// 유효한 MBTI 목록 정의
+const VALID_MBTI = [
+  "INTJ",
+  "INTP",
+  "ENTJ",
+  "ENTP",
+  "INFJ",
+  "INFP",
+  "ENFJ",
+  "ENFP",
+  "ISTJ",
+  "ISFJ",
+  "ESTJ",
+  "ESFJ",
+  "ISTP",
+  "ISFP",
+  "ESTP",
+  "ESFP",
+];
 
 export interface UserProfile {
   photo: string;
   nickname: string;
   name: string;
-  birthDate: string; // YYYY-MM-DD 형식
+  notificationEmail: string;
+  birthDate: string;
   gender: string;
   mbti: string;
   travelStyles: string[];
   isVerified: boolean;
-  avatarEmoji?: string; // 기본 아바타용
-  avatarColor?: string; // 기본 아바타용
+  avatarEmoji?: string;
+  avatarColor?: string;
+
+  // 입력 필드
+  email?: string; // 소셜 로그인 이메일
+  isPrivateName: boolean; // 이름 비공개 여부 추가
+  isPrivateAge: boolean; // 나이 비공개 여부 추가
+  isPrivateGender: boolean; // 성별 비공개 여부 추가
+  isAdultConfirmed: boolean; // 성인 인증 확인 여부
+
+  // 알림 설정 필드
+  tripAlert: boolean; // 여행 일정 알림
+  marketingAgreed: boolean; // 마케팅 수신 동의
+  emailAgreed: boolean; // 이메일 수신 동의
+
+  // 동적 키 접근을 위한 인덱스 시그니처 추가
+  [key: string]: any;
 }
 
 export function useUserProfile() {
   const [profile, setProfile] = useState<UserProfile>(() => {
+    const saved = localStorage.getItem(STORAGE_KEYS.USER_PROFILE);
+    if (saved) return JSON.parse(saved);
+
+    // 데이터가 없을 때만 생성하고 즉시 저장
     const { emoji, color } = generateRandomAvatar();
-    return { 
-      ...DEFAULT_PROFILE, 
-      travelStyles: [],
+    const initialProfile = {
+      ...DEFAULT_PROFILE,
       avatarEmoji: emoji,
-      avatarColor: color
+      avatarColor: color,
+      notificationEmail: "",
+      isPrivateName: false,
+      isPrivateAge: false,
+      isPrivateGender: false,
+      isAdultConfirmed: false,
+      tripAlert: true,
+      marketingAgreed: false,
+      emailAgreed: false,
     };
+
+    // 즉시 저장하여 새로고침 시 고정
+    localStorage.setItem(
+      STORAGE_KEYS.USER_PROFILE,
+      JSON.stringify(initialProfile)
+    );
+    return initialProfile;
   });
-  
+
+  const navigate = useNavigate();
   const [hasChanges, setHasChanges] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
-
-  // 로컬스토리지에서 불러오기
-  useEffect(() => {
-    const saved = localStorage.getItem(STORAGE_KEYS.USER_PROFILE);
-    if (saved) {
-      try {
-        const parsedProfile = JSON.parse(saved);
-        // 기존 프로필에 avatarEmoji/Color가 없으면 생성
-        if (!parsedProfile.avatarEmoji || !parsedProfile.avatarColor) {
-          const { emoji, color } = generateRandomAvatar();
-          parsedProfile.avatarEmoji = emoji;
-          parsedProfile.avatarColor = color;
-        }
-        setProfile(parsedProfile);
-      } catch (error) {
-        console.error('프로필 불러오기 실패:', error);
-      }
-    }
-  }, []);
 
   // 변경사항 감지
   useEffect(() => {
@@ -59,7 +98,7 @@ export function useUserProfile() {
 
   // 프로필 업데이트
   const updateProfile = (updates: Partial<UserProfile>) => {
-    setProfile(prev => ({ ...prev, ...updates }));
+    setProfile((prev) => ({ ...prev, ...updates }));
   };
 
   // 프로필 저장
@@ -67,7 +106,10 @@ export function useUserProfile() {
     setIsSaving(true);
     return new Promise((resolve) => {
       setTimeout(() => {
-        localStorage.setItem(STORAGE_KEYS.USER_PROFILE, JSON.stringify(profile));
+        localStorage.setItem(
+          STORAGE_KEYS.USER_PROFILE,
+          JSON.stringify(profile)
+        );
         setHasChanges(false);
         setIsSaving(false);
         resolve();
@@ -96,7 +138,7 @@ export function useUserProfile() {
   const toggleTravelStyle = (style: string) => {
     const styles = profile.travelStyles || [];
     if (styles.includes(style)) {
-      updateProfile({ travelStyles: styles.filter(s => s !== style) });
+      updateProfile({ travelStyles: styles.filter((s) => s !== style) });
     } else {
       updateProfile({ travelStyles: [...styles, style] });
     }
@@ -112,16 +154,42 @@ export function useUserProfile() {
     });
   };
 
+  // 아바타 랜덤 변경
+  const regenerateAvatar = () => {
+    const { emoji, color } = generateRandomAvatar();
+    updateProfile({
+      avatarEmoji: emoji,
+      avatarColor: color,
+      photo: "",
+    });
+  };
+
   // 계정 탈퇴
   const deleteAccount = () => {
     localStorage.removeItem(STORAGE_KEYS.USER_PROFILE);
+
     const { emoji, color } = generateRandomAvatar();
-    setProfile({ 
-      ...DEFAULT_PROFILE, 
+
+    // 모든 상태 초기화
+    setProfile({
+      ...DEFAULT_PROFILE,
       travelStyles: [],
       avatarEmoji: emoji,
-      avatarColor: color
+      avatarColor: color,
+
+      email: "",
+      notificationEmail: "",
+      isPrivateName: false,
+      isPrivateAge: false,
+      isPrivateGender: false,
+      isAdultConfirmed: false,
+      tripAlert: true,
+      marketingAgreed: false,
+      emailAgreed: false,
     });
+
+    // 홈화면 이동
+    navigate("/");
   };
 
   // 나이 계산
@@ -131,19 +199,22 @@ export function useUserProfile() {
     const birth = new Date(birthDate);
     let age = today.getFullYear() - birth.getFullYear();
     const monthDiff = today.getMonth() - birth.getMonth();
-    if (monthDiff < 0 || (monthDiff === 0 && today.getDate() < birth.getDate())) {
+    if (
+      monthDiff < 0 ||
+      (monthDiff === 0 && today.getDate() < birth.getDate())
+    ) {
       age--;
     }
     return age;
   };
 
-  // 폼 유효성 검사
-  const isFormValid = !!(
-    profile.nickname && 
-    profile.name && 
-    profile.birthDate && 
-    profile.gender
-  );
+  // MBTI 유효성 검사: 비어있거나, 4글자이면서 유효 목록에 포함되어야 함
+  const isMBTIValid =
+    !profile.mbti ||
+    (profile.mbti.length === 4 && VALID_MBTI.includes(profile.mbti));
+
+  // 닉네임 필수, MBTI 입력할 경우에만 유효성 체크
+  const isFormValid = !!profile.nickname && isMBTIValid;
 
   const age = calculateAge(profile.birthDate);
 
@@ -153,6 +224,7 @@ export function useUserProfile() {
     hasChanges,
     isSaving,
     isFormValid,
+    VALID_MBTI,
     fileInputRef,
     age,
 
@@ -165,5 +237,6 @@ export function useUserProfile() {
     verify,
     deleteAccount,
     calculateAge,
+    regenerateAvatar,
   };
 }

--- a/src/pages/UserSetting.tsx
+++ b/src/pages/UserSetting.tsx
@@ -1,42 +1,86 @@
-// pages/user/UserSettings.tsx
-
-import React, { useState } from 'react';
-import { Shield, Camera, X, AlertTriangle, Home, ArrowLeft } from 'lucide-react';
-import { useNavigate } from 'react-router-dom';
-import { useUserProfile } from '../hooks/useUserSetting';
-import { 
-  GENDERS, 
-  MBTI_TYPES,
+import React, { useState } from "react";
+import { useEffect } from "react";
+import {
+  Shield,
+  Camera,
+  X,
+  AlertTriangle,
+  ChevronDown,
+  ChevronUp,
+} from "lucide-react";
+import { useNavigate } from "react-router-dom";
+import { useUserProfile } from "../hooks/useUserSetting";
+import type { UserProfile } from "../hooks/useUserSetting";
+import {
   TRAVEL_STYLES,
-  MODAL_MESSAGES 
-} from '../components/user/User.constant';
-import styles from '../styles/user/UserSetting.module.css';
+  MODAL_MESSAGES,
+} from "../components/user/User.constant";
+import styles from "../styles/user/UserSetting.module.css";
 
 export default function UserSettings() {
   const navigate = useNavigate();
-  
+  const [activeTab, setActiveTab] = useState("내 정보");
+
   const {
-    profile,
-    hasChanges,
-    isSaving,
-    isFormValid,
-    fileInputRef,
-    age,
-    updateProfile,
-    saveProfile,
-    handlePhotoChange,
+    profile, // 프로필 데이터
+    updateProfile, // 업데이트 함수
+    hasChanges, // 변경 사항 여부
+    isSaving, // 저장 중 상태
+    isFormValid, // 유효성 검사
+    VALID_MBTI, // 추천 리스트
+    saveProfile, // 저장 함수
+    regenerateAvatar,
     triggerPhotoUpload,
     toggleTravelStyle,
     verify,
     deleteAccount,
+    fileInputRef,
+    handlePhotoChange,
   } = useUserProfile();
+
+  // 추천 목록 표시 여부 상태
+  const [showSuggestions, setShowSuggestions] = useState(false);
+
+  // 입력값 필터링 (영어만 허용 및 대문자 변환)
+  const handleMBTIChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value.replace(/[^A-Za-z]/g, "").toUpperCase();
+    updateProfile({ mbti: value });
+    setShowSuggestions(true);
+  };
+
+  const filteredMBTI = VALID_MBTI.filter(
+    (type) => profile.mbti && type.startsWith(profile.mbti)
+  );
+
+  // 새로고침 경고문
+  useEffect(() => {
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      if (hasChanges) {
+        e.preventDefault();
+        e.returnValue =
+          "저장하지 않은 변경사항이 있습니다. 정말 나가시겠습니까?";
+      }
+    };
+
+    window.addEventListener("beforeunload", handleBeforeUnload);
+
+    return () => {
+      window.removeEventListener("beforeunload", handleBeforeUnload);
+    };
+  }, [hasChanges]);
 
   const [showVerifyModal, setShowVerifyModal] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
 
-  // 홈으로 이동
-  const handleGoHome = () => {
-    navigate('/');
+  // 토글 상태
+  const [openSections, setOpenSections] = useState({
+    social: false, // 소셜 관리 섹션 초기 상태
+    notifications: false, // 알림 설정 섹션 초기 상태
+  });
+
+  // 섹션 토글 함수
+  const toggleSection = (section: "social" | "notifications") => {
+    setOpenSections((prev) => ({ ...prev, [section]: !prev[section] }));
   };
 
   // 저장 핸들러
@@ -59,224 +103,585 @@ export default function UserSettings() {
     setShowDeleteModal(false);
   };
 
+  // X 버튼 경고문
+  const handleClose = () => {
+    if (hasChanges) {
+      const confirmLeave = window.confirm(
+        "수정 중인 변경사항이 있습니다. 저장하지 않고 나가시겠습니까?"
+      );
+      if (!confirmLeave) return;
+    }
+
+    navigate(-1);
+  };
+
   return (
     <div className={styles.page}>
       <div className={styles.ticket}>
         {/* Header */}
         <div className={styles.header}>
-          <button 
-            className={styles.homeButton}
-            onClick={handleGoHome}
-            title="홈으로"
+          {/* 왼쪽 : 인증 완료 */}
+          {profile.isVerified && (
+            <div className={styles.verifiedBadge}>
+              <Shield size={14} />
+              <span>인증 완료</span>
+            </div>
+          )}
+          {/* 오른쪽 : X 버튼 */}
+          <button
+            className={styles.closeButton}
+            onClick={handleClose}
+            title="닫기"
           >
-            <Home size={20} />
+            <X size={24} />
           </button>
-          
+
           <div className={styles.headerContent}>
             <h1 className={styles.title}>MY PAGE</h1>
-            <p className={styles.subtitle}>프로필 및 계정 설정</p>
-            {profile.isVerified && (
-              <div className={styles.verifiedBadge}>
-                <Shield size={14} />
-                <span>인증 완료</span>
-              </div>
-            )}
-          </div>
-        </div>
 
-        {/* Profile Section */}
-        <section className={styles.section}>
-          <h2 className={styles.sectionTitle}>프로필 정보</h2>
-
-          {/* Profile Photo */}
-          <div className={styles.profileRow}>
-            <div 
-              className={styles.avatar}
-              onClick={triggerPhotoUpload}
-              style={{
-                background: profile.photo ? 'transparent' : profile.avatarColor
-              }}
-            >
-              {profile.photo ? (
-                <img src={profile.photo} alt="Profile" />
-              ) : (
-                <span className={styles.avatarEmoji}>{profile.avatarEmoji}</span>
-              )}
-              <div className={styles.avatarOverlay}>
-                <Camera size={20} />
-              </div>
-            </div>
-            
-            <input
-              ref={fileInputRef}
-              type="file"
-              accept="image/*"
-              onChange={handlePhotoChange}
-              style={{ display: 'none' }}
-            />
-            
-            <div className={styles.avatarInfo}>
-              <button 
-                className={styles.secondaryButton}
-                style={{ marginTop: '20px' }}
-                onClick={triggerPhotoUpload}
-              >
-                사진 업로드
-              </button>
-              <p className={styles.avatarDesc}>
-                프로필 사진을 업로드하지 않으면 랜덤 아바타가 표시됩니다
-              </p>
-            </div>
-          </div>
-
-          {/* Basic Info */}
-          <div className={styles.grid}>
-            <div className={styles.field}>
-              <label className={styles.label}>
-                닉네임<span className={styles.required}>*</span>
-              </label>
-              <input 
-                className={styles.input} 
-                placeholder="닉네임 입력"
-                value={profile.nickname}
-                onChange={(e) => updateProfile({ nickname: e.target.value })}
-              />
-            </div>
-
-            <div className={styles.field}>
-              <label className={styles.label}>
-                이름<span className={styles.required}>*</span>
-              </label>
-              <input 
-                className={styles.input} 
-                placeholder="이름 입력"
-                value={profile.name}
-                onChange={(e) => updateProfile({ name: e.target.value })}
-              />
-            </div>
-
-            <div className={styles.field}>
-              <label className={styles.label}>
-                생년월일<span className={styles.required}>*</span>
-              </label>
-              <input 
-                className={styles.input}
-                type="date"
-                value={profile.birthDate}
-                onChange={(e) => updateProfile({ birthDate: e.target.value })}
-                max={new Date().toISOString().split('T')[0]}
-              />
-              {age > 0 && (
-                <span className={styles.ageDisplay}>만 {age}세</span>
-              )}
-            </div>
-
-            <div className={styles.field}>
-              <label className={styles.label}>
-                성별<span className={styles.required}>*</span>
-              </label>
-              <select 
-                className={styles.input}
-                value={profile.gender}
-                onChange={(e) => updateProfile({ gender: e.target.value })}
-              >
-                <option value="">성별 선택</option>
-                {GENDERS.map((gender) => (
-                  <option key={gender} value={gender}>
-                    {gender}
-                  </option>
-                ))}
-              </select>
-            </div>
-
-            <div className={styles.field}>
-              <label className={styles.label}>MBTI</label>
-              <select 
-                className={styles.input}
-                value={profile.mbti}
-                onChange={(e) => updateProfile({ mbti: e.target.value })}
-              >
-                <option value="">MBTI 선택</option>
-                {MBTI_TYPES.map((mbti) => (
-                  <option key={mbti} value={mbti}>
-                    {mbti}
-                  </option>
-                ))}
-              </select>
-            </div>
-          </div>
-
-          {/* Travel Styles */}
-          <div className={styles.travelStyleSection}>
-            <label className={styles.label}>여행 스타일</label>
-            <p className={styles.desc}>관심있는 여행 스타일을 선택해주세요 (복수 선택 가능)</p>
-            <div className={styles.travelStyleGrid}>
-              {TRAVEL_STYLES.map((style) => (
+            {/* 탭 메뉴 구성 */}
+            <div className={styles.tabContainer}>
+              {["내 정보", "계정 및 설정", "신고 관리"].map((tab) => (
                 <button
-                  key={style}
-                  className={`${styles.travelStyleBtn} ${
-                    profile.travelStyles?.includes(style) ? styles.active : ''
+                  key={tab}
+                  className={`${styles.tabItem} ${
+                    activeTab === tab ? styles.activeTab : ""
                   }`}
-                  onClick={() => toggleTravelStyle(style)}
-                  type="button"
+                  onClick={() => setActiveTab(tab)}
                 >
-                  {style}
+                  {tab}
                 </button>
               ))}
             </div>
           </div>
+        </div>
 
-          {/* Save Button */}
-          {hasChanges && (
-            <button 
-              className={`${styles.saveButton} ${isSaving ? styles.saving : ''}`}
-              onClick={handleSave}
-              disabled={!isFormValid || isSaving}
-            >
-              {isSaving ? '저장 중...' : '변경사항 저장'}
-            </button>
-          )}
-        </section>
+        {/* 내 정보 섹션 */}
+        {activeTab === "내 정보" && (
+          <>
+            <section className={styles.section}>
+              {/* 프로필 섹션 */}
+              <h2 className={styles.sectionTitle}>프로필 정보</h2>
 
-        {/* Verification Section */}
-        <section className={styles.section}>
-          <h2 className={styles.sectionTitle}>본인 인증</h2>
-          <p className={styles.desc}>
-            {profile.isVerified 
-              ? '✅ 본인 인증이 완료되었습니다.'
-              : '커뮤니티 이용을 위해 본인 인증이 필요합니다.'
-            }
-          </p>
-          <button 
-            className={styles.primaryButton}
-            onClick={() => setShowVerifyModal(true)}
-            disabled={profile.isVerified || !isFormValid}
+              <div className={styles.profileRow}>
+                <div
+                  className={styles.avatar}
+                  onClick={regenerateAvatar}
+                  title="클릭 시 랜덤 아바타 변경"
+                  style={{
+                    background: profile.photo
+                      ? "transparent"
+                      : profile.avatarColor,
+                  }}
+                >
+                  {profile.photo ? (
+                    <img src={profile.photo} alt="Profile" />
+                  ) : (
+                    <span className={styles.avatarEmoji}>
+                      {profile.avatarEmoji}
+                    </span>
+                  )}
+                  <div className={styles.avatarOverlay}>
+                    <Camera size={20} />
+                  </div>
+                </div>
+
+                <div className={styles.avatarInfo}>
+                  <p className={styles.avatarDesc}>
+                    동그란 프로필을 클릭하면 랜덤 아바타로 바뀝니다.
+                  </p>
+                  <button
+                    className={styles.secondaryButton}
+                    onClick={triggerPhotoUpload}
+                  >
+                    대표 사진 업로드
+                  </button>
+                  <input
+                    ref={fileInputRef}
+                    type="file"
+                    accept="image/*"
+                    style={{ display: "none" }}
+                    onChange={handlePhotoChange}
+                  />
+                </div>
+              </div>
+
+              <div className={styles.grid}>
+                {/* 닉네임 섹션 */}
+                <div className={styles.field}>
+                  <label className={styles.label}>
+                    닉네임<span className={styles.required}>*</span>
+                  </label>
+                  <input
+                    className={`${styles.input} ${
+                      !profile.nickname ? styles.inputError : ""
+                    }`}
+                    value={profile.nickname || ""}
+                    placeholder="닉네임은 필수 입력 항목입니다."
+                    onChange={(e) =>
+                      updateProfile({ nickname: e.target.value })
+                    }
+                  />
+                  {/* 데이터가 없거나 지웠을 때만 표시 */}
+                  {!profile.nickname && (
+                    <span className={styles.errorText}>
+                      닉네임은 필수 입력 사항입니다.
+                    </span>
+                  )}
+                </div>
+
+                {/* 이름: 소셜 데이터 기반 잠금 */}
+                <div className={styles.field}>
+                  <label className={styles.label}>이름</label>
+                  <input
+                    className={`${styles.input} ${styles.inputLocked}`}
+                    value={profile.name}
+                    readOnly
+                  />
+                </div>
+
+                {/* 알림 수신 이메일 */}
+                <div className={styles.field}>
+                  <label className={styles.label}>알림 수신 이메일</label>
+                  <input
+                    className={styles.input}
+                    placeholder="example@email.com"
+                    value={profile.notificationEmail}
+                    onChange={(e) =>
+                      updateProfile({ notificationEmail: e.target.value })
+                    }
+                  />
+                </div>
+
+                {/* 성별: 잠금 */}
+                <div className={styles.field}>
+                  <label className={styles.label}>성별</label>
+                  <input
+                    className={`${styles.input} ${styles.inputLocked}`}
+                    value={profile.gender}
+                    readOnly
+                  />
+                </div>
+
+                {/* 생년월일: 잠금 */}
+                <div className={styles.field}>
+                  <label className={styles.label}>생년월일</label>
+                  <input
+                    className={`${styles.input} ${styles.inputLocked}`}
+                    type="date"
+                    value={profile.birthDate}
+                    readOnly
+                  />
+                </div>
+
+                {/* MBTI: 수정 가능 */}
+                <div className={styles.field}>
+                  <label className={styles.label}>MBTI</label>
+                  <div className={styles.autocompleteWrapper}>
+                    <input
+                      className={`${styles.input} ${
+                        profile.mbti &&
+                        !VALID_MBTI.includes(profile.mbti) &&
+                        profile.mbti.length === 4
+                          ? styles.inputError
+                          : ""
+                      }`}
+                      style={{ width: "100%" }}
+                      value={profile.mbti || ""}
+                      onChange={handleMBTIChange}
+                      onFocus={() => setShowSuggestions(true)}
+                      onBlur={() =>
+                        setTimeout(() => setShowSuggestions(false), 200)
+                      }
+                      placeholder="예: ENFP"
+                      maxLength={4}
+                    />
+
+                    {showSuggestions &&
+                      filteredMBTI.length > 0 &&
+                      profile.mbti && (
+                        <ul className={styles.suggestionList}>
+                          {filteredMBTI.map((type) => (
+                            <li
+                              key={type}
+                              className={styles.suggestionItem}
+                              onMouseDown={() => updateProfile({ mbti: type })}
+                            >
+                              <span className={styles.clockIcon}>👉</span>
+                              {type}
+                            </li>
+                          ))}
+                        </ul>
+                      )}
+                  </div>
+
+                  {/* 잘못된 MBTI 입력 시 경고 */}
+                  {profile.mbti &&
+                    !VALID_MBTI.includes(profile.mbti) &&
+                    profile.mbti.length === 4 && (
+                      <span className={styles.errorText}>
+                        유효하지 않은 MBTI 유형입니다.
+                      </span>
+                    )}
+                </div>
+              </div>
+
+              {/* 여행 스타일 */}
+              <div className={styles.travelStyleSection}>
+                <label className={styles.label}>여행 스타일</label>
+                <p className={styles.desc}>
+                  관심있는 여행 스타일을 선택해주세요 (복수 선택 가능)
+                </p>
+                <div className={styles.travelStyleGrid}>
+                  {TRAVEL_STYLES.map((style) => (
+                    <button
+                      key={style}
+                      className={`${styles.travelStyleBtn} ${
+                        profile.travelStyles?.includes(style)
+                          ? styles.active
+                          : ""
+                      }`}
+                      onClick={() => toggleTravelStyle(style)}
+                      type="button"
+                    >
+                      {style}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            </section>
+          </>
+        )}
+
+        {/* 계정 및 설정 섹션 */}
+        {activeTab === "계정 및 설정" && (
+          <div className={styles.settingsWrapper}>
+            {/* 계정 관리 (아코디언) */}
+            <section className={styles.section}>
+              <div
+                className={styles.accordionHeader}
+                onClick={() => toggleSection("social")}
+              >
+                <h2 className={styles.sectionTitle}>계정 관리</h2>
+                {openSections.social ? (
+                  <ChevronUp size={20} />
+                ) : (
+                  <ChevronDown size={20} />
+                )}
+              </div>
+
+              {openSections.social && (
+                <div className={styles.accordionContent}>
+                  <div className={styles.socialStatusCard}>
+                    <div className={styles.socialItem}>
+                      <div className={styles.socialInfo}>
+                        <span
+                          className={`${styles.socialIcon} ${styles.kakao}`}
+                        >
+                          K
+                        </span>
+                        <div className={styles.socialText}>
+                          <p className={styles.socialName}>카카오 계정</p>
+                          <p className={styles.socialDetail}>
+                            {profile.email
+                              ? profile.email
+                              : "연결된 이메일 정보가 없습니다."}
+                          </p>
+                        </div>
+                      </div>
+                      <span
+                        className={`${styles.connectionBadge} ${
+                          !profile.email ? styles.notConnected : ""
+                        }`}
+                      >
+                        {profile.email ? "연결됨" : "연결 안 됨"}
+                      </span>
+                    </div>
+                    {/* 개인정보 설정 부분 */}
+                    <div className={styles.privacyToggleArea}>
+                      {[
+                        { id: "isPrivateName", label: "이름 공개여부" },
+                        { id: "isPrivateAge", label: "나이 공개여부" },
+                        { id: "isPrivateGender", label: "성별 공개여부" },
+                      ].map((item) => (
+                        <div key={item.id} className={styles.toggleRow}>
+                          <span>{item.label}</span>
+                          <label className={styles.switch}>
+                            <input
+                              type="checkbox"
+                              checked={profile[item.id as keyof UserProfile]}
+                              onChange={(e) =>
+                                updateProfile({ [item.id]: e.target.checked })
+                              }
+                            />
+                            <span className={styles.slider}></span>
+                          </label>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              )}
+            </section>
+
+            {/* 알림 설정 (아코디언) */}
+            <section className={styles.section}>
+              <div
+                className={styles.accordionHeader}
+                onClick={() => toggleSection("notifications")}
+              >
+                <h2 className={styles.sectionTitle}>알림 설정</h2>
+                {openSections.notifications ? (
+                  <ChevronUp size={20} />
+                ) : (
+                  <ChevronDown size={20} />
+                )}
+              </div>
+
+              {openSections.notifications && (
+                <div className={styles.accordionContent}>
+                  <div className={styles.settingList}>
+                    {[
+                      {
+                        id: "tripAlert",
+                        label: "여행 일정 및 초대 알림",
+                        desc: "새로운 팀원 초대 및 일정 변경 알림",
+                      },
+                      {
+                        id: "marketingAgreed",
+                        label: "마케팅 정보 수신 동의",
+                        desc: "이벤트 및 혜택 정보 안내",
+                      },
+                      {
+                        id: "emailAgreed",
+                        label: "이메일 수신 동의",
+                        desc: "주요 공지 및 업데이트 리포트",
+                      },
+                    ].map((item) => (
+                      <div key={item.id} className={styles.settingItem}>
+                        <div className={styles.settingText}>
+                          <p className={styles.settingLabel}>{item.label}</p>
+                          <p className={styles.settingDesc}>{item.desc}</p>
+                        </div>
+                        <label className={styles.switch}>
+                          <input
+                            type="checkbox"
+                            checked={profile[item.id]}
+                            onChange={(e) =>
+                              updateProfile({ [item.id]: e.target.checked })
+                            }
+                          />
+                          <span className={styles.slider}></span>
+                        </label>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </section>
+
+            {/* 본인 인증 및 서비스 이용 확인 */}
+            <section className={styles.section}>
+              <h2 className={styles.sectionTitle}>서비스 이용 인증</h2>
+              <div className={styles.adultVerifyBox}>
+                <p className={styles.verifyTitle}>🔞 만 19세 이상 이용 안내</p>
+                <p className={styles.verifyDesc}>
+                  트립모아는 안전한 동행 및 여행 계획 공유를 위해{" "}
+                  <strong>성인 전용</strong>으로 운영됩니다.
+                </p>
+                <div className={styles.confirmCheckboxArea}>
+                  <label className={styles.checkboxContainer}>
+                    <input
+                      type="checkbox"
+                      checked={profile.isAdultConfirmed}
+                      disabled={profile.isAdultConfirmed}
+                      onChange={(e) =>
+                        updateProfile({ isAdultConfirmed: e.target.checked })
+                      }
+                    />
+                    <span className={styles.checkmark}></span>
+                    <span className={styles.checkboxLabel}>
+                      본인은 만 19세 이상임을 확인합니다.
+                    </span>
+                  </label>
+                </div>
+                <p className={styles.legalWarning}>
+                  * 허위 정보 입력 시 서비스 이용 제한 및 법적 책임은 사용자
+                  본인에게 있습니다.
+                </p>
+              </div>
+
+              <p className={styles.desc} style={{ marginTop: 20 }}>
+                {profile.isVerified
+                  ? "✅ 본인 인증이 완료되었습니다."
+                  : "커뮤니티 이용을 위해 본인 인증이 필요합니다."}
+              </p>
+              <button
+                className={styles.primaryButton}
+                onClick={() => setShowVerifyModal(true)}
+                disabled={profile.isVerified || !isFormValid}
+              >
+                {profile.isVerified ? "인증 완료" : "본인 인증하기"}
+              </button>
+            </section>
+
+            {/* 고객 지원 섹션 */}
+            <section className={styles.section}>
+              <h2 className={styles.sectionTitle}>고객 지원</h2>
+              <div className={styles.supportGrid}>
+                {/* 아직 페이지가 없으므로 알림창으로 대체합니다 */}
+                <button
+                  className={styles.supportBtn}
+                  onClick={() => alert("공지사항 기능은 현재 준비 중입니다.")}
+                >
+                  공지사항
+                </button>
+                <button
+                  className={styles.supportBtn}
+                  onClick={() => alert("FAQ 기능은 현재 준비 중입니다.")}
+                >
+                  FAQ
+                </button>
+                <button
+                  className={styles.supportBtnPrimary}
+                  onClick={() =>
+                    window.open("http://pf.kakao.com/_내채널ID/chat", "_blank")
+                  }
+                >
+                  카카오톡 1:1 문의
+                </button>
+              </div>
+            </section>
+
+            {/* 계정 관리 (탈퇴) */}
+            <section className={`${styles.section} ${styles.danger}`}>
+              <h2 className={styles.sectionTitle}>계정 관리</h2>
+              <p className={styles.desc}>
+                탈퇴 시 모든 여행 데이터와 프로필 정보가 영구적으로 파기됩니다.
+              </p>
+              <button
+                className={styles.dangerButton}
+                onClick={() => setShowDeleteModal(true)}
+              >
+                회원 탈퇴하기
+              </button>
+            </section>
+          </div>
+        )}
+
+        {/* 신고 관리 섹션  */}
+        {activeTab === "신고 관리" && (
+          <>
+            {/* 나의 신고 현황 */}
+            <section className={styles.section}>
+              <h2 className={styles.sectionTitle}>나의 신고 현황</h2>
+              <div className={styles.reportSummary}>
+                <div className={styles.statusBox}>
+                  <span className={styles.statusLabel}>현재 제재 단계</span>
+                  <span className={styles.statusValue}>1단계 (주의)</span>
+                </div>
+                <div className={styles.statusBox}>
+                  <span className={styles.statusLabel}>누적 신고 횟수</span>
+                  <span className={styles.statusValue}>2회</span>
+                </div>
+              </div>
+
+              <table className={styles.reportTable}>
+                <thead>
+                  <tr>
+                    <th>위치</th>
+                    <th>사유</th>
+                    <th>날짜</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td>댓글</td>
+                    <td>욕설 및 비방</td>
+                    <td>2026.01.05</td>
+                  </tr>
+                  <tr>
+                    <td>채팅</td>
+                    <td>도배</td>
+                    <td>2025.12.30</td>
+                  </tr>
+                </tbody>
+              </table>
+            </section>
+
+            {/* 제재 단계 안내 및 강조 문구 */}
+            <section className={styles.section}>
+              <h2 className={styles.sectionTitle}>신고 및 제재 안내</h2>
+              <div className={styles.guideCard}>
+                <ul className={styles.guideList}>
+                  <li>
+                    <strong>1단계:</strong> 신고자 본인 화면에서 메시지 숨김
+                  </li>
+                  <li>
+                    <strong>2단계:</strong> 전체 화면에서 "신고된 메시지"로 치환
+                  </li>
+                  <li>
+                    <strong>3단계:</strong> 서비스 로그인 시 경고 팝업 노출
+                  </li>
+                  <li>
+                    <strong>4단계:</strong> 계정 상태 '정지' 처리 및 접속 차단
+                  </li>
+                </ul>
+
+                {/* 사용자 강조 문구 */}
+                <div className={styles.importantNote}>
+                  <p className={styles.noteTitle}>
+                    ⚠️ 여행 계획(Trip) 관련 중요 공지
+                  </p>
+                  <p className={styles.noteText}>
+                    여행 계획 내에서 신고가 누적될 경우,{" "}
+                    <strong>해당 계획에서 즉시 강제 퇴출</strong>당합니다.
+                    작성하신 내용은 팀원들을 위해 <strong>'작성자 미상'</strong>
+                    으로 유지되며, 퇴출 사실은 팀원들에게 즉시 통보됩니다.
+                  </p>
+                </div>
+              </div>
+            </section>
+
+            {/* 이의 제기 버튼 */}
+            <section className={styles.section}>
+              <button
+                className={styles.secondaryButton}
+                style={{ width: "100%" }}
+                onClick={() =>
+                  window.open("http://pf.kakao.com/_내채널ID/chat", "_blank")
+                }
+              >
+                신고 관련 이의 제기하기
+              </button>
+            </section>
+          </>
+        )}
+
+        {/* 저장 버튼 */}
+        {hasChanges && (
+          <button
+            className={`${styles.saveButton} ${isSaving ? styles.saving : ""}`}
+            onClick={handleSave}
+            disabled={!isFormValid || isSaving}
           >
-            {profile.isVerified ? '인증 완료' : '본인 인증하기'}
+            {isSaving ? "저장 중..." : "변경사항 저장"}
           </button>
-        </section>
-
-        {/* Account Section */}
-        <section className={`${styles.section} ${styles.danger}`}>
-          <h2 className={styles.sectionTitle}>계정</h2>
-          <p className={styles.desc}>
-            계정을 삭제하면 모든 데이터가 영구적으로 삭제됩니다.
-          </p>
-          <button 
-            className={styles.dangerButton}
-            onClick={() => setShowDeleteModal(true)}
-          >
-            계정 탈퇴
-          </button>
-        </section>
+        )}
       </div>
 
-      {/* Verify Modal */}
+      {/* 본인 인증 Model */}
       {showVerifyModal && (
-        <div className={styles.modalOverlay} onClick={() => setShowVerifyModal(false)}>
-          <div className={styles.modalContent} onClick={(e) => e.stopPropagation()}>
-            <button 
-              className={styles.modalCloseBtn} 
+        <div
+          className={styles.modalOverlay}
+          onClick={() => setShowVerifyModal(false)}
+        >
+          <div
+            className={styles.modalContent}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <button
+              className={styles.modalCloseBtn}
               onClick={() => setShowVerifyModal(false)}
             >
               <X size={20} />
@@ -286,24 +691,23 @@ export default function UserSettings() {
             </div>
             <h2 className={styles.modalTitle}>{MODAL_MESSAGES.VERIFY.TITLE}</h2>
             <p className={styles.modalText}>
-              {MODAL_MESSAGES.VERIFY.DESCRIPTION.split('\n').map((line, i) => (
+              {MODAL_MESSAGES.VERIFY.DESCRIPTION.split("\n").map((line, i) => (
                 <React.Fragment key={i}>
                   {line}
-                  {i < MODAL_MESSAGES.VERIFY.DESCRIPTION.split('\n').length - 1 && <br />}
+                  {i <
+                    MODAL_MESSAGES.VERIFY.DESCRIPTION.split("\n").length -
+                      1 && <br />}
                 </React.Fragment>
               ))}
             </p>
             <div className={styles.modalButtons}>
-              <button 
+              <button
                 className={styles.modalCancelBtn}
                 onClick={() => setShowVerifyModal(false)}
               >
                 취소
               </button>
-              <button 
-                className={styles.modalConfirmBtn}
-                onClick={handleVerify}
-              >
+              <button className={styles.modalConfirmBtn} onClick={handleVerify}>
                 {MODAL_MESSAGES.VERIFY.BUTTON}
               </button>
             </div>
@@ -311,12 +715,18 @@ export default function UserSettings() {
         </div>
       )}
 
-      {/* Delete Account Modal */}
+      {/* 탈퇴 Model */}
       {showDeleteModal && (
-        <div className={styles.modalOverlay} onClick={() => setShowDeleteModal(false)}>
-          <div className={styles.modalContent} onClick={(e) => e.stopPropagation()}>
-            <button 
-              className={styles.modalCloseBtn} 
+        <div
+          className={styles.modalOverlay}
+          onClick={() => setShowDeleteModal(false)}
+        >
+          <div
+            className={styles.modalContent}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <button
+              className={styles.modalCloseBtn}
               onClick={() => setShowDeleteModal(false)}
             >
               <X size={20} />
@@ -326,21 +736,23 @@ export default function UserSettings() {
             </div>
             <h2 className={styles.modalTitle}>{MODAL_MESSAGES.DELETE.TITLE}</h2>
             <p className={styles.modalText}>
-              {MODAL_MESSAGES.DELETE.DESCRIPTION.split('\n').map((line, i) => (
+              {MODAL_MESSAGES.DELETE.DESCRIPTION.split("\n").map((line, i) => (
                 <React.Fragment key={i}>
                   {i === 1 ? <strong>{line}</strong> : line}
-                  {i < MODAL_MESSAGES.DELETE.DESCRIPTION.split('\n').length - 1 && <br />}
+                  {i <
+                    MODAL_MESSAGES.DELETE.DESCRIPTION.split("\n").length -
+                      1 && <br />}
                 </React.Fragment>
               ))}
             </p>
             <div className={styles.modalButtons}>
-              <button 
+              <button
                 className={styles.modalCancelBtn}
                 onClick={() => setShowDeleteModal(false)}
               >
                 취소
               </button>
-              <button 
+              <button
                 className={styles.modalDangerBtn}
                 onClick={handleDeleteAccount}
               >

--- a/src/styles/user/UserSetting.module.css
+++ b/src/styles/user/UserSetting.module.css
@@ -1,13 +1,15 @@
-/* styles/user/UserSetting.module.css */
-
-/* === Page === */
 .page {
   width: 100%;
   min-height: 100vh;
   background: #f5f5f5;
   display: flex;
   justify-content: center;
+  align-items: flex-start;
   padding: 3rem 1rem;
+
+  background-image: linear-gradient(#e5e7eb 1px, transparent 1px),
+    linear-gradient(90deg, #e5e7eb 1px, transparent 1px);
+  background-size: 40px 40px;
 }
 
 .ticket {
@@ -21,30 +23,9 @@
 
 /* === Header === */
 .header {
+  position: relative;
   text-align: center;
   margin-bottom: 2.5rem;
-  position: relative;
-}
-
-.homeButton {
-  position: absolute;
-  top: 0;
-  left: 0;
-  padding: 0.6rem;
-  background: white;
-  border: 2px solid black;
-  cursor: pointer;
-  transition: all 0.2s;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-family: monospace;
-}
-
-.homeButton:hover {
-  background: #fbbf24;
-  transform: translate(-2px, -2px);
-  box-shadow: 3px 3px 0 0 black;
 }
 
 .headerContent {
@@ -64,11 +45,33 @@
   margin-top: 0.5rem;
 }
 
+.closeButton {
+  position: absolute;
+  top: 0;
+  right: 0;
+  padding: 0.6rem;
+  background: white;
+  border: 2px solid black;
+  cursor: pointer;
+  transition: all 0.2s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.closeButton:hover {
+  background: #ff4d4d;
+  color: white;
+  transform: translate(-2px, -2px);
+  box-shadow: 3px 3px 0 0 black;
+}
+
 .verifiedBadge {
-  display: inline-flex;
+  position: absolute;
+  display: flex;
   align-items: center;
   gap: 6px;
-  margin-top: 12px;
+  margin-top: 10px;
   padding: 6px 12px;
   background: #e8f5e9;
   border: 2px solid #2e7d32;
@@ -76,6 +79,37 @@
   color: #2e7d32;
   font-size: 0.75rem;
   font-weight: 700;
+}
+
+/* === Tabs === */
+.tabContainer {
+  display: flex;
+  justify-content: center;
+  gap: 1.5rem;
+  margin-top: 1.5rem;
+  border-bottom: 2px solid #eee;
+  padding-bottom: 0.5rem;
+}
+
+.tabItem {
+  background: none;
+  border: none;
+  font-size: 1rem;
+  font-weight: 700;
+  color: #999;
+  cursor: pointer;
+  padding: 0.5rem 0.2rem;
+  font-family: monospace;
+  transition: all 0.2s;
+}
+
+.tabItem:hover {
+  color: black;
+}
+
+.activeTab {
+  color: black;
+  border-bottom: 3px solid black;
 }
 
 /* === Section === */
@@ -93,10 +127,17 @@
 }
 
 .sectionTitle::before {
-  content: '';
+  content: "";
   width: 4px;
   height: 20px;
   background: black;
+}
+
+.desc {
+  font-size: 0.85rem;
+  color: #666;
+  margin-bottom: 1rem;
+  line-height: 1.5;
 }
 
 /* === Profile Photo === */
@@ -128,10 +169,6 @@
   box-shadow: 4px 4px 0 0 black;
 }
 
-.avatar:hover .avatarOverlay {
-  opacity: 1;
-}
-
 .avatar img {
   width: 100%;
   height: 100%;
@@ -154,6 +191,10 @@
   transition: opacity 0.2s;
 }
 
+.avatar:hover .avatarOverlay {
+  opacity: 1;
+}
+
 .avatarInfo {
   display: flex;
   flex-direction: column;
@@ -168,7 +209,7 @@
   margin: 0;
 }
 
-/* === Grid === */
+/* === Grid / Inputs === */
 .grid {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
@@ -204,6 +245,8 @@
   font-family: monospace;
   font-weight: 600;
   transition: all 0.2s;
+  width: 100%;
+  box-sizing: border-box;
 }
 
 .input:focus {
@@ -212,18 +255,85 @@
   box-shadow: 3px 3px 0 0 black;
 }
 
-.ageDisplay {
-  font-size: 0.75rem;
+.inputLocked {
+  background-color: #f0f0f0 !important;
+  border-color: #ccc !important;
   color: #666;
-  margin-top: 4px;
-  font-weight: 600;
+  cursor: not-allowed;
+  transform: none !important;
+  box-shadow: none !important;
 }
 
-.desc {
-  font-size: 0.85rem;
-  color: #666;
-  margin-bottom: 1rem;
-  line-height: 1.5;
+.inputLocked:focus {
+  transform: none !important;
+  box-shadow: none !important;
+}
+
+/* 입력창 에러 */
+.inputError {
+  border-color: #d32f2f !important;
+  background-color: #fff9f9 !important;
+}
+
+.errorText {
+  font-size: 0.7rem;
+  color: #d32f2f;
+  margin-top: 4px;
+  font-weight: 700;
+  font-family: monospace;
+}
+
+/* === Autocomplete (MBTI) === */
+.autocompleteWrapper {
+  position: relative;
+  width: 100%;
+  display: flex;
+}
+
+.autocompleteWrapper .input {
+  width: 100%;
+}
+
+.suggestionList {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  background: white;
+  border: 2px solid black;
+  box-shadow: 4px 4px 0 0 black;
+  z-index: 50;
+  margin: 4px 0 0 0;
+  padding: 0;
+  list-style: none;
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.suggestionItem {
+  padding: 0.8rem;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  cursor: pointer;
+  border-bottom: 1px solid #eee;
+  font-family: monospace;
+  font-weight: 700;
+  transition: background 0.2s;
+}
+
+.suggestionItem:hover {
+  background: #fbbf24;
+}
+
+.clockIcon {
+  color: #ccc;
+  font-size: 0.8rem;
+}
+
+.deleteIcon {
+  margin-left: auto;
+  color: #ccc;
 }
 
 /* === Travel Styles === */
@@ -256,7 +366,7 @@
   box-shadow: 3px 3px 0 0 black;
 }
 
-.travelStyleBtn.active {
+.active {
   background: #fbbf24;
   color: black;
   transform: translate(-2px, -2px);
@@ -336,7 +446,316 @@
   cursor: not-allowed;
 }
 
-.saveButton.saving {
+.saving {
+  background: #fbbf24;
+  color: black;
+}
+
+/* === Account / Settings Wrapper === */
+.settingsWrapper {
+  width: 100%;
+}
+
+/* === Accordion === */
+.accordionHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  cursor: pointer;
+  padding: 0.5rem 0;
+  transition: opacity 0.2s;
+}
+
+.accordionHeader:hover {
+  opacity: 0.7;
+}
+
+.accordionHeader .sectionTitle {
+  margin-bottom: 0;
+}
+
+.accordionContent {
+  margin-top: 1rem;
+  animation: slideDown 0.3s ease-out;
+}
+
+@keyframes slideDown {
+  from {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* === Social / Settings Lists === */
+.socialStatusCard,
+.settingList {
+  border: 2px solid black;
+  background: white;
+  padding: 1rem;
+}
+
+.socialItem,
+.settingItem {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  padding: 0.8rem 0;
+}
+
+.settingItem:not(:last-child) {
+  border-bottom: 1px solid #eee;
+}
+
+.socialInfo {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+/* 텍스트 영역 */
+.socialText {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  text-align: left;
+}
+
+.socialName {
+  margin: 0;
+  font-weight: 900;
+  font-size: 0.9rem;
+  font-family: monospace;
+}
+
+.socialDetail {
+  margin: 0;
+  font-size: 0.8rem;
+  color: #666;
+  font-family: monospace;
+}
+
+.socialIcon {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: 2px solid black;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 900;
+  font-size: 1.2rem;
+}
+
+.kakao {
+  background-color: #fee500 !important;
+  color: #3c1e1e !important;
+}
+
+.connectionBadge {
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: #666;
+  background: #f0f0f0;
+  padding: 4px 8px;
+  border: 1px solid black;
+  margin-left: auto;
+  white-space: nowrap;
+}
+
+.notConnected {
+  background-color: #fce4ec !important;
+  color: #d81b60 !important;
+  border-color: #d81b60 !important;
+}
+
+/* === Toggle switch === */
+.privacyToggleArea {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding-top: 1rem;
+}
+
+.toggleRow {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  font-size: 0.85rem;
+  font-weight: 700;
+  padding: 0.4rem 0;
+}
+
+.switch {
+  position: relative;
+  display: inline-block;
+  width: 44px;
+  height: 24px;
+}
+
+.switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.slider {
+  position: absolute;
+  cursor: pointer;
+  inset: 0;
+  background-color: #eee;
+  border: 2px solid black;
+  transition: 0.2s;
+}
+
+.slider:before {
+  position: absolute;
+  content: "";
+  height: 14px;
+  width: 14px;
+  left: 3px;
+  bottom: 3px;
+  background-color: black;
+  transition: 0.2s;
+}
+
+.switch input:checked + .slider {
+  background-color: #fbbf24;
+}
+.switch input:checked + .slider:before {
+  transform: translateX(20px);
+}
+
+/* === Notification setting text === */
+.settingText {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.settingLabel {
+  font-size: 0.9rem;
+  font-weight: 800;
+  margin: 0;
+}
+
+.settingDesc {
+  font-size: 0.75rem;
+  color: #888;
+  margin: 0;
+}
+
+/* === Adult verify box === */
+.adultVerifyBox {
+  background: #fff0f0;
+  border: 2px solid black;
+  padding: 1.5rem;
+}
+
+.verifyTitle {
+  font-weight: 900;
+  margin-bottom: 0.5rem;
+  color: #d32f2f;
+}
+
+.verifyDesc {
+  font-size: 0.85rem;
+  line-height: 1.5;
+  margin-bottom: 1rem;
+}
+
+.confirmCheckboxArea {
+  margin-top: 0.8rem;
+}
+
+.legalWarning {
+  font-size: 0.75rem;
+  color: #666;
+  margin-top: 1rem;
+  font-style: italic;
+}
+
+/* Custom checkbox */
+.checkboxContainer {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  cursor: pointer;
+  font-weight: 700;
+  font-size: 0.9rem;
+}
+
+.checkboxContainer input {
+  display: none;
+}
+
+.checkboxLabel {
+  font-family: monospace;
+}
+
+.checkmark {
+  width: 20px;
+  height: 20px;
+  border: 2px solid black;
+  background: white;
+  position: relative;
+}
+
+.checkboxContainer input:checked ~ .checkmark {
+  background: #fbbf24;
+}
+
+.checkboxContainer input:checked ~ .checkmark:after {
+  content: "✔";
+  position: absolute;
+  left: 3px;
+  top: -2px;
+  font-size: 14px;
+}
+
+/* disabled styles */
+.checkboxContainer input:disabled ~ .checkboxLabel {
+  color: #999;
+  cursor: not-allowed;
+}
+.checkboxContainer input:disabled ~ .checkmark {
+  background-color: #eee;
+  border-color: #ccc;
+  cursor: not-allowed;
+}
+
+/* === Support === */
+.supportGrid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+}
+
+.supportBtn,
+.supportBtnPrimary {
+  padding: 0.8rem;
+  border: 2px solid black;
+  font-family: monospace;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.supportBtn {
+  background: white;
+}
+
+.supportBtnPrimary {
+  background: black;
+  color: white;
+  grid-column: span 2;
+}
+
+.supportBtnPrimary:hover {
   background: #fbbf24;
   color: black;
 }
@@ -368,13 +787,90 @@
   box-shadow: 5px 5px 0 0 #d32f2f;
 }
 
+/* === Report tab === */
+.reportSummary {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.statusBox {
+  flex: 1;
+  padding: 1rem;
+  border: 2px solid black;
+  text-align: center;
+}
+
+.statusLabel {
+  display: block;
+  font-size: 0.75rem;
+  color: #666;
+  margin-bottom: 0.5rem;
+}
+
+.statusValue {
+  font-size: 1.1rem;
+  font-weight: 900;
+}
+
+.reportTable {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: monospace;
+  font-size: 0.85rem;
+}
+
+.reportTable th,
+.reportTable td {
+  border: 1px solid #ddd;
+  padding: 0.8rem;
+  text-align: center;
+}
+
+.reportTable th {
+  background: #f5f5f5;
+  font-weight: 800;
+}
+
+.guideCard {
+  background: #fff9db;
+  border: 2px solid black;
+  padding: 1.5rem;
+}
+
+.guideList {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 1.5rem 0;
+}
+
+.guideList li {
+  font-size: 0.9rem;
+  margin-bottom: 0.6rem;
+  line-height: 1.4;
+}
+
+.importantNote {
+  border-top: 2px dashed black;
+  padding-top: 1rem;
+  color: #d32f2f;
+}
+
+.noteTitle {
+  font-weight: 900;
+  font-size: 0.95rem;
+  margin-bottom: 0.5rem;
+}
+
+.noteText {
+  font-size: 0.85rem;
+  line-height: 1.6;
+}
+
 /* === Modal === */
 .modalOverlay {
   position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
+  inset: 0;
   background: rgba(0, 0, 0, 0.5);
   display: flex;
   align-items: center;


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #47

---

## 🎨 작업 내용 (What)
* **디자인 시스템 적용**: 네오 브루탈리즘 스타일의 테두리, 그림자, 체크무늬 배경 패턴 적용
* **헤더 UI 개편**: 좌측 상단 '본인 인증 배지'와 우측 상단 '닫기(X)' 버튼 대칭 배치
* **탭 기능 구현**: '내 정보', '계정/설정', '신고 관리' 3개 탭 분리 및 전환 로직 추가
* **입력 유효성 검사**: 닉네임 필수 입력 및 16종 MBTI 자동 완성/유효성 검사 로직 구현
* **데이터 보호 시스템**: 
    * 변경사항 미저장 시 이탈 방지 얼럿(`beforeunload`) 추가
    * 소셜 연동 데이터(이름, 성별 등) 수정 불가(`readOnly`) 및 시각적 잠금 처리
    * 초기 생성 아바타 `localStorage` 즉시 저장으로 새로고침 시 상태 유지

---

## 🧭 작업 목적 (Why)
* 네오 브루탈리즘 스타일 적용을 통한 서비스 브랜드 정체성 확립 및 시각적 차별화
* 사용자 개인정보(나이, 성별 등) 노출 범위를 직접 제어할 수 있는 세부 설정 기능 제공
* 데이터 유실 방지 및 필수 정보 입력 유도 로직을 통해 서비스 데이터 무결성 확보

---

## 🧩 변경 범위
- [x] UI / Layout
- [x] 컴포넌트
- [x] 상태 관리
- [ ] API 연동 (추후 서버 연동 예정)
- [x] 스타일(CSS/Styled)

---

## 🧪 테스트 방법
- [x] 로컬 실행 및 탭 전환 동작 확인
- [x] 닉네임 미입력 및 MBTI 유효성 검사에 따른 저장 버튼 활성화 여부 확인
- [x] 데이터 수정 후 저장하지 않고 이탈 시 경고창 발생 확인
- [x] 회원 탈퇴 시 `localStorage` 및 `profile state` 초기화 정상 여부 확인

---

## ⚠️ 참고 사항
* MBTI 입력 시 대문자로 자동 변환되며, 4자리 미만 또는 16종 외 유형 입력 시 경고 문구가 노출됩니다.
* '계정 관리' 및 '알림 설정' 섹션은 기본적으로 접혀(Collapsed) 있으며, 성인 인증 섹션은 중요 정보로 판단하여 상시 노출됩니다.

---

## ✅ 체크리스트
- [x] main 브랜치 직접 push 하지 않음
- [x] feature 브랜치에서 작업함
- [x] 불필요한 console.log 제거
- [x] PR 단위가 과도하게 크지 않음
