### PR TITLE
[FE] feature: 설정 페이지 스타일 개선 및 항목 확장

### DIFF
--- a/src/components/user/User.constant.ts
+++ b/src/components/user/User.constant.ts
@@ -1,88 +1,158 @@
 // constants/user.constants.ts
 
 export const STORAGE_KEYS = {
-  USER_PROFILE: 'tripmoa_user_profile',
+  USER_PROFILE: "tripmoa_user_profile",
 } as const;
 
-export const GENDERS = ['남성', '여성', '기타'] as const;
+export const GENDERS = ["남성", "여성", "기타"] as const;
 
 export const MBTI_TYPES = [
-  'INTJ', 'INTP', 'ENTJ', 'ENTP',
-  'INFJ', 'INFP', 'ENFJ', 'ENFP',
-  'ISTJ', 'ISFJ', 'ESTJ', 'ESFJ',
-  'ISTP', 'ISFP', 'ESTP', 'ESFP'
+  "INTJ",
+  "INTP",
+  "ENTJ",
+  "ENTP",
+  "INFJ",
+  "INFP",
+  "ENFJ",
+  "ENFP",
+  "ISTJ",
+  "ISFJ",
+  "ESTJ",
+  "ESFJ",
+  "ISTP",
+  "ISFP",
+  "ESTP",
+  "ESFP",
 ] as const;
 
 export const TRAVEL_STYLES = [
-  '맛집탐방',
-  '액티비티', 
-  '힐링',
-  '문화탐방',
-  '쇼핑',
-  '자연',
-  '사진',
-  '야경',
-  '로컬체험',
-  '카페투어',
-  '축제',
-  '역사탐방',
-  '야외활동',
-  '미식투어',
-  '럭셔리',
-  '배낭여행'
+  "맛집탐방",
+  "액티비티",
+  "힐링",
+  "문화탐방",
+  "쇼핑",
+  "자연",
+  "사진",
+  "야경",
+  "로컬체험",
+  "카페투어",
+  "축제",
+  "역사탐방",
+  "야외활동",
+  "미식투어",
+  "럭셔리",
+  "배낭여행",
 ] as const;
 
 // 랜덤 아바타용 이모지
 export const AVATAR_EMOJIS = [
-  '😊', '🎉', '✈️', '🌍', '📸', '🎒', '🗺️', '🌟',
-  '🎨', '🎭', '🎪', '🎯', '🎸', '🎺', '🎬', '🎮',
-  '⚽', '🏀', '🎾', '🏐', '🏈', '⚾', '🥎', '🏉',
-  '🌸', '🌺', '🌻', '🌷', '🌹', '🌼', '🌿', '🍀',
-  '⭐', '🌙', '☀️', '🌈', '⚡', '❄️', '🔥', '💎'
+  "😊",
+  "🎉",
+  "✈️",
+  "🌍",
+  "📸",
+  "🎒",
+  "🗺️",
+  "🌟",
+  "🎨",
+  "🎭",
+  "🎪",
+  "🎯",
+  "🎸",
+  "🎺",
+  "🎬",
+  "🎮",
+  "⚽",
+  "🏀",
+  "🎾",
+  "🏐",
+  "🏈",
+  "⚾",
+  "🥎",
+  "🏉",
+  "🌸",
+  "🌺",
+  "🌻",
+  "🌷",
+  "🌹",
+  "🌼",
+  "🌿",
+  "🍀",
+  "⭐",
+  "🌙",
+  "☀️",
+  "🌈",
+  "⚡",
+  "❄️",
+  "🔥",
+  "💎",
 ] as const;
 
 // 랜덤 아바타용 배경색
 export const AVATAR_COLORS = [
-  '#FFE5E5', '#FFE5CC', '#FFF4CC', '#E5F5E5', 
-  '#E5F0FF', '#F0E5FF', '#FFE5F5', '#FFEBE5',
-  '#FFD4D4', '#FFD4B8', '#FFEAB8', '#D4F0D4',
-  '#D4E5FF', '#E5D4FF', '#FFD4F0', '#FFD9C8',
-  '#FEC6C6', '#FEC6A3', '#FFDEA3', '#C6E8C6',
-  '#C6DAFF', '#DAC6FF', '#FFC6E8', '#FFC8B8'
+  "#FFE5E5",
+  "#FFE5CC",
+  "#FFF4CC",
+  "#E5F5E5",
+  "#E5F0FF",
+  "#F0E5FF",
+  "#FFE5F5",
+  "#FFEBE5",
+  "#FFD4D4",
+  "#FFD4B8",
+  "#FFEAB8",
+  "#D4F0D4",
+  "#D4E5FF",
+  "#E5D4FF",
+  "#FFD4F0",
+  "#FFD9C8",
+  "#FEC6C6",
+  "#FEC6A3",
+  "#FFDEA3",
+  "#C6E8C6",
+  "#C6DAFF",
+  "#DAC6FF",
+  "#FFC6E8",
+  "#FFC8B8",
 ] as const;
 
 export const DEFAULT_PROFILE = {
-  photo: '',
-  nickname: '',
-  name: '',
-  birthDate: '',
-  gender: '',
-  mbti: '',
+  photo: "",
+  nickname: "",
+  name: "",
+  birthDate: "",
+  gender: "",
+  mbti: "",
   travelStyles: [] as string[],
   isVerified: false,
 } as const;
 
+// 모달 내용
 export const MODAL_MESSAGES = {
   VERIFY: {
-    TITLE: '본인 인증',
-    DESCRIPTION: '실제 서비스에서는 휴대폰 인증, 아이핀 인증 등이 진행됩니다.\n데모에서는 바로 인증이 완료됩니다.',
-    BUTTON: '인증하기',
-    SUCCESS: '✅ 본인 인증이 완료되었습니다!',
+    TITLE: "본인 인증",
+    DESCRIPTION:
+      "실제 서비스에서는 휴대폰 인증, 아이핀 인증 등이 진행됩니다.\n데모에서는 바로 인증이 완료됩니다.",
+    BUTTON: "인증하기",
+    SUCCESS: "✅ 본인 인증이 완료되었습니다!",
   },
   DELETE: {
-    TITLE: '계정을 탈퇴하시겠습니까?',
-    DESCRIPTION: '모든 여행 기록, 메이트 정보, 채팅 내역이 영구적으로 삭제됩니다.\n이 작업은 되돌릴 수 없습니다.',
-    BUTTON: '탈퇴하기',
-    SUCCESS: '계정이 탈퇴되었습니다. 그동안 이용해주셔서 감사합니다.',
+    TITLE: "계정을 탈퇴하시겠습니까?",
+    DESCRIPTION:
+      "모든 여행 기록, 채팅 내역이 영구적으로 삭제됩니다.\n이 작업은 되돌릴 수 없습니다.",
+    BUTTON: "탈퇴하기",
+    SUCCESS: "계정이 탈퇴되었습니다. 그동안 이용해주셔서 감사합니다.",
   },
   SAVE: {
-    SUCCESS: '✅ 프로필이 저장되었습니다!',
+    SUCCESS: "✅ 프로필이 저장되었습니다!",
   },
 } as const;
 
 // 랜덤 아바타 생성 함수
 export function generateRandomAvatar(): { emoji: string; color: string } {
-  const randomEmoji = AVATAR_EMOJIS[Math.floor(Math.random() * AVATAR_EMOJIS.length)];
-  const randomColor = AVATAR_COLORS[Math.floor(Math.random() * AVATAR_COLORS.length)];
+  const randomEmoji =
+    AVATAR_EMOJIS[Math.floor(Math.random() * AVATAR_EMOJIS.length)];
+  const randomColor =
+    AVATAR_COLORS[Math.floor(Math.random() * AVATAR_COLORS.length)];
   return { emoji: randomEmoji, color: randomColor };
 }

--- a/src/hooks/useUserSetting.ts
+++ b/src/hooks/useUserSetting.ts
@@ -1,54 +1,93 @@
-// hooks/useUserProfile.ts
+import { useState, useEffect, useRef } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  STORAGE_KEYS,
+  DEFAULT_PROFILE,
+  generateRandomAvatar,
+} from "../components/user/User.constant";
 
-import { useState, useEffect, useRef } from 'react';
-import { STORAGE_KEYS, DEFAULT_PROFILE, generateRandomAvatar } from '../components/user/User.constant';
+// 유효한 MBTI 목록 정의
+const VALID_MBTI = [
+  "INTJ",
+  "INTP",
+  "ENTJ",
+  "ENTP",
+  "INFJ",
+  "INFP",
+  "ENFJ",
+  "ENFP",
+  "ISTJ",
+  "ISFJ",
+  "ESTJ",
+  "ESFJ",
+  "ISTP",
+  "ISFP",
+  "ESTP",
+  "ESFP",
+];
 
 export interface UserProfile {
   photo: string;
   nickname: string;
   name: string;
-  birthDate: string; // YYYY-MM-DD 형식
+  notificationEmail: string;
+  birthDate: string;
   gender: string;
   mbti: string;
   travelStyles: string[];
   isVerified: boolean;
-  avatarEmoji?: string; // 기본 아바타용
-  avatarColor?: string; // 기본 아바타용
+  avatarEmoji?: string;
+  avatarColor?: string;
+
+  // 입력 필드
+  email?: string; // 소셜 로그인 이메일
+  isPrivateName: boolean; // 이름 비공개 여부 추가
+  isPrivateAge: boolean; // 나이 비공개 여부 추가
+  isPrivateGender: boolean; // 성별 비공개 여부 추가
+  isAdultConfirmed: boolean; // 성인 인증 확인 여부
+
+  // 알림 설정 필드
+  tripAlert: boolean; // 여행 일정 알림
+  marketingAgreed: boolean; // 마케팅 수신 동의
+  emailAgreed: boolean; // 이메일 수신 동의
+
+  // 동적 키 접근을 위한 인덱스 시그니처 추가
+  [key: string]: any;
 }
 
 export function useUserProfile() {
   const [profile, setProfile] = useState<UserProfile>(() => {
+    const saved = localStorage.getItem(STORAGE_KEYS.USER_PROFILE);
+    if (saved) return JSON.parse(saved);
+
+    // 데이터가 없을 때만 생성하고 즉시 저장
     const { emoji, color } = generateRandomAvatar();
-    return { 
-      ...DEFAULT_PROFILE, 
-      travelStyles: [],
+    const initialProfile = {
+      ...DEFAULT_PROFILE,
       avatarEmoji: emoji,
-      avatarColor: color
+      avatarColor: color,
+      notificationEmail: "",
+      isPrivateName: false,
+      isPrivateAge: false,
+      isPrivateGender: false,
+      isAdultConfirmed: false,
+      tripAlert: true,
+      marketingAgreed: false,
+      emailAgreed: false,
     };
+
+    // 즉시 저장하여 새로고침 시 고정
+    localStorage.setItem(
+      STORAGE_KEYS.USER_PROFILE,
+      JSON.stringify(initialProfile)
+    );
+    return initialProfile;
   });
-  
+
+  const navigate = useNavigate();
   const [hasChanges, setHasChanges] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
-
-  // 로컬스토리지에서 불러오기
-  useEffect(() => {
-    const saved = localStorage.getItem(STORAGE_KEYS.USER_PROFILE);
-    if (saved) {
-      try {
-        const parsedProfile = JSON.parse(saved);
-        // 기존 프로필에 avatarEmoji/Color가 없으면 생성
-        if (!parsedProfile.avatarEmoji || !parsedProfile.avatarColor) {
-          const { emoji, color } = generateRandomAvatar();
-          parsedProfile.avatarEmoji = emoji;
-          parsedProfile.avatarColor = color;
-        }
-        setProfile(parsedProfile);
-      } catch (error) {
-        console.error('프로필 불러오기 실패:', error);
-      }
-    }
-  }, []);
 
   // 변경사항 감지
   useEffect(() => {
@@ -59,7 +98,7 @@ export function useUserProfile() {
 
   // 프로필 업데이트
   const updateProfile = (updates: Partial<UserProfile>) => {
-    setProfile(prev => ({ ...prev, ...updates }));
+    setProfile((prev) => ({ ...prev, ...updates }));
   };
 
   // 프로필 저장
@@ -67,7 +106,10 @@ export function useUserProfile() {
     setIsSaving(true);
     return new Promise((resolve) => {
       setTimeout(() => {
-        localStorage.setItem(STORAGE_KEYS.USER_PROFILE, JSON.stringify(profile));
+        localStorage.setItem(
+          STORAGE_KEYS.USER_PROFILE,
+          JSON.stringify(profile)
+        );
         setHasChanges(false);
         setIsSaving(false);
         resolve();
@@ -96,7 +138,7 @@ export function useUserProfile() {
   const toggleTravelStyle = (style: string) => {
     const styles = profile.travelStyles || [];
     if (styles.includes(style)) {
-      updateProfile({ travelStyles: styles.filter(s => s !== style) });
+      updateProfile({ travelStyles: styles.filter((s) => s !== style) });
     } else {
       updateProfile({ travelStyles: [...styles, style] });
     }
@@ -112,16 +154,42 @@ export function useUserProfile() {
     });
   };
 
+  // 아바타 랜덤 변경
+  const regenerateAvatar = () => {
+    const { emoji, color } = generateRandomAvatar();
+    updateProfile({
+      avatarEmoji: emoji,
+      avatarColor: color,
+      photo: "",
+    });
+  };
+
   // 계정 탈퇴
   const deleteAccount = () => {
     localStorage.removeItem(STORAGE_KEYS.USER_PROFILE);
+
     const { emoji, color } = generateRandomAvatar();
-    setProfile({ 
-      ...DEFAULT_PROFILE, 
+
+    // 모든 상태 초기화
+    setProfile({
+      ...DEFAULT_PROFILE,
       travelStyles: [],
       avatarEmoji: emoji,
-      avatarColor: color
+      avatarColor: color,
+
+      email: "",
+      notificationEmail: "",
+      isPrivateName: false,
+      isPrivateAge: false,
+      isPrivateGender: false,
+      isAdultConfirmed: false,
+      tripAlert: true,
+      marketingAgreed: false,
+      emailAgreed: false,
     });
+
+    // 홈화면 이동
+    navigate("/");
   };
 
   // 나이 계산
@@ -131,19 +199,22 @@ export function useUserProfile() {
     const birth = new Date(birthDate);
     let age = today.getFullYear() - birth.getFullYear();
     const monthDiff = today.getMonth() - birth.getMonth();
-    if (monthDiff < 0 || (monthDiff === 0 && today.getDate() < birth.getDate())) {
+    if (
+      monthDiff < 0 ||
+      (monthDiff === 0 && today.getDate() < birth.getDate())
+    ) {
       age--;
     }
     return age;
   };
 
-  // 폼 유효성 검사
-  const isFormValid = !!(
-    profile.nickname && 
-    profile.name && 
-    profile.birthDate && 
-    profile.gender
-  );
+  // MBTI 유효성 검사: 비어있거나, 4글자이면서 유효 목록에 포함되어야 함
+  const isMBTIValid =
+    !profile.mbti ||
+    (profile.mbti.length === 4 && VALID_MBTI.includes(profile.mbti));
+
+  // 닉네임 필수, MBTI 입력할 경우에만 유효성 체크
+  const isFormValid = !!profile.nickname && isMBTIValid;
 
   const age = calculateAge(profile.birthDate);
 
@@ -153,6 +224,7 @@ export function useUserProfile() {
     hasChanges,
     isSaving,
     isFormValid,
+    VALID_MBTI,
     fileInputRef,
     age,
 
@@ -165,5 +237,6 @@ export function useUserProfile() {
     verify,
     deleteAccount,
     calculateAge,
+    regenerateAvatar,
   };
 }

--- a/src/styles/user/UserSetting.module.css
+++ b/src/styles/user/UserSetting.module.css
@@ -1,13 +1,15 @@
-/* styles/user/UserSetting.module.css */
-
-/* === Page === */
 .page {
   width: 100%;
   min-height: 100vh;
   background: #f5f5f5;
   display: flex;
   justify-content: center;
+  align-items: flex-start;
   padding: 3rem 1rem;
+
+  background-image: linear-gradient(#e5e7eb 1px, transparent 1px),
+    linear-gradient(90deg, #e5e7eb 1px, transparent 1px);
+  background-size: 40px 40px;
 }
 
 .ticket {
@@ -21,30 +23,9 @@
 
 /* === Header === */
 .header {
+  position: relative;
   text-align: center;
   margin-bottom: 2.5rem;
-  position: relative;
-}
-
-.homeButton {
-  position: absolute;
-  top: 0;
-  left: 0;
-  padding: 0.6rem;
-  background: white;
-  border: 2px solid black;
-  cursor: pointer;
-  transition: all 0.2s;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-family: monospace;
-}
-
-.homeButton:hover {
-  background: #fbbf24;
-  transform: translate(-2px, -2px);
-  box-shadow: 3px 3px 0 0 black;
 }
 
 .headerContent {
@@ -64,11 +45,33 @@
   margin-top: 0.5rem;
 }
 
+.closeButton {
+  position: absolute;
+  top: 0;
+  right: 0;
+  padding: 0.6rem;
+  background: white;
+  border: 2px solid black;
+  cursor: pointer;
+  transition: all 0.2s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.closeButton:hover {
+  background: #ff4d4d;
+  color: white;
+  transform: translate(-2px, -2px);
+  box-shadow: 3px 3px 0 0 black;
+}
+
 .verifiedBadge {
-  display: inline-flex;
+  position: absolute;
+  display: flex;
   align-items: center;
   gap: 6px;
-  margin-top: 12px;
+  margin-top: 10px;
   padding: 6px 12px;
   background: #e8f5e9;
   border: 2px solid #2e7d32;
@@ -76,6 +79,37 @@
   color: #2e7d32;
   font-size: 0.75rem;
   font-weight: 700;
+}
+
+/* === Tabs === */
+.tabContainer {
+  display: flex;
+  justify-content: center;
+  gap: 1.5rem;
+  margin-top: 1.5rem;
+  border-bottom: 2px solid #eee;
+  padding-bottom: 0.5rem;
+}
+
+.tabItem {
+  background: none;
+  border: none;
+  font-size: 1rem;
+  font-weight: 700;
+  color: #999;
+  cursor: pointer;
+  padding: 0.5rem 0.2rem;
+  font-family: monospace;
+  transition: all 0.2s;
+}
+
+.tabItem:hover {
+  color: black;
+}
+
+.activeTab {
+  color: black;
+  border-bottom: 3px solid black;
 }
 
 /* === Section === */
@@ -93,10 +127,17 @@
 }
 
 .sectionTitle::before {
-  content: '';
+  content: "";
   width: 4px;
   height: 20px;
   background: black;
+}
+
+.desc {
+  font-size: 0.85rem;
+  color: #666;
+  margin-bottom: 1rem;
+  line-height: 1.5;
 }
 
 /* === Profile Photo === */
@@ -128,10 +169,6 @@
   box-shadow: 4px 4px 0 0 black;
 }
 
-.avatar:hover .avatarOverlay {
-  opacity: 1;
-}
-
 .avatar img {
   width: 100%;
   height: 100%;
@@ -154,6 +191,10 @@
   transition: opacity 0.2s;
 }
 
+.avatar:hover .avatarOverlay {
+  opacity: 1;
+}
+
 .avatarInfo {
   display: flex;
   flex-direction: column;
@@ -168,7 +209,7 @@
   margin: 0;
 }
 
-/* === Grid === */
+/* === Grid / Inputs === */
 .grid {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
@@ -204,6 +245,8 @@
   font-family: monospace;
   font-weight: 600;
   transition: all 0.2s;
+  width: 100%;
+  box-sizing: border-box;
 }
 
 .input:focus {
@@ -212,18 +255,85 @@
   box-shadow: 3px 3px 0 0 black;
 }
 
-.ageDisplay {
-  font-size: 0.75rem;
+.inputLocked {
+  background-color: #f0f0f0 !important;
+  border-color: #ccc !important;
   color: #666;
-  margin-top: 4px;
-  font-weight: 600;
+  cursor: not-allowed;
+  transform: none !important;
+  box-shadow: none !important;
 }
 
-.desc {
-  font-size: 0.85rem;
-  color: #666;
-  margin-bottom: 1rem;
-  line-height: 1.5;
+.inputLocked:focus {
+  transform: none !important;
+  box-shadow: none !important;
+}
+
+/* 입력창 에러 */
+.inputError {
+  border-color: #d32f2f !important;
+  background-color: #fff9f9 !important;
+}
+
+.errorText {
+  font-size: 0.7rem;
+  color: #d32f2f;
+  margin-top: 4px;
+  font-weight: 700;
+  font-family: monospace;
+}
+
+/* === Autocomplete (MBTI) === */
+.autocompleteWrapper {
+  position: relative;
+  width: 100%;
+  display: flex;
+}
+
+.autocompleteWrapper .input {
+  width: 100%;
+}
+
+.suggestionList {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  background: white;
+  border: 2px solid black;
+  box-shadow: 4px 4px 0 0 black;
+  z-index: 50;
+  margin: 4px 0 0 0;
+  padding: 0;
+  list-style: none;
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.suggestionItem {
+  padding: 0.8rem;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  cursor: pointer;
+  border-bottom: 1px solid #eee;
+  font-family: monospace;
+  font-weight: 700;
+  transition: background 0.2s;
+}
+
+.suggestionItem:hover {
+  background: #fbbf24;
+}
+
+.clockIcon {
+  color: #ccc;
+  font-size: 0.8rem;
+}
+
+.deleteIcon {
+  margin-left: auto;
+  color: #ccc;
 }
 
 /* === Travel Styles === */
@@ -256,7 +366,7 @@
   box-shadow: 3px 3px 0 0 black;
 }
 
-.travelStyleBtn.active {
+.active {
   background: #fbbf24;
   color: black;
   transform: translate(-2px, -2px);
@@ -336,7 +446,316 @@
   cursor: not-allowed;
 }
 
-.saveButton.saving {
+.saving {
+  background: #fbbf24;
+  color: black;
+}
+
+/* === Account / Settings Wrapper === */
+.settingsWrapper {
+  width: 100%;
+}
+
+/* === Accordion === */
+.accordionHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  cursor: pointer;
+  padding: 0.5rem 0;
+  transition: opacity 0.2s;
+}
+
+.accordionHeader:hover {
+  opacity: 0.7;
+}
+
+.accordionHeader .sectionTitle {
+  margin-bottom: 0;
+}
+
+.accordionContent {
+  margin-top: 1rem;
+  animation: slideDown 0.3s ease-out;
+}
+
+@keyframes slideDown {
+  from {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* === Social / Settings Lists === */
+.socialStatusCard,
+.settingList {
+  border: 2px solid black;
+  background: white;
+  padding: 1rem;
+}
+
+.socialItem,
+.settingItem {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  padding: 0.8rem 0;
+}
+
+.settingItem:not(:last-child) {
+  border-bottom: 1px solid #eee;
+}
+
+.socialInfo {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+/* 텍스트 영역 */
+.socialText {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  text-align: left;
+}
+
+.socialName {
+  margin: 0;
+  font-weight: 900;
+  font-size: 0.9rem;
+  font-family: monospace;
+}
+
+.socialDetail {
+  margin: 0;
+  font-size: 0.8rem;
+  color: #666;
+  font-family: monospace;
+}
+
+.socialIcon {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: 2px solid black;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 900;
+  font-size: 1.2rem;
+}
+
+.kakao {
+  background-color: #fee500 !important;
+  color: #3c1e1e !important;
+}
+
+.connectionBadge {
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: #666;
+  background: #f0f0f0;
+  padding: 4px 8px;
+  border: 1px solid black;
+  margin-left: auto;
+  white-space: nowrap;
+}
+
+.notConnected {
+  background-color: #fce4ec !important;
+  color: #d81b60 !important;
+  border-color: #d81b60 !important;
+}
+
+/* === Toggle switch === */
+.privacyToggleArea {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding-top: 1rem;
+}
+
+.toggleRow {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  font-size: 0.85rem;
+  font-weight: 700;
+  padding: 0.4rem 0;
+}
+
+.switch {
+  position: relative;
+  display: inline-block;
+  width: 44px;
+  height: 24px;
+}
+
+.switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.slider {
+  position: absolute;
+  cursor: pointer;
+  inset: 0;
+  background-color: #eee;
+  border: 2px solid black;
+  transition: 0.2s;
+}
+
+.slider:before {
+  position: absolute;
+  content: "";
+  height: 14px;
+  width: 14px;
+  left: 3px;
+  bottom: 3px;
+  background-color: black;
+  transition: 0.2s;
+}
+
+.switch input:checked + .slider {
+  background-color: #fbbf24;
+}
+.switch input:checked + .slider:before {
+  transform: translateX(20px);
+}
+
+/* === Notification setting text === */
+.settingText {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.settingLabel {
+  font-size: 0.9rem;
+  font-weight: 800;
+  margin: 0;
+}
+
+.settingDesc {
+  font-size: 0.75rem;
+  color: #888;
+  margin: 0;
+}
+
+/* === Adult verify box === */
+.adultVerifyBox {
+  background: #fff0f0;
+  border: 2px solid black;
+  padding: 1.5rem;
+}
+
+.verifyTitle {
+  font-weight: 900;
+  margin-bottom: 0.5rem;
+  color: #d32f2f;
+}
+
+.verifyDesc {
+  font-size: 0.85rem;
+  line-height: 1.5;
+  margin-bottom: 1rem;
+}
+
+.confirmCheckboxArea {
+  margin-top: 0.8rem;
+}
+
+.legalWarning {
+  font-size: 0.75rem;
+  color: #666;
+  margin-top: 1rem;
+  font-style: italic;
+}
+
+/* Custom checkbox */
+.checkboxContainer {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  cursor: pointer;
+  font-weight: 700;
+  font-size: 0.9rem;
+}
+
+.checkboxContainer input {
+  display: none;
+}
+
+.checkboxLabel {
+  font-family: monospace;
+}
+
+.checkmark {
+  width: 20px;
+  height: 20px;
+  border: 2px solid black;
+  background: white;
+  position: relative;
+}
+
+.checkboxContainer input:checked ~ .checkmark {
+  background: #fbbf24;
+}
+
+.checkboxContainer input:checked ~ .checkmark:after {
+  content: "✔";
+  position: absolute;
+  left: 3px;
+  top: -2px;
+  font-size: 14px;
+}
+
+/* disabled styles */
+.checkboxContainer input:disabled ~ .checkboxLabel {
+  color: #999;
+  cursor: not-allowed;
+}
+.checkboxContainer input:disabled ~ .checkmark {
+  background-color: #eee;
+  border-color: #ccc;
+  cursor: not-allowed;
+}
+
+/* === Support === */
+.supportGrid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+}
+
+.supportBtn,
+.supportBtnPrimary {
+  padding: 0.8rem;
+  border: 2px solid black;
+  font-family: monospace;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.supportBtn {
+  background: white;
+}
+
+.supportBtnPrimary {
+  background: black;
+  color: white;
+  grid-column: span 2;
+}
+
+.supportBtnPrimary:hover {
   background: #fbbf24;
   color: black;
 }
@@ -368,13 +787,90 @@
   box-shadow: 5px 5px 0 0 #d32f2f;
 }
 
+/* === Report tab === */
+.reportSummary {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.statusBox {
+  flex: 1;
+  padding: 1rem;
+  border: 2px solid black;
+  text-align: center;
+}
+
+.statusLabel {
+  display: block;
+  font-size: 0.75rem;
+  color: #666;
+  margin-bottom: 0.5rem;
+}
+
+.statusValue {
+  font-size: 1.1rem;
+  font-weight: 900;
+}
+
+.reportTable {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: monospace;
+  font-size: 0.85rem;
+}
+
+.reportTable th,
+.reportTable td {
+  border: 1px solid #ddd;
+  padding: 0.8rem;
+  text-align: center;
+}
+
+.reportTable th {
+  background: #f5f5f5;
+  font-weight: 800;
+}
+
+.guideCard {
+  background: #fff9db;
+  border: 2px solid black;
+  padding: 1.5rem;
+}
+
+.guideList {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 1.5rem 0;
+}
+
+.guideList li {
+  font-size: 0.9rem;
+  margin-bottom: 0.6rem;
+  line-height: 1.4;
+}
+
+.importantNote {
+  border-top: 2px dashed black;
+  padding-top: 1rem;
+  color: #d32f2f;
+}
+
+.noteTitle {
+  font-weight: 900;
+  font-size: 0.95rem;
+  margin-bottom: 0.5rem;
+}
+
+.noteText {
+  font-size: 0.85rem;
+  line-height: 1.6;
+}
+
 /* === Modal === */
 .modalOverlay {
   position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
+  inset: 0;
   background: rgba(0, 0, 0, 0.5);
   display: flex;
   align-items: center;


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #47

---

## 🎨 작업 내용 (What)
* **디자인 시스템 적용**: 네오 브루탈리즘 스타일의 테두리, 그림자, 체크무늬 배경 패턴 적용
* **헤더 UI 개편**: 좌측 상단 '본인 인증 배지'와 우측 상단 '닫기(X)' 버튼 대칭 배치
* **탭 기능 구현**: '내 정보', '계정/설정', '신고 관리' 3개 탭 분리 및 전환 로직 추가
* **입력 유효성 검사**: 닉네임 필수 입력 및 16종 MBTI 자동 완성/유효성 검사 로직 구현
* **데이터 보호 시스템**: 
    * 변경사항 미저장 시 이탈 방지 얼럿(`beforeunload`) 추가
    * 소셜 연동 데이터(이름, 성별 등) 수정 불가(`readOnly`) 및 시각적 잠금 처리
    * 초기 생성 아바타 `localStorage` 즉시 저장으로 새로고침 시 상태 유지

---

## 🧭 작업 목적 (Why)
* 네오 브루탈리즘 스타일 적용을 통한 서비스 브랜드 정체성 확립 및 시각적 차별화
* 사용자 개인정보(나이, 성별 등) 노출 범위를 직접 제어할 수 있는 세부 설정 기능 제공
* 데이터 유실 방지 및 필수 정보 입력 유도 로직을 통해 서비스 데이터 무결성 확보

---

## 🧩 변경 범위
- [x] UI / Layout
- [x] 컴포넌트
- [x] 상태 관리
- [ ] API 연동 (추후 서버 연동 예정)
- [x] 스타일(CSS/Styled)

---

## 🧪 테스트 방법
- [x] 로컬 실행 및 탭 전환 동작 확인
- [x] 닉네임 미입력 및 MBTI 유효성 검사에 따른 저장 버튼 활성화 여부 확인
- [x] 데이터 수정 후 저장하지 않고 이탈 시 경고창 발생 확인
- [x] 회원 탈퇴 시 `localStorage` 및 `profile state` 초기화 정상 여부 확인

---

## ⚠️ 참고 사항
* MBTI 입력 시 대문자로 자동 변환되며, 4자리 미만 또는 16종 외 유형 입력 시 경고 문구가 노출됩니다.
* '계정 관리' 및 '알림 설정' 섹션은 기본적으로 접혀(Collapsed) 있으며, 성인 인증 섹션은 중요 정보로 판단하여 상시 노출됩니다.

---

## ✅ 체크리스트
- [x] main 브랜치 직접 push 하지 않음
- [x] feature 브랜치에서 작업함
- [x] 불필요한 console.log 제거
- [x] PR 단위가 과도하게 크지 않음
