### PR TITLE
[FE] refactor: TravelStory 전반 구조 정리 및 UI 로직 분리

### DIFF
--- a/src/components/travelStory/ConfirmModal.tsx
+++ b/src/components/travelStory/ConfirmModal.tsx
@@ -1,0 +1,127 @@
+interface ConfirmModalProps {
+  show: boolean;
+  title: string;
+  message: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+  confirmText?: string;
+  cancelText?: string;
+}
+
+function ConfirmModal({
+  show,
+  title,
+  message,
+  onConfirm,
+  onCancel,
+  confirmText = '확인',
+  cancelText = '취소'
+}: ConfirmModalProps) {
+  if (!show) return null;
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        background: 'rgba(0, 0, 0, 0.7)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 100000
+      }}
+      onClick={onCancel}
+    >
+      <div
+        style={{
+          background: '#fff',
+          border: '3px solid #000',
+          boxShadow: '15px 15px 0px #000',
+          width: '360px'
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* 헤더 */}
+        <div
+          style={{
+            background: '#000',
+            color: '#fff',
+            padding: '12px 20px'
+          }}
+        >
+          <span
+            style={{
+              fontFamily: "'Share Tech Mono', monospace",
+              fontSize: '16px',
+              fontWeight: 900,
+              letterSpacing: '1px'
+            }}
+          >
+            {title}
+          </span>
+        </div>
+
+        {/* 본문 */}
+        <div style={{ padding: '24px' }}>
+          <p
+            style={{
+              fontFamily: "'Share Tech Mono', monospace",
+              fontSize: '14px',
+              lineHeight: '1.6',
+              marginBottom: '24px',
+              whiteSpace: 'pre-line'
+            }}
+          >
+            {message}
+          </p>
+
+          {/* 버튼 */}
+          <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '10px' }}>
+            <button
+              onClick={onCancel}
+              style={{
+                border: '2px solid #000',
+                background: '#fff',
+                padding: '8px 16px',
+                fontWeight: 900,
+                fontSize: '12px',
+                fontFamily: "'Share Tech Mono', monospace",
+                cursor: 'pointer'
+              }}
+            >
+              {cancelText}
+            </button>
+            <button
+              onClick={onConfirm}
+              style={{
+                border: '2px solid #d00000',
+                background: '#fff',
+                color: '#d00000',
+                padding: '8px 16px',
+                fontWeight: 900,
+                fontSize: '12px',
+                fontFamily: "'Share Tech Mono', monospace",
+                cursor: 'pointer'
+              }}
+              onMouseEnter={(e) => {
+                e.currentTarget.style.background = '#d00000';
+                e.currentTarget.style.color = '#fff';
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.background = '#fff';
+                e.currentTarget.style.color = '#d00000';
+              }}
+            >
+              {confirmText}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default ConfirmModal;

--- a/src/components/travelStory/CustomAlert.tsx
+++ b/src/components/travelStory/CustomAlert.tsx
@@ -1,0 +1,86 @@
+interface CustomAlertProps {
+  show: boolean;
+  message: string;
+  onClose: () => void;
+}
+
+function CustomAlert({ show, message, onClose }: CustomAlertProps) {
+  if (!show || !message) return null;
+
+  return (
+    <div 
+      className="custom-alert" 
+      onClick={onClose}
+      style={{
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        background: 'rgba(0, 0, 0, 0.7)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 10000
+      }}
+    >
+      <div 
+        className="custom-alert-content" 
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          background: '#fff',
+          border: '3px solid #000',
+          padding: '35px 50px',
+          minWidth: '400px',
+          maxWidth: '500px',
+          textAlign: 'center',
+          boxShadow: '8px 8px 0px rgba(0, 0, 0, 1)'
+        }}
+      >
+        <div 
+          className="custom-alert-message"
+          style={{
+            fontSize: '14px',
+            fontWeight: 700,
+            fontFamily: "'Share Tech Mono', monospace",
+            color: '#000',
+            marginBottom: '25px',
+            lineHeight: 1.6
+          }}
+        >
+          {message}
+        </div>
+        <button 
+          className="custom-alert-btn" 
+          onClick={onClose}
+          style={{
+            background: '#000',
+            color: '#fff',
+            border: '3px solid #000',
+            padding: '10px 40px',
+            fontSize: '12px',
+            fontWeight: 700,
+            fontFamily: "'Share Tech Mono', monospace",
+            textTransform: 'uppercase',
+            letterSpacing: '1px',
+            cursor: 'pointer',
+            transition: 'all 0.2s',
+            boxShadow: '4px 4px 0px rgba(0, 0, 0, 1)'
+          }}
+          onMouseEnter={(e) => {
+            e.currentTarget.style.background = '#fff';
+            e.currentTarget.style.color = '#000';
+          }}
+          onMouseLeave={(e) => {
+            e.currentTarget.style.background = '#000';
+            e.currentTarget.style.color = '#fff';
+          }}
+        >
+          확인
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default CustomAlert;

--- a/src/components/travelStory/DeleteModal.tsx
+++ b/src/components/travelStory/DeleteModal.tsx
@@ -1,0 +1,123 @@
+interface DeleteModalProps {
+  show: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  title?: string;
+  message?: string;
+}
+
+function DeleteModal({ 
+  show, 
+  onClose, 
+  onConfirm,
+  title = '댓글 삭제',
+  message = '댓글을 삭제하시겠습니까?\n삭제된 댓글은 복구할 수 없습니다.'
+}: DeleteModalProps) {
+  if (!show) return null;
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        background: 'rgba(0, 0, 0, 0.7)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 100000
+      }}
+      onClick={onClose}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          background: '#fff',
+          border: '3px solid #000',
+          boxShadow: '15px 15px 0px #000',
+          width: '360px'
+        }}
+      >
+        {/* 헤더 */}
+        <div
+          style={{
+            background: '#000',
+            color: '#fff',
+            padding: '12px 20px'
+          }}
+        >
+          <span
+            style={{
+              fontFamily: "'Share Tech Mono', monospace",
+              fontSize: '16px',
+              fontWeight: 900,
+              letterSpacing: '1px'
+            }}
+          >
+            {title}
+          </span>
+        </div>
+
+        {/* 본문 */}
+        <div style={{ padding: '24px' }}>
+          <p
+            style={{
+              fontFamily: "'Share Tech Mono', monospace",
+              fontSize: '14px',
+              lineHeight: '1.6',
+              marginBottom: '24px',
+              whiteSpace: 'pre-line'
+            }}
+          >
+            {message}
+          </p>
+
+          {/* 버튼 */}
+          <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '10px' }}>
+            <button
+              onClick={onClose}
+              style={{
+                border: '2px solid #000',
+                background: '#fff',
+                padding: '8px 16px',
+                fontWeight: 900,
+                fontSize: '12px',
+                fontFamily: "'Share Tech Mono', monospace",
+                cursor: 'pointer'
+              }}
+            >
+              취소
+            </button>
+            <button
+              onClick={onConfirm}
+              style={{
+                border: '2px solid #d00000',
+                background: '#fff',
+                color: '#d00000',
+                padding: '8px 16px',
+                fontWeight: 900,
+                fontSize: '12px',
+                fontFamily: "'Share Tech Mono', monospace",
+                cursor: 'pointer'
+              }}
+              onMouseEnter={(e) => {
+                e.currentTarget.style.background = '#d00000';
+                e.currentTarget.style.color = '#fff';
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.background = '#fff';
+                e.currentTarget.style.color = '#d00000';
+              }}
+            >
+              삭제
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default DeleteModal;

--- a/src/components/travelStory/DetailPage.tsx
+++ b/src/components/travelStory/DetailPage.tsx
@@ -1,0 +1,527 @@
+import { useEffect, useState, useRef } from 'react';
+import CommentSection from './CommentSection';
+
+interface DetailPageProps {
+  story: any;
+  goBack: () => void;
+  likedStories: number[];
+  toggleLike: (id: number) => void;
+  followedStories: number[];
+  setFollowedStories: (ids: number[] | ((prev: number[]) => number[])) => void;
+  incrementViews: (id: number) => void;
+}
+
+function DetailPage({
+  story,
+  goBack,
+  likedStories,
+  toggleLike,
+  followedStories,
+  setFollowedStories,
+  incrementViews
+}: DetailPageProps) {
+  // 업로드한 이미지들만 사용 (커버 이미지 무시)
+  const images = (story.images && story.images.length > 0) ? story.images : [story.image];
+  const [likesCount, setLikesCount] = useState(story.likes);
+  const [followCount, setFollowCount] = useState(story.follows);
+  const [isLiked, setIsLiked] = useState(likedStories.includes(story.id));
+  const [isFollowed, setIsFollowed] = useState(followedStories.includes(story.id));
+  const hasIncrementedViews = useRef(false);
+
+  // story가 변경되면 카운트 업데이트
+  useEffect(() => {
+    setLikesCount(story.likes);
+    setFollowCount(story.follows);
+    setIsLiked(likedStories.includes(story.id));
+    setIsFollowed(followedStories.includes(story.id));
+  }, [story.likes, story.follows, story.id, likedStories, followedStories]);
+
+  // 조회수 증가 - DetailPage 마운트 시 1번만 (React Strict Mode 대응)
+  useEffect(() => {
+    if (!hasIncrementedViews.current) {
+      hasIncrementedViews.current = true;
+      incrementViews(story.id);
+    }
+  }, []);
+
+  // 슬라이더 버튼 이벤트 리스너
+  useEffect(() => {
+    // DOM이 완전히 렌더링된 후 실행
+    setTimeout(() => {
+      const sliders = document.querySelectorAll('.image-slider-wrapper');
+      
+      sliders.forEach(slider => {
+        const imagesContainer = slider.querySelector('.slider-images-container');
+        const prevBtn = slider.querySelector('.slider-prev-btn');
+        const nextBtn = slider.querySelector('.slider-next-btn');
+        const indicator = slider.querySelector('.slider-indicator');
+        
+        if (!imagesContainer) return;
+        
+        const images = Array.from(imagesContainer.querySelectorAll('img'));
+        if (images.length === 0) return;
+        
+        let currentIndex = 0;
+        
+        // 초기 상태: 첫 번째 이미지만 표시
+        images.forEach((img, idx) => {
+          const imgElement = img as HTMLElement;
+          imgElement.style.position = 'absolute';
+          imgElement.style.top = '0';
+          imgElement.style.left = '0';
+          imgElement.style.width = '100%';
+          imgElement.style.height = '100%';
+          imgElement.style.objectFit = 'cover';
+          imgElement.style.display = idx === 0 ? 'block' : 'none';
+        });
+        
+        // 이전 버튼
+        if (prevBtn) {
+          const handlePrev = (e: Event) => {
+            e.preventDefault();
+            e.stopPropagation();
+            images[currentIndex].style.display = 'none';
+            currentIndex = (currentIndex - 1 + images.length) % images.length;
+            images[currentIndex].style.display = 'block';
+            if (indicator) {
+              indicator.textContent = `${currentIndex + 1}/${images.length}`;
+            }
+          };
+          prevBtn.removeEventListener('click', handlePrev as EventListener);
+          prevBtn.addEventListener('click', handlePrev as EventListener);
+        }
+        
+        // 다음 버튼
+        if (nextBtn) {
+          const handleNext = (e: Event) => {
+            e.preventDefault();
+            e.stopPropagation();
+            images[currentIndex].style.display = 'none';
+            currentIndex = (currentIndex + 1) % images.length;
+            images[currentIndex].style.display = 'block';
+            if (indicator) {
+              indicator.textContent = `${currentIndex + 1}/${images.length}`;
+            }
+          };
+          nextBtn.removeEventListener('click', handleNext as EventListener);
+          nextBtn.addEventListener('click', handleNext as EventListener);
+        }
+      });
+    }, 100);
+  }, [story.content, story.description]);
+
+  return (
+    <div className="detail-page-container">
+      <div className="detail-page-content">
+
+        {/* ================= HEADER ================= */}
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'flex-start',
+            paddingBottom: '24px',
+            borderBottom: '2px solid #000',
+            marginBottom: '40px'
+          }}
+        >
+          {/* 왼쪽 */}
+          <div>
+            <h1
+              style={{
+                fontSize: '32px',
+                fontWeight: 700,
+                marginBottom: '10px',
+                fontFamily: "'Share Tech Mono', monospace"
+              }}
+            >
+              {story.title}
+            </h1>
+
+            <div style={{ display: 'flex', gap: '10px' }}>
+              {[story.destination, story.duration, `${parseInt(story.budget).toLocaleString()}원`].map(
+                (item) => (
+                  <div
+                    key={item}
+                    style={{
+                      padding: '6px 14px',
+                      border: '2px solid #000',
+                      background: '#f5f5f5',
+                      fontSize: '12px',
+                      fontWeight: 700,
+                      fontFamily: "'Share Tech Mono', monospace"
+                    }}
+                  >
+                    {item}
+                  </div>
+                )
+              )}
+            </div>
+          </div>
+
+          {/* 오른쪽 */}
+          <div style={{ position: 'relative', marginTop: '32px' }}>
+            <button
+              onClick={goBack}
+              style={{
+                position: 'absolute',
+                top: '-28px',
+                right: '0',
+                border: 'none',
+                background: 'transparent',
+                cursor: 'pointer'
+              }}
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                style={{ width: '28px', height: '28px', fill: '#000' }}
+              >
+                <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/>
+              </svg>
+            </button>
+
+            <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+              <div style={{ width: '40px', height: '40px', background: '#000' }} />
+              <div>
+                <div
+                  style={{
+                    fontWeight: 700,
+                    fontFamily: "'Share Tech Mono', monospace"
+                  }}
+                >
+                  {story.author}
+                </div>
+                <div
+                  style={{
+                    fontSize: '11px',
+                    color: '#999',
+                    lineHeight: '1.4',
+                    fontFamily: "'Share Tech Mono', monospace"
+                  }}
+                >
+                  {story.date}<br />
+                  {story.views} VIEWS
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        {/* ================= HEADER 끝 ================= */}
+
+        {/* 본문 내용 (슬라이더 포함) */}
+
+        {/* Description */}
+        <div
+          style={{
+            fontSize: '15px',
+            lineHeight: '1.8',
+            marginBottom: '40px',
+            fontFamily: "'Share Tech Mono', monospace"
+          }}
+          dangerouslySetInnerHTML={{ __html: story.description }}
+        />
+
+        {/* ================= 여행 경비 총정리 ================= */}
+        <div
+          style={{
+            maxWidth: '700px',
+            margin: '40px auto',
+            border: '2px solid #000',
+            padding: '20px',
+            background: '#fff'
+          }}
+        >
+          <h2
+            style={{
+              fontSize: '18px',
+              fontWeight: 700,
+              marginBottom: '12px',
+              fontFamily: "'Share Tech Mono', monospace"
+            }}
+          >
+            여행 경비 총정리
+          </h2>
+
+          {[
+            ['교통비 (렌터카)', '95,000원'],
+            ['숙박비', '85,000원'],
+            ['식비', '98,000원'],
+            ['관광/입장료', '15,000원'],
+            ['쇼핑/기타', '35,000원']
+          ].map(([label, price]) => (
+            <div
+              key={label}
+              style={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                padding: '10px 0',
+                borderBottom: '1px solid #ddd',
+                fontSize: '14px',
+                fontFamily: "'Share Tech Mono', monospace"
+              }}
+            >
+              <span>{label}</span>
+              <span style={{ fontWeight: 700 }}>{price}</span>
+            </div>
+          ))}
+
+          <div
+            style={{
+              marginTop: '16px',
+              background: '#000',
+              color: '#fff',
+              padding: '14px 16px',
+              display: 'flex',
+              justifyContent: 'space-between',
+              fontFamily: "'Share Tech Mono', monospace"
+            }}
+          >
+            <span style={{ fontWeight: 700 }}>총 합계</span>
+            <span style={{ fontWeight: 700 }}>328,000원</span>
+          </div>
+        </div>
+        {/* ================= 여행 경비 총정리 끝 ================= */}
+
+        {/* ================= 좋아요/팔로우 버튼 ================= */}
+        <div style={{
+          display: 'flex',
+          gap: '12px',
+          marginTop: '40px',
+          marginBottom: '40px'
+        }}>
+          {/* 좋아요 버튼 */}
+          <button
+            onClick={() => {
+              toggleLike(story.id);
+            }}
+            title="LIKES"
+            style={{
+              padding: '12px 24px',
+              border: '3px solid #000',
+              background: isLiked ? '#000' : '#fff',
+              color: isLiked ? '#fff' : '#000',
+              fontSize: '14px',
+              fontWeight: 700,
+              fontFamily: "'Share Tech Mono', monospace",
+              cursor: 'pointer',
+              display: 'flex',
+              alignItems: 'center',
+              gap: '12px',
+              transition: 'all 0.2s',
+              boxShadow: '4px 4px 0px rgba(0, 0, 0, 1)'
+            }}
+            onMouseEnter={(e) => {
+              if (!isLiked) {
+                e.currentTarget.style.background = '#f5f5f5';
+              }
+            }}
+            onMouseLeave={(e) => {
+              if (!isLiked) {
+                e.currentTarget.style.background = '#fff';
+              }
+            }}
+          >
+            <svg 
+              xmlns="http://www.w3.org/2000/svg" 
+              viewBox="0 0 24 24" 
+              style={{ 
+                width: '20px', 
+                height: '20px',
+                fill: isLiked ? '#fff' : 'none',
+                stroke: isLiked ? '#fff' : '#000',
+                strokeWidth: '2',
+                transition: 'all 0.2s'
+              }}
+            >
+              <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/>
+            </svg>
+            <span>{likesCount}</span>
+          </button>
+
+          {/* 팔로우 버튼 */}
+          <button
+            onClick={() => {
+              setFollowedStories((prev: number[]) =>
+                prev.includes(story.id)
+                  ? prev.filter((id: number) => id !== story.id)
+                  : [...prev, story.id]
+              );
+            }}
+            title="FOLLOW THIS"
+            style={{
+              padding: '12px 24px',
+              border: '3px solid #000',
+              background: isFollowed ? '#000' : '#fff',
+              color: isFollowed ? '#fff' : '#000',
+              fontSize: '14px',
+              fontWeight: 700,
+              fontFamily: "'Share Tech Mono', monospace",
+              cursor: 'pointer',
+              display: 'flex',
+              alignItems: 'center',
+              gap: '12px',
+              transition: 'all 0.2s',
+              boxShadow: '4px 4px 0px rgba(0, 0, 0, 1)'
+            }}
+            onMouseEnter={(e) => {
+              if (!isFollowed) {
+                e.currentTarget.style.background = '#f5f5f5';
+              }
+            }}
+            onMouseLeave={(e) => {
+              if (!isFollowed) {
+                e.currentTarget.style.background = '#fff';
+              }
+            }}
+          >
+            <svg 
+              xmlns="http://www.w3.org/2000/svg" 
+              viewBox="0 0 24 24" 
+              style={{ 
+                width: '20px', 
+                height: '20px',
+                fill: 'none',
+                stroke: isFollowed ? '#fff' : '#000',
+                strokeWidth: '3',
+                transition: 'all 0.2s'
+              }}
+            >
+              <line x1="12" y1="5" x2="12" y2="19"/>
+              <line x1="5" y1="12" x2="19" y2="12"/>
+            </svg>
+            <span>{followCount}</span>
+          </button>
+        </div>
+        {/* ================= 좋아요/팔로우 버튼 끝 ================= */}
+
+        <CommentSection storyId={story.id} />
+
+        <style>{`
+          /* 본문 내 일반 이미지는 숨김 (슬라이더만 표시) */
+          .detail-page-content > div + div img:not(.slider-images-container img) {
+            display: none;
+          }
+
+          /* 슬라이더는 표시 */
+          .image-slider-wrapper {
+            display: block !important;
+            position: relative;
+            width: 693px;
+            max-width: 100%;
+            margin: 20px auto;
+            background: #f5f5f5;
+            border: 3px solid #000;
+            box-shadow: 4px 4px 0px rgba(0, 0, 0, 1);
+          }
+          
+          .slider-images-container {
+            display: block !important;
+            position: relative;
+            width: 100%;
+            height: 619px;
+            overflow: hidden;
+          }
+          
+          .slider-images-container img {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            object-fit: cover;
+          }
+          
+          .slider-prev-btn,
+          .slider-next-btn {
+            display: flex !important;
+            position: absolute;
+            top: 50%;
+            transform: translateY(-50%);
+            width: 40px;
+            height: 40px;
+            background: rgba(0, 0, 0, 0.5);
+            color: #fff;
+            border: 2px solid #fff;
+            font-size: 28px;
+            font-weight: 700;
+            cursor: pointer;
+            z-index: 10;
+            align-items: center;
+            justify-content: center;
+            transition: all 0.2s;
+          }
+          
+          /* 화살표 버튼은 무조건 표시 */
+          .slider-prev-btn,
+          .slider-next-btn {
+            display: flex !important;
+            visibility: visible !important;
+            opacity: 1 !important;
+          }
+          
+          .slider-prev-btn {
+            left: 12px;
+          }
+          
+          .slider-next-btn {
+            right: 12px;
+          }
+          
+          .slider-prev-btn:hover,
+          .slider-next-btn:hover {
+            background: rgba(0, 0, 0, 0.8);
+          }
+          
+          .slider-indicator {
+            display: block !important;
+            position: absolute;
+            bottom: 12px;
+            left: 50%;
+            transform: translateX(-50%);
+            background: rgba(0, 0, 0, 0.7);
+            color: #fff;
+            padding: 4px 12px;
+            border-radius: 12px;
+            font-family: 'Share Tech Mono', monospace;
+            font-size: 12px;
+            font-weight: 700;
+            z-index: 10;
+          }
+
+          /* 버튼들은 숨김 - COVER만 숨기고 화살표는 살리기 */
+          [contenteditable="false"]:not(.image-slider-wrapper):not(.slider-images-container):not(.slider-prev-btn):not(.slider-next-btn):not(.slider-indicator) {
+            display: none !important;
+          }
+
+          /* COVER 버튼만 숨김 (화살표는 살림) */
+          .set-cover-btn,
+          .cover-label,
+          .cover-text,
+          .editor-toolbar,
+          .editor-menu,
+          .editor-controls,
+          .slider-button-container,
+          .slider-delete-container {
+            display: none !important;
+            visibility: hidden !important;
+          }
+
+          /* 노란색 COVER 버튼만 숨김 */
+          .image-slider-wrapper button[style*="yellow"],
+          .image-slider-wrapper button[style*="#FFD93D"],
+          .image-slider-wrapper > div:has(button[style*="yellow"]) {
+            display: none !important;
+          }
+
+          div:has(> span:contains("COVER")),
+          div:has(> span:contains("커버")) {
+            display: none !important;
+          }
+        `}</style>
+      </div>
+    </div>
+  );
+}
+
+export default DetailPage;

--- a/src/components/travelStory/DraftModal.tsx
+++ b/src/components/travelStory/DraftModal.tsx
@@ -1,0 +1,241 @@
+import { useState } from 'react';
+import ConfirmModal from './ConfirmModal';
+
+interface DraftModalProps {
+  show: boolean;
+  drafts: any[];
+  onClose: () => void;
+  onSelectDraft: (draft: any) => void;
+  onDeleteDraft: (id: number) => void;
+  hoveredDraftId: number | null;
+  setHoveredDraftId: (id: number | null) => void;
+  deleteHoverId: number | null;
+  setDeleteHoverId: (id: number | null) => void;
+}
+
+function DraftModal({
+  show,
+  drafts,
+  onClose,
+  onSelectDraft,
+  onDeleteDraft,
+  hoveredDraftId,
+  setHoveredDraftId,
+  deleteHoverId,
+  setDeleteHoverId
+}: DraftModalProps) {
+  if (!show) return null;
+
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const [targetDraftId, setTargetDraftId] = useState<number | null>(null);
+
+  return (
+    <>
+      <div 
+        style={{
+          position: 'fixed',
+          top: 0,
+          left: 0,
+          right: 0,
+          bottom: 0,
+          background: 'rgba(0, 0, 0, 0.7)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          zIndex: 10000
+        }}
+        onClick={onClose}
+      >
+        <div 
+          style={{ 
+            background: '#fff',
+            border: '3px solid #000',
+            boxShadow: '15px 15px 0px #000',
+            maxWidth: '600px',
+            width: '90%',
+            maxHeight: '70vh',
+            display: 'flex',
+            flexDirection: 'column'
+          }}
+          onClick={(e) => e.stopPropagation()}
+        >
+          <div style={{
+            background: '#000',
+            color: '#fff',
+            padding: '15px 20px',
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center'
+          }}>
+            <h2 style={{
+              fontFamily: "'Share Tech Mono', monospace",
+              fontSize: '16px',
+              fontWeight: 900,
+              letterSpacing: '1px',
+              margin: 0
+            }}>
+              {'>> DRAFT LIST'}
+            </h2>
+            <button 
+              onClick={onClose}
+              style={{
+                background: 'none',
+                border: '1px solid #fff',
+                color: '#fff',
+                padding: '6px 12px',
+                fontSize: '11px',
+                fontWeight: 700,
+                cursor: 'pointer',
+                fontFamily: "'Share Tech Mono', monospace",
+                letterSpacing: '0.5px',
+                transition: 'all 0.2s'
+              }}
+              onMouseEnter={(e) => {
+                e.currentTarget.style.background = '#fff';
+                e.currentTarget.style.color = '#000';
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.background = 'none';
+                e.currentTarget.style.color = '#fff';
+              }}
+            >
+              CLOSE [X]
+            </button>
+          </div>
+
+          <div style={{ 
+            flex: 1, 
+            overflowY: 'auto',
+            padding: '30px',
+            background: '#fff'
+          }}>
+            {drafts.map((draft: any) => (
+              <div 
+                key={draft.id}
+                onMouseEnter={() => setHoveredDraftId(draft.id)}
+                onMouseLeave={() => {
+                  setHoveredDraftId(null);
+                  setDeleteHoverId(null);
+                }}
+                style={{
+                  position: 'relative',
+                  padding: '15px',
+                  marginBottom: '15px',
+                  border: '2px solid #000',
+                  cursor: 'pointer',
+                  transition: 'all 0.2s',
+                  background: '#fff',
+                  boxShadow: '4px 4px 0px #000'
+                }}
+              >
+                <div onClick={() => onSelectDraft(draft)}>
+                  <div style={{
+                    fontSize: '14px',
+                    fontWeight: 900,
+                    marginBottom: '6px',
+                    color: '#000',
+                    fontFamily: "'Share Tech Mono', monospace",
+                    paddingRight: '40px'
+                  }}>
+                    {draft.title}
+                  </div>
+                  <div style={{
+                    fontSize: '11px',
+                    color: '#999',
+                    fontFamily: "'Share Tech Mono', monospace",
+                    fontWeight: 600
+                  }}>
+                    {draft.date}
+                  </div>
+                </div>
+                
+                {hoveredDraftId === draft.id && (
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setTargetDraftId(draft.id);
+                      setShowDeleteModal(true);
+                    }}
+                    onMouseEnter={() => setDeleteHoverId(draft.id)}
+                    onMouseLeave={() => setDeleteHoverId(null)}
+                    style={{
+                      position: 'absolute',
+                      top: '50%',
+                      right: '15px',
+                      transform: 'translateY(-50%)',
+                      background: 'none',
+                      border: 'none',
+                      cursor: 'pointer',
+                      padding: '5px',
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      transition: 'all 0.2s'
+                    }}
+                  >
+                    <svg
+                      width="20"
+                      height="20"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M3 6h18M8 6V4c0-1.1.9-2 2-2h4c1.1 0 2 .9 2 2v2m3 0v14c0 1.1-.9 2-2 2H7c-1.1 0-2-.9-2-2V6h14z"
+                        stroke={deleteHoverId === draft.id ? '#ff4d4d' : '#999'}
+                        strokeWidth="2"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      />
+                      <path
+                        d="M10 11v6M14 11v6"
+                        stroke={deleteHoverId === draft.id ? '#ff4d4d' : '#999'}
+                        strokeWidth="2"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      />
+                    </svg>
+                  </button>
+                )}
+              </div>
+            ))}
+
+            {drafts.length === 0 && (
+              <div style={{
+                textAlign: 'center',
+                padding: '60px 20px',
+                color: '#999',
+                fontSize: '13px',
+                fontFamily: "'Share Tech Mono', monospace",
+                fontWeight: 600
+              }}>
+                임시저장된 글이 없습니다.
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <ConfirmModal
+        show={showDeleteModal}
+        title="임시저장 삭제"
+        message={`임시저장 글을 삭제하시겠습니까?\n삭제된 글은 복구되지 못합니다.`}
+        confirmText="삭제"
+        cancelText="취소"
+        onConfirm={() => {
+          if (targetDraftId !== null) {
+            onDeleteDraft(targetDraftId);
+          }
+          setShowDeleteModal(false);
+          setTargetDraftId(null);
+        }}
+        onCancel={() => {
+          setShowDeleteModal(false);
+          setTargetDraftId(null);
+        }}
+      />
+    </>
+  );
+}
+
+export default DraftModal;

--- a/src/components/travelStory/FilterSection.tsx
+++ b/src/components/travelStory/FilterSection.tsx
@@ -2,8 +2,9 @@ interface FilterSectionProps {
   filters: {
     destination: string;
     duration: string;
-    budget: string;
-    style: string;
+    minBudget: string;    
+    maxBudget: string;    
+    tags: string[]; 
   };
   setFilters: (filters: any) => void;
 }
@@ -136,7 +137,7 @@ function FilterSection({ filters, setFilters }: FilterSectionProps) {
             예산대
           </label>
           <select 
-            value={filters.budget}
+            value={filters.minBudget}
             onChange={(e) => setFilters({...filters, budget: e.target.value})}
             style={{
               width: '100%',
@@ -174,8 +175,8 @@ function FilterSection({ filters, setFilters }: FilterSectionProps) {
             여행 스타일
           </label>
           <select 
-            value={filters.style}
-            onChange={(e) => setFilters({...filters, style: e.target.value})}
+            value={filters.tags[0] || '전체'}
+            onChange={(e) => setFilters({...filters, tags: e.target.value === '전체' ? [] : [e.target.value]})}
             style={{
               width: '100%',
               padding: '10px 12px',
@@ -224,11 +225,11 @@ function FilterSection({ filters, setFilters }: FilterSectionProps) {
             TAGS
           </span>
           {['힐링여행', '액티비티', '맛집투어', '문화탐방', '쇼핑', '사진명소', '가성비', '럭셔리'].map((tag) => {
-            const isSelected = filters.style === tag;
+            const isSelected = filters.tags.includes(tag);
             return (
               <button 
                 key={tag} 
-                onClick={() => setFilters({...filters, style: isSelected ? '전체' : tag})}
+                onClick={() => setFilters({...filters, tags: isSelected ? [] : [tag]})}
                 style={{
                   padding: '6px 12px',
                   border: '2px solid #000',

--- a/src/components/travelStory/LikesModal.tsx
+++ b/src/components/travelStory/LikesModal.tsx
@@ -1,0 +1,183 @@
+interface LikesModalProps {
+  show: boolean;
+  onClose: () => void;
+  stories: any[];
+  onStoryClick: (story: any) => void;
+}
+
+function LikesModal({ show, onClose, stories, onStoryClick }: LikesModalProps) {
+  if (!show) return null;
+
+  return (
+    <div 
+      style={{
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        background: 'rgba(0, 0, 0, 0.7)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 10000
+      }}
+      onClick={onClose}
+    >
+      <div 
+        style={{ 
+          background: '#fff',
+          border: '3px solid #000',
+          boxShadow: '15px 15px 0px #000',
+          maxWidth: '700px',
+          width: '90%',
+          maxHeight: '70vh',
+          display: 'flex',
+          flexDirection: 'column'
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* 헤더 */}
+        <div style={{
+          background: '#000',
+          color: '#fff',
+          padding: '15px 20px',
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center'
+        }}>
+          <h2 style={{
+            fontFamily: "'Share Tech Mono', monospace",
+            fontSize: '16px',
+            fontWeight: 900,
+            letterSpacing: '1px',
+            margin: 0,
+            display: 'flex',
+            alignItems: 'center',
+            gap: '8px'
+          }}>
+            {'>>'}
+            <svg 
+              xmlns="http://www.w3.org/2000/svg" 
+              viewBox="0 0 24 24" 
+              width="16"
+              height="16"
+              fill="none"
+              stroke="#fff"
+              strokeWidth="2"
+            >
+              <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/>
+            </svg>
+            {'LIKES LIST'}
+          </h2>
+
+          <button 
+            onClick={onClose}
+            style={{
+              background: 'none',
+              border: '1px solid #fff',
+              color: '#fff',
+              padding: '6px 12px',
+              fontSize: '11px',
+              fontWeight: 700,
+              cursor: 'pointer',
+              fontFamily: "'Share Tech Mono', monospace",
+              letterSpacing: '0.5px',
+              transition: 'all 0.2s'
+            }}
+            onMouseEnter={(e) => {
+              e.currentTarget.style.background = '#fff';
+              e.currentTarget.style.color = '#000';
+            }}
+            onMouseLeave={(e) => {
+              e.currentTarget.style.background = 'none';
+              e.currentTarget.style.color = '#fff';
+            }}
+          >
+            CLOSE [X]
+          </button>
+        </div>
+
+        {/* 바디 */}
+        <div style={{ 
+          flex: 1, 
+          overflowY: 'auto',
+          padding: '30px',
+          background: '#fff'
+        }}>
+          {stories.map((story: any) => (
+            <div 
+              key={story.id}
+              onClick={() => onStoryClick(story)}
+              style={{
+                display: 'flex',
+                gap: '15px',
+                alignItems: 'center',
+                padding: '15px',
+                marginBottom: '15px',
+                border: '2px solid #000',
+                cursor: 'pointer',
+                transition: 'all 0.2s',
+                background: '#fff',
+                boxShadow: '4px 4px 0px #000'
+              }}
+              onMouseEnter={(e) => {
+                e.currentTarget.style.transform = 'translate(-2px, -2px)';
+                e.currentTarget.style.boxShadow = '6px 6px 0px #000';
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.transform = 'none';
+                e.currentTarget.style.boxShadow = '4px 4px 0px #000';
+              }}
+            >
+              <img 
+                src={story.image} 
+                alt={story.title}
+                style={{
+                  width: '80px',
+                  height: '80px',
+                  objectFit: 'cover',
+                  border: '2px solid #000'
+                }}
+              />
+              <div style={{ flex: 1 }}>
+                <div style={{
+                  fontSize: '14px',
+                  fontWeight: 900,
+                  marginBottom: '6px',
+                  color: '#000',
+                  fontFamily: "'Share Tech Mono', monospace"
+                }}>
+                  {story.title}
+                </div>
+                <div style={{
+                  fontSize: '11px',
+                  color: '#666',
+                  fontFamily: "'Share Tech Mono', monospace",
+                  fontWeight: 600
+                }}>
+                  {story.destination} · {story.duration} · {parseInt(story.budget).toLocaleString()}원
+                </div>
+              </div>
+            </div>
+          ))}
+
+          {stories.length === 0 && (
+            <div style={{
+              textAlign: 'center',
+              padding: '60px 20px',
+              color: '#999',
+              fontSize: '13px',
+              fontFamily: "'Share Tech Mono', monospace",
+              fontWeight: 600
+            }}>
+              좋아요한 여행기가 없습니다.
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default LikesModal;

--- a/src/components/travelStory/MainPage.tsx
+++ b/src/components/travelStory/MainPage.tsx
@@ -1,0 +1,249 @@
+import { useEffect, useRef } from 'react';
+import CommentSection from './CommentSection';
+
+interface DetailPageProps {
+  story: any;
+  goBack: () => void;
+  likedStories: number[];
+  toggleLike: (id: number) => void;
+  followedStories: number[];
+  setFollowedStories: (ids: number[] | ((prev: number[]) => number[])) => void;
+  incrementViews: (id: number) => void;
+}
+
+function DetailPage({
+  story,
+  goBack,
+  likedStories,
+  toggleLike,
+  followedStories,
+  setFollowedStories,
+  incrementViews
+}: DetailPageProps) {
+  const hasIncrementedViews = useRef(false);
+
+  useEffect(() => {
+    if (!hasIncrementedViews.current) {
+      incrementViews(story.id);
+      hasIncrementedViews.current = true;
+    }
+  }, [story.id, incrementViews]);
+
+  return (
+    <div className="detail-page-container">
+      <div className="detail-page-content">
+
+        {/* ================= HEADER ================= */}
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'flex-start',
+            paddingBottom: '24px',
+            borderBottom: '2px solid #000',
+            marginBottom: '40px'
+          }}
+        >
+          {/* 왼쪽 */}
+          <div>
+            <h1
+              style={{
+                fontSize: '32px',
+                fontWeight: 700,
+                marginBottom: '10px',
+                fontFamily: "'Share Tech Mono', monospace"
+              }}
+            >
+              {story.title}
+            </h1>
+
+            <div style={{ display: 'flex', gap: '10px' }}>
+              {[story.destination, story.duration, `${parseInt(story.budget).toLocaleString()}원`].map(
+                (item) => (
+                  <div
+                    key={item}
+                    style={{
+                      padding: '6px 14px',
+                      border: '2px solid #000',
+                      background: '#f5f5f5',
+                      fontSize: '12px',
+                      fontWeight: 700,
+                      fontFamily: "'Share Tech Mono', monospace"
+                    }}
+                  >
+                    {item}
+                  </div>
+                )
+              )}
+            </div>
+          </div>
+
+          {/* 오른쪽 */}
+          <div style={{ position: 'relative', marginTop: '32px' }}>
+            <button
+              onClick={goBack}
+              style={{
+                position: 'absolute',
+                top: '-28px',
+                right: '0',
+                border: 'none',
+                background: 'transparent',
+                cursor: 'pointer'
+              }}
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                style={{ width: '28px', height: '28px', fill: '#000' }}
+              >
+                <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/>
+              </svg>
+            </button>
+
+            <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+              <div style={{ width: '40px', height: '40px', background: '#000' }} />
+              <div>
+                <div
+                  style={{
+                    fontWeight: 700,
+                    fontFamily: "'Share Tech Mono', monospace"
+                  }}
+                >
+                  {story.author}
+                </div>
+                <div
+                  style={{
+                    fontSize: '11px',
+                    color: '#999',
+                    lineHeight: '1.4',
+                    fontFamily: "'Share Tech Mono', monospace"
+                  }}
+                >
+                  {story.date}<br />
+                  {story.views} VIEWS
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        {/* ================= HEADER 끝 ================= */}
+
+        {/* Cover Image - 화살표/점 완전 제거 */}
+        <div style={{ maxWidth: '700px', margin: '0 auto 40px auto' }}>
+          <img
+            src={story.image}
+            alt={story.title}
+            style={{ width: '100%', display: 'block' }}
+          />
+        </div>
+
+        {/* Description */}
+        <div
+          style={{
+            fontSize: '15px',
+            lineHeight: '1.8',
+            marginBottom: '40px',
+            fontFamily: "'Share Tech Mono', monospace"
+          }}
+          dangerouslySetInnerHTML={{ __html: story.description }}
+        />
+
+        {/* ================= 여행 경비 총정리 ================= */}
+        <div
+          style={{
+            maxWidth: '700px',
+            margin: '0 auto 40px auto',
+            border: '2px solid #000',
+            padding: '20px',
+            background: '#f7f7f7'
+          }}
+        >
+          <h2
+            style={{
+              fontSize: '18px',
+              fontWeight: 700,
+              marginBottom: '12px',
+              fontFamily: "'Share Tech Mono', monospace"
+            }}
+          >
+            여행 경비 총정리
+          </h2>
+
+          {[
+            ['교통비 (렌터카)', '95,000원'],
+            ['숙박비', '85,000원'],
+            ['식비', '98,000원'],
+            ['관광/입장료', '15,000원'],
+            ['쇼핑/기타', '35,000원']
+          ].map(([label, price]) => (
+            <div
+              key={label}
+              style={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                padding: '10px 0',
+                borderBottom: '1px solid #ddd',
+                fontSize: '14px',
+                fontFamily: "'Share Tech Mono', monospace",
+                background: '#f7f7f7'
+              }}
+            >
+              <span>{label}</span>
+              <span style={{ fontWeight: 700 }}>{price}</span>
+            </div>
+          ))}
+
+          <div
+            style={{
+              marginTop: '16px',
+              background: '#000',
+              color: '#fff',
+              padding: '14px 16px',
+              display: 'flex',
+              justifyContent: 'space-between',
+              fontFamily: "'Share Tech Mono', monospace"
+            }}
+          >
+            <span style={{ fontWeight: 700 }}>총 합계</span>
+            <span style={{ fontWeight: 700 }}>328,000원</span>
+          </div>
+        </div>
+        {/* ================= 여행 경비 총정리 끝 ================= */}
+
+        <CommentSection storyId={story.id} />
+
+        <style>{`
+          img {
+            max-width: 566px;
+            margin: 20px auto;
+          }
+
+          .detail-page-content > div + div img {
+            display: none;
+          }
+
+          [contenteditable="false"] {
+            display: none !important;
+          }
+
+          .set-cover-btn,
+          .cover-label,
+          .cover-text,
+          .editor-toolbar,
+          .editor-menu,
+          .editor-controls {
+            display: none !important;
+          }
+
+          div:has(> span:contains("COVER")),
+          div:has(> span:contains("커버")),
+          div:has(> span:contains("삭제")) {
+            display: none !important;
+          }
+        `}</style>
+      </div>
+    </div>
+  );
+}
+
+export default DetailPage;

--- a/src/components/travelStory/MyStoriesPage.tsx
+++ b/src/components/travelStory/MyStoriesPage.tsx
@@ -1,0 +1,218 @@
+import StoryCard from './StoryCard';
+
+interface MyStoriesPageProps {
+  goBack: () => void;
+  navigateToPage: (page: string) => void;
+  getFilteredStories: () => any[];
+  handleStoryClick: (story: any) => void;
+  handleEdit: (story: any) => void;
+  handleDelete: (id: number) => void;
+  likedStories: number[];
+  setLikedStories: (ids: number[] | ((prev: number[]) => number[])) => void;
+  followedStories: number[];
+  setFollowedStories: (ids: number[] | ((prev: number[]) => number[])) => void;
+  setShowLikesModal: (show: boolean) => void;
+}
+
+function MyStoriesPage({
+  goBack,
+  navigateToPage,
+  getFilteredStories,
+  handleStoryClick,
+  handleEdit,
+  handleDelete,
+  likedStories,
+  setLikedStories,
+  followedStories,
+  setFollowedStories,
+  setShowLikesModal
+}: MyStoriesPageProps) {
+  const stories = getFilteredStories();
+
+  return (
+    <div className="container">
+      {/* Header with Close Button */}
+      <div style={{
+        position: 'relative',
+        marginBottom: '30px',
+        padding: '20px',
+        background: '#fff',
+        border: '3px solid #000',
+        boxShadow: '8px 8px 0px rgba(0, 0, 0, 1)',
+        zIndex: 1
+      }}>
+        <button
+          onClick={(e) => { 
+            e.preventDefault(); 
+            e.stopPropagation(); 
+            goBack(); 
+          }}
+          style={{
+            position: 'absolute',
+            top: '-15px',
+            right: '-15px',
+            width: '40px',
+            height: '40px',
+            border: '2px solid #000',
+            background: '#fff',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            cursor: 'pointer',
+            pointerEvents: 'auto',
+            borderRadius: '50%',
+            boxShadow: '2px 2px 4px rgba(0, 0, 0, 0.2)',
+            zIndex: 99999,
+            transition: 'all 0.2s'
+          }}
+          onMouseEnter={(e) => {
+            e.currentTarget.style.background = '#000';
+            const svg = e.currentTarget.querySelector('svg');
+            if (svg) (svg as SVGElement).style.fill = '#fff';
+          }}
+          onMouseLeave={(e) => {
+            e.currentTarget.style.background = '#fff';
+            const svg = e.currentTarget.querySelector('svg');
+            if (svg) (svg as SVGElement).style.fill = '#000';
+          }}
+        >
+          <svg 
+            xmlns="http://www.w3.org/2000/svg" 
+            viewBox="0 0 24 24" 
+            style={{ width: '24px', height: '24px', fill: '#000', transition: 'fill 0.2s' }}
+          >
+            <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/>
+          </svg>
+        </button>
+
+        {/* 통계 그리드 */}
+        <div style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(4, 1fr)',
+          gap: '12px',
+          padding: '0 20px'
+        }}>
+          {/* 작성한 여행기 */}
+          <div style={{
+            padding: '12px 15px',
+            border: '2px solid #000',
+            background: '#fff',
+            textAlign: 'center'
+          }}>
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', marginBottom: '4px' }}>
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" style={{ width: '20px', height: '20px', fill: '#000' }}>
+                <path d="M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z"/>
+              </svg>
+            </div>
+            <div style={{ fontSize: '22px', fontWeight: 700, marginBottom: '4px', fontFamily: "'Share Tech Mono', monospace" }}>
+              {stories.length}
+            </div>
+            <div style={{ fontSize: '10px', color: '#666', fontFamily: "'Share Tech Mono', monospace", textTransform: 'uppercase', letterSpacing: '0.5px' }}>
+              작성한 여행기
+            </div>
+          </div>
+
+          {/* 총 조회수 */}
+          <div style={{
+            padding: '12px 15px',
+            border: '2px solid #000',
+            background: '#fff',
+            textAlign: 'center'
+          }}>
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', marginBottom: '4px' }}>
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" style={{ width: '20px', height: '20px', fill: '#000' }}>
+                <path d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z"/>
+              </svg>
+            </div>
+            <div style={{ fontSize: '22px', fontWeight: 700, marginBottom: '4px', fontFamily: "'Share Tech Mono', monospace" }}>
+              {stories.reduce((sum, story) => sum + parseInt(story.views || '0'), 0)}
+            </div>
+            <div style={{ fontSize: '10px', color: '#666', fontFamily: "'Share Tech Mono', monospace", textTransform: 'uppercase', letterSpacing: '0.5px' }}>
+              총 조회수
+            </div>
+          </div>
+
+          {/* 받은 좋아요 */}
+          <div style={{
+            padding: '12px 15px',
+            border: '2px solid #000',
+            background: '#fff',
+            textAlign: 'center'
+          }}>
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', marginBottom: '4px' }}>
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" style={{ width: '20px', height: '20px', fill: '#ff4757' }}>
+                <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/>
+              </svg>
+            </div>
+            <div style={{ fontSize: '22px', fontWeight: 700, marginBottom: '4px', fontFamily: "'Share Tech Mono', monospace" }}>
+              {stories.reduce((sum, story) => sum + (story.likes || 0), 0)}
+            </div>
+            <div style={{ fontSize: '10px', color: '#666', fontFamily: "'Share Tech Mono', monospace", textTransform: 'uppercase', letterSpacing: '0.5px' }}>
+              받은 좋아요
+            </div>
+          </div>
+
+          {/* 좋아요 목록 */}
+          <div 
+            onClick={() => setShowLikesModal(true)}
+            style={{
+              padding: '12px 15px',
+              border: '2px solid #000',
+              background: '#fff',
+              textAlign: 'center',
+              cursor: 'pointer',
+              transition: 'all 0.2s'
+            }}
+            onMouseEnter={(e) => {
+              e.currentTarget.style.transform = 'translateY(-3px)';
+              e.currentTarget.style.boxShadow = '4px 4px 0px rgba(0, 0, 0, 1)';
+            }}
+            onMouseLeave={(e) => {
+              e.currentTarget.style.transform = 'translateY(0)';
+              e.currentTarget.style.boxShadow = 'none';
+            }}
+          >
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', marginBottom: '4px' }}>
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" style={{ width: '20px', height: '20px', fill: 'none', stroke: '#000', strokeWidth: '2' }}>
+                <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/>
+              </svg>
+            </div>
+            <div style={{ fontSize: '22px', fontWeight: 700, marginBottom: '4px', fontFamily: "'Share Tech Mono', monospace" }}>
+              {likedStories.length}
+            </div>
+            <div style={{ fontSize: '10px', color: '#666', fontFamily: "'Share Tech Mono', monospace", textTransform: 'uppercase', letterSpacing: '0.5px' }}>
+              좋아요 목록
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Stories Grid */}
+      <div className="posts-grid">
+        {stories.map((story: any) => (
+          <StoryCard 
+            key={story.id}
+            story={story}
+            onCardClick={handleStoryClick}
+            likedStories={likedStories}
+            setLikedStories={setLikedStories}
+            followedStories={followedStories}
+            setFollowedStories={setFollowedStories}
+            onEdit={handleEdit}
+            onDelete={handleDelete}
+            isMyStory={true}
+          />
+        ))}
+      </div>
+
+      {stories.length === 0 && (
+        <div className="no-results-fullpage">
+          <div className="no-results-text">작성한 여행기가 없습니다.</div>
+          <div className="no-results-subtext">첫 여행기를 작성해보세요!</div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default MyStoriesPage;

--- a/src/components/travelStory/StoryCard.tsx
+++ b/src/components/travelStory/StoryCard.tsx
@@ -1,8 +1,11 @@
+import { useState, useEffect } from 'react';
+
 interface Story {
   id: number;
   title: string;
   description: string;
   image: string;
+  images?: string[];
   author: string;
   authorAvatar: string;
   destination: string;
@@ -19,57 +22,311 @@ interface Story {
 interface StoryCardProps {
   story: Story;
   onCardClick: (story: Story) => void;
+  likedStories: number[];
+  setLikedStories: (ids: number[] | ((prev: number[]) => number[])) => void;
+  followedStories: number[];
+  setFollowedStories: (ids: number[] | ((prev: number[]) => number[])) => void;
+  onEdit?: (story: any) => void;
+  onDelete?: (id: number) => void;
+  isMyStory?: boolean;
 }
 
-function StoryCard({ story, onCardClick }: StoryCardProps) {
+function StoryCard({ 
+  story, 
+  onCardClick, 
+  onEdit, 
+  onDelete, 
+  isMyStory 
+}: StoryCardProps) {
+  const images = story.images || [story.image];
+  const [currentImageIndex, setCurrentImageIndex] = useState(0);
+  const [actualCommentsCount, setActualCommentsCount] = useState(0);
+
+  // localStorage에서 실제 댓글 수 가져오기
+  useEffect(() => {
+    const updateCommentsCount = () => {
+      const STORAGE_KEY = `comments_${story.id}`;
+      const saved = localStorage.getItem(STORAGE_KEY);
+      if (saved) {
+        try {
+          const comments = JSON.parse(saved);
+          setActualCommentsCount(comments.length);
+        } catch (e) {
+          setActualCommentsCount(0);
+        }
+      } else {
+        setActualCommentsCount(0);
+      }
+    };
+
+    // 초기 로드
+    updateCommentsCount();
+
+    // window focus 시 업데이트 (DetailPage에서 돌아올 때)
+    window.addEventListener('focus', updateCommentsCount);
+    
+    return () => {
+      window.removeEventListener('focus', updateCommentsCount);
+    };
+  }, [story.id]);
+
+  const handlePrevImage = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setCurrentImageIndex((prev) => (prev === 0 ? images.length - 1 : prev - 1));
+  };
+
+  const handleNextImage = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setCurrentImageIndex((prev) => (prev === images.length - 1 ? 0 : prev + 1));
+  };
+
   return (
-    <div className="story-card" onClick={() => onCardClick(story)}>
-      <img className="story-image" src={story.image} alt={story.title} />
-      <div className="story-stats-badge">
-        <span>{story.views}</span>
+    <div className="story-card" style={{ position: 'relative' }}>
+      {/* 이미지 영역 */}
+      <div 
+        onClick={() => onCardClick(story)}
+        style={{ position: 'relative' }}
+      >
+        <img 
+          className="story-image" 
+          src={images[currentImageIndex]} 
+          alt={story.title} 
+        />
+        
+        {/* 이미지 슬라이드 컨트롤 */}
+        {images.length > 1 && (
+          <>
+            {/* 왼쪽 화살표 */}
+            <button
+              onClick={handlePrevImage}
+              style={{
+                position: 'absolute',
+                left: '10px',
+                top: '50%',
+                transform: 'translateY(-50%)',
+                width: '32px',
+                height: '32px',
+                border: 'none',
+                background: 'rgba(255, 255, 255, 0.9)',
+                borderRadius: '50%',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                cursor: 'pointer',
+                zIndex: 2,
+                boxShadow: '0 2px 4px rgba(0,0,0,0.2)',
+                transition: 'all 0.2s'
+              }}
+              onMouseEnter={(e) => {
+                e.currentTarget.style.background = 'rgba(255, 255, 255, 1)';
+                e.currentTarget.style.transform = 'translateY(-50%) scale(1.1)';
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.background = 'rgba(255, 255, 255, 0.9)';
+                e.currentTarget.style.transform = 'translateY(-50%) scale(1)';
+              }}
+            >
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none">
+                <path d="M15 18l-6-6 6-6" stroke="#000" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+              </svg>
+            </button>
+
+            {/* 오른쪽 화살표 */}
+            <button
+              onClick={handleNextImage}
+              style={{
+                position: 'absolute',
+                right: '10px',
+                top: '50%',
+                transform: 'translateY(-50%)',
+                width: '32px',
+                height: '32px',
+                border: 'none',
+                background: 'rgba(255, 255, 255, 0.9)',
+                borderRadius: '50%',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                cursor: 'pointer',
+                zIndex: 2,
+                boxShadow: '0 2px 4px rgba(0,0,0,0.2)',
+                transition: 'all 0.2s'
+              }}
+              onMouseEnter={(e) => {
+                e.currentTarget.style.background = 'rgba(255, 255, 255, 1)';
+                e.currentTarget.style.transform = 'translateY(-50%) scale(1.1)';
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.background = 'rgba(255, 255, 255, 0.9)';
+                e.currentTarget.style.transform = 'translateY(-50%) scale(1)';
+              }}
+            >
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none">
+                <path d="M9 18l6-6-6-6" stroke="#000" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+              </svg>
+            </button>
+
+            {/* 인디케이터 점 */}
+            <div style={{
+              position: 'absolute',
+              bottom: '10px',
+              left: '50%',
+              transform: 'translateX(-50%)',
+              display: 'flex',
+              gap: '6px',
+              zIndex: 2
+            }}>
+              {images.map((_, index) => (
+                <div
+                  key={index}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setCurrentImageIndex(index);
+                  }}
+                  style={{
+                    width: '6px',
+                    height: '6px',
+                    borderRadius: '50%',
+                    background: index === currentImageIndex 
+                      ? '#fff' 
+                      : 'rgba(255, 255, 255, 0.5)',
+                    transition: 'all 0.3s',
+                    boxShadow: '0 1px 2px rgba(0,0,0,0.3)',
+                    cursor: 'pointer'
+                  }}
+                />
+              ))}
+            </div>
+          </>
+        )}
+
+        <div className="story-stats-badge">
+          <span>{story.views}</span>
+        </div>
       </div>
       
       <div className="story-content">
-        <div className="story-header">
-          <div className="author-avatar">{story.authorAvatar}</div>
-          <div className="author-info">
-            <div className="author-name">{story.author}</div>
+        <div onClick={() => onCardClick(story)}>
+          <div className="story-header">
+            <div className="author-avatar">{story.authorAvatar}</div>
+            <div className="author-info">
+              <div className="author-name">{story.author}</div>
+            </div>
           </div>
-        </div>
-        
-        <div className="story-title">{story.title}</div>
-        <div className="story-description">{story.description}</div>
-        
-        <div className="story-tags">
-          {story.tags.map((tag, index) => (
-            <span key={index} className="story-tag">{tag}</span>
-          ))}
+          
+          <div className="story-title">{story.title}</div>
+          <div className="story-description">
+            {story.description
+              .replace(/<[^>]*>/g, '') // HTML 태그 제거
+              .replace(/\d+\/\d+COVER/gi, '') // "1/5COVER" 같은 텍스트 제거
+              .replace(/COVER/gi, '') // "COVER" 텍스트 제거
+              .replace(/<>/g, '') // "<>" 제거
+              .replace(/[<>]/g, '') // 남은 < > 제거
+              .trim()}
+          </div>
+          
+          <div className="story-tags">
+            {story.tags.map((tag, index) => (
+              <span key={index} className="story-tag">{tag}</span>
+            ))}
+          </div>
+
+          <div className="story-stats-simple">
+            <div className="stat-simple-item">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/>
+              </svg>
+              <span>LIKES</span>
+            </div>
+            <div className="stat-simple-item">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/>
+              </svg>
+              <span>FOLLOW THIS</span>
+            </div>
+            <div className="stat-simple-item">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                <path d="M12 2C6.48 2 2 6.48 2 12c0 1.54.36 3 .97 4.29L2 22l5.71-.97C9 21.64 10.46 22 12 22c5.52 0 10-4.48 10-10S17.52 2 12 2zm0 18c-1.38 0-2.68-.3-3.86-.83l-.28-.15-2.86.49.49-2.86-.15-.28C4.3 14.68 4 13.38 4 12c0-4.41 3.59-8 8-8s8 3.59 8 8-3.59 8-8 8z"/>
+              </svg>
+              <span>{actualCommentsCount}</span>
+            </div>
+          </div>
+
+          <div className="story-meta">
+            <span>{story.date}</span>
+          </div>
         </div>
 
-        <div className="story-stats-simple">
-          <div className="stat-simple-item">
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-              <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/>
-            </svg>
-            <span>LIKES</span>
+        {isMyStory && (
+          <div style={{
+            display: 'flex',
+            gap: '8px',
+            marginTop: '15px',
+            paddingTop: '15px',
+            borderTop: '2px solid #f0f0f0'
+          }}>
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                onEdit?.(story);
+              }}
+              style={{
+                flex: 1,
+                padding: '8px 16px',
+                border: '2px solid #000',
+                background: '#fff',
+                color: '#000',
+                fontSize: '11px',
+                fontWeight: 700,
+                fontFamily: "'Share Tech Mono', monospace",
+                textTransform: 'uppercase',
+                cursor: 'pointer',
+                transition: 'all 0.2s',
+                letterSpacing: '0.5px'
+              }}
+              onMouseEnter={(e) => {
+                e.currentTarget.style.background = '#000';
+                e.currentTarget.style.color = '#fff';
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.background = '#fff';
+                e.currentTarget.style.color = '#000';
+              }}
+            >
+              EDIT
+            </button>
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                onDelete?.(story.id);
+              }}
+              style={{
+                flex: 1,
+                padding: '8px 16px',
+                border: '2px solid #dc3545',
+                background: '#fff',
+                color: '#dc3545',
+                fontSize: '11px',
+                fontWeight: 700,
+                fontFamily: "'Share Tech Mono', monospace",
+                textTransform: 'uppercase',
+                cursor: 'pointer',
+                transition: 'all 0.2s',
+                letterSpacing: '0.5px'
+              }}
+              onMouseEnter={(e) => {
+                e.currentTarget.style.background = '#dc3545';
+                e.currentTarget.style.color = '#fff';
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.background = '#fff';
+                e.currentTarget.style.color = '#dc3545';
+              }}
+            >
+              DELETE
+            </button>
           </div>
-          <div className="stat-simple-item">
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-              <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/>
-            </svg>
-            <span>FOLLOW THIS</span>
-          </div>
-          <div className="stat-simple-item">
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-              <path d="M12 2C6.48 2 2 6.48 2 12c0 1.54.36 3 .97 4.29L2 22l5.71-.97C9 21.64 10.46 22 12 22c5.52 0 10-4.48 10-10S17.52 2 12 2zm0 18c-1.38 0-2.68-.3-3.86-.83l-.28-.15-2.86.49.49-2.86-.15-.28C4.3 14.68 4 13.38 4 12c0-4.41 3.59-8 8-8s8 3.59 8 8-3.59 8-8 8z"/>
-            </svg>
-            <span>{story.comments}</span>
-          </div>
-        </div>
-
-        <div className="story-meta">
-          <span>{story.date}</span>
-        </div>
+        )}
       </div>
     </div>
   );

--- a/src/components/travelStory/WritePage.tsx
+++ b/src/components/travelStory/WritePage.tsx
@@ -1,74 +1,672 @@
-import { useState } from 'react';
+import { useState, useEffect, useRef } from 'react';
+import ConfirmModal from './ConfirmModal';
 
 interface WritePageProps {
+  goBack: () => void;
+  onPublish: () => void;
+  onSaveDraft: () => void;
+  onOpenDraftModal: () => void;
   editingStory?: any;
   currentDraft?: any;
-  onBack: () => void;
-  onSaveDraft: () => void;
-  onPublish: () => void;
   drafts: any[];
-  onShowDraftModal: () => void;
 }
 
 function WritePage({ 
+  goBack,
+  onPublish, 
+  onSaveDraft,
+  onOpenDraftModal,
   editingStory, 
-  currentDraft, 
-  onBack, 
-  onSaveDraft, 
-  onPublish,
-  drafts,
-  onShowDraftModal
+  currentDraft,
+  drafts
 }: WritePageProps) {
-  const [coverImage, setCoverImage] = useState<string | null>(editingStory?.image || null);
+  const [selectedCoverImage, setSelectedCoverImage] = useState<string | null>(editingStory?.image || null);
+  const [showConfirmModal, setShowConfirmModal] = useState(false);
+  const [confirmAction, setConfirmAction] = useState<'back' | null>(null);
+  const [activeHeading, setActiveHeading] = useState<'h2' | 'h3' | null>(null);
+  const [activeList, setActiveList] = useState<'ol' | 'ul' | null>(null);
 
-  const handleCoverImageUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (file) {
-      const reader = new FileReader();
-      reader.onload = (event) => {
-        setCoverImage(event.target?.result as string);
-      };
-      reader.readAsDataURL(file);
+  // onPublish 함수 검증
+  useEffect(() => {
+    if (typeof onPublish !== 'function') {
+      console.error('onPublish is not a function:', onPublish);
     }
+  }, [onPublish]);
+
+  // ⭐ 글을 작성했는지 체크하는 함수
+  const hasContent = () => {
+    // 수정 중이거나 임시저장 글인 경우, 항상 확인 필요
+    if (editingStory || currentDraft) {
+      return true;
+    }
+    
+    const titleInput = document.querySelector('.title-input') as HTMLInputElement;
+    const destinationInput = document.querySelector('.form-input') as HTMLInputElement;
+    const editor = document.querySelector('.blog-editor-wysiwyg') as HTMLDivElement;
+    
+    const title = titleInput?.value.trim();
+    const destination = destinationInput?.value.trim();
+    const content = editor?.innerText.trim();
+    
+    // 제목, 목적지, 내용 중 하나라도 있으면 true
+    return !!(title || destination || (content && content !== '여행 이야기를 자유롭게 작성해주세요...'));
   };
 
-  const handleImageInsert = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (file) {
-      const reader = new FileReader();
-      reader.onload = (event) => {
-        const img = event.target?.result as string;
-        const editor = document.querySelector('.blog-editor-wysiwyg') as HTMLDivElement;
-        if (editor) {
-          const imgHtml = `<img src="${img}" alt="uploaded" style="max-width: 100%; margin: 20px auto; display: block; border: 3px solid #000;" />`;
-          document.execCommand('insertHTML', false, imgHtml);
+  const savedRangeRef = useRef<Range | null>(null);
+
+  // 새로고침 방지
+  useEffect(() => {
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      // ⭐ 글을 쓴 경우에만 새로고침 방지
+      if (hasContent()) {
+        e.preventDefault();
+        e.returnValue = '';
+      }
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload);
+  }, []);
+
+  
+  useEffect(() => {
+    if ((editingStory && editingStory.tags) || currentDraft) {
+      setTimeout(() => {
+        // 태그 처리
+        if (editingStory && editingStory.tags) {
+          document.querySelectorAll('.style-tag').forEach((btn) => {
+            const button = btn as HTMLButtonElement;
+            const tagText = button.textContent || '';
+            if (editingStory.tags.includes(tagText)) {
+              button.style.background = '#000';
+              button.style.color = '#fff';
+              button.style.boxShadow = '2px 2px 0px rgba(0,0,0,1)';
+              button.style.transform = 'translate(-1px, -1px)';
+            }
+          });
         }
-      };
-      reader.readAsDataURL(file);
+
+        // 슬라이더 이벤트 리스너 등록 (수정 & 임시저장 페이지에서)
+        const sliders = document.querySelectorAll('.image-slider-wrapper');
+        sliders.forEach(slider => {
+          const imagesContainer = slider.querySelector('.slider-images-container');
+          const prevBtn = slider.querySelector('.slider-prev-btn');
+          const nextBtn = slider.querySelector('.slider-next-btn');
+          const indicator = slider.querySelector('.slider-indicator');
+          
+          if (!imagesContainer) return;
+          
+          const images = Array.from(imagesContainer.querySelectorAll('img'));
+          if (images.length === 0) return;
+          
+          let currentIndex = 0;
+          
+          // 초기 상태: 첫 번째 이미지만 표시
+          images.forEach((img, idx) => {
+            (img as HTMLElement).style.display = idx === 0 ? 'block' : 'none';
+          });
+          
+          // 이전 버튼
+          if (prevBtn) {
+            const handlePrev = (e: Event) => {
+              e.preventDefault();
+              e.stopPropagation();
+              (images[currentIndex] as HTMLElement).style.display = 'none';
+              currentIndex = (currentIndex - 1 + images.length) % images.length;
+              (images[currentIndex] as HTMLElement).style.display = 'block';
+              if (indicator) {
+                indicator.textContent = `${currentIndex + 1}/${images.length}`;
+              }
+            };
+            prevBtn.removeEventListener('click', handlePrev as EventListener);
+            prevBtn.addEventListener('click', handlePrev as EventListener);
+          }
+          
+          // 다음 버튼
+          if (nextBtn) {
+            const handleNext = (e: Event) => {
+              e.preventDefault();
+              e.stopPropagation();
+              (images[currentIndex] as HTMLElement).style.display = 'none';
+              currentIndex = (currentIndex + 1) % images.length;
+              (images[currentIndex] as HTMLElement).style.display = 'block';
+              if (indicator) {
+                indicator.textContent = `${currentIndex + 1}/${images.length}`;
+              }
+            };
+            nextBtn.removeEventListener('click', handleNext as EventListener);
+            nextBtn.addEventListener('click', handleNext as EventListener);
+          }
+        });
+      }, 100);
     }
+  }, [editingStory, currentDraft]);
+
+  const handleImageInsert = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files;
+    if (!files || files.length === 0) return;
+    
+    // 최대 5장 제한 (localStorage 용량 문제)
+    const fileArray = Array.from(files).slice(0, 5);
+    
+    if (files.length > 5) {
+      alert('이미지는 최대 5장까지 선택할 수 있습니다.');
+    }
+    
+    // 모든 파일을 base64로 변환
+    const imagePromises = fileArray.map(file => {
+      return new Promise<string>((resolve) => {
+        const reader = new FileReader();
+        reader.onload = (event) => resolve(event.target?.result as string);
+        reader.readAsDataURL(file);
+      });
+    });
+    
+    Promise.all(imagePromises).then(imageSrcs => {
+      const editor = document.querySelector('.blog-editor-wysiwyg') as HTMLDivElement;
+      if (!editor) return;
+      
+      editor.focus();
+      const sliderId = `slider-${Date.now()}`;
+      
+      // 슬라이더 wrapper 생성
+      const sliderWrapper = document.createElement('div');
+      sliderWrapper.className = 'image-slider-wrapper';
+      sliderWrapper.setAttribute('data-slider-id', sliderId);
+      sliderWrapper.setAttribute('contenteditable', 'false');
+      sliderWrapper.style.cssText = `
+        position: relative;
+        width: 693px;
+        max-width: 100%;
+        margin: 20px auto;
+        background: #f5f5f5;
+        border: 3px solid #000;
+        box-shadow: 4px 4px 0px rgba(0, 0, 0, 1);
+      `;
+      
+      // 이미지 컨테이너
+      const imagesContainer = document.createElement('div');
+      imagesContainer.className = 'slider-images-container';
+      imagesContainer.style.cssText = `
+        position: relative;
+        width: 100%;
+        height: 619px;
+        overflow: hidden;
+      `;
+      
+      // 각 이미지 추가
+      imageSrcs.forEach((src, index) => {
+        const img = document.createElement('img');
+        img.src = src;
+        img.alt = `slide ${index + 1}`;
+        img.setAttribute('data-image-src', src);
+        img.style.cssText = `
+          position: absolute;
+          top: 0;
+          left: 0;
+          width: 100%;
+          height: 100%;
+          object-fit: cover;
+          display: ${index === 0 ? 'block' : 'none'};
+        `;
+        imagesContainer.appendChild(img);
+      });
+      
+      sliderWrapper.appendChild(imagesContainer);
+      
+      // 현재 인덱스 저장
+      let currentIndex = 0;
+      
+      // 이전 버튼
+      if (imageSrcs.length > 1) {
+        const prevBtn = document.createElement('button');
+        prevBtn.className = 'slider-prev-btn';
+        prevBtn.innerHTML = '‹';
+        prevBtn.setAttribute('contenteditable', 'false');
+        prevBtn.style.cssText = `
+          position: absolute;
+          left: 12px;
+          top: 50%;
+          transform: translateY(-50%);
+          width: 40px;
+          height: 40px;
+          background: rgba(0, 0, 0, 0.5);
+          color: #fff;
+          border: 2px solid #fff;
+          font-size: 28px;
+          font-weight: 700;
+          cursor: pointer;
+          z-index: 10;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          transition: all 0.2s;
+        `;
+        
+        prevBtn.addEventListener('mouseenter', () => {
+          prevBtn.style.background = 'rgba(0, 0, 0, 0.8)';
+        });
+        prevBtn.addEventListener('mouseleave', () => {
+          prevBtn.style.background = 'rgba(0, 0, 0, 0.5)';
+        });
+        
+        prevBtn.addEventListener('click', (evt) => {
+          evt.preventDefault();
+          evt.stopPropagation();
+          
+          const images = imagesContainer.querySelectorAll('img');
+          images[currentIndex].style.display = 'none';
+          currentIndex = (currentIndex - 1 + images.length) % images.length;
+          images[currentIndex].style.display = 'block';
+          
+          // 인디케이터 업데이트
+          const indicator = sliderWrapper.querySelector('.slider-indicator') as HTMLElement;
+          if (indicator) {
+            indicator.textContent = `${currentIndex + 1}/${images.length}`;
+          }
+          
+          // COVER 버튼 상태 업데이트
+          const currentImg = images[currentIndex] as HTMLImageElement;
+          const currentSrc = currentImg.getAttribute('data-image-src');
+          if (currentSrc === selectedCoverImage) {
+            // 현재 이미지가 커버이면 노란색으로 표시하고 항상 보이게
+            coverBtn.style.background = '#FFD93D';
+            coverBtn.style.color = '#000';
+            buttonContainer.style.opacity = '1';
+          } else {
+            // 현재 이미지가 커버가 아니면 검정색으로 표시하고 숨김
+            coverBtn.style.background = '#000';
+            coverBtn.style.color = '#fff';
+            buttonContainer.style.opacity = '0';
+          }
+        });
+        
+        sliderWrapper.appendChild(prevBtn);
+      }
+      
+      // 다음 버튼
+      if (imageSrcs.length > 1) {
+        const nextBtn = document.createElement('button');
+        nextBtn.className = 'slider-next-btn';
+        nextBtn.innerHTML = '›';
+        nextBtn.setAttribute('contenteditable', 'false');
+        nextBtn.style.cssText = `
+          position: absolute;
+          right: 12px;
+          top: 50%;
+          transform: translateY(-50%);
+          width: 40px;
+          height: 40px;
+          background: rgba(0, 0, 0, 0.5);
+          color: #fff;
+          border: 2px solid #fff;
+          font-size: 28px;
+          font-weight: 700;
+          cursor: pointer;
+          z-index: 10;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          transition: all 0.2s;
+        `;
+        
+        nextBtn.addEventListener('mouseenter', () => {
+          nextBtn.style.background = 'rgba(0, 0, 0, 0.8)';
+        });
+        nextBtn.addEventListener('mouseleave', () => {
+          nextBtn.style.background = 'rgba(0, 0, 0, 0.5)';
+        });
+        
+        nextBtn.addEventListener('click', (evt) => {
+          evt.preventDefault();
+          evt.stopPropagation();
+          
+          const images = imagesContainer.querySelectorAll('img');
+          images[currentIndex].style.display = 'none';
+          currentIndex = (currentIndex + 1) % images.length;
+          images[currentIndex].style.display = 'block';
+          
+          // 인디케이터 업데이트
+          const indicator = sliderWrapper.querySelector('.slider-indicator') as HTMLElement;
+          if (indicator) {
+            indicator.textContent = `${currentIndex + 1}/${images.length}`;
+          }
+          
+          // COVER 버튼 상태 업데이트
+          const currentImg = images[currentIndex] as HTMLImageElement;
+          const currentSrc = currentImg.getAttribute('data-image-src');
+          if (currentSrc === selectedCoverImage) {
+            // 현재 이미지가 커버이면 노란색으로 표시하고 항상 보이게
+            coverBtn.style.background = '#FFD93D';
+            coverBtn.style.color = '#000';
+            buttonContainer.style.opacity = '1';
+          } else {
+            // 현재 이미지가 커버가 아니면 검정색으로 표시하고 숨김
+            coverBtn.style.background = '#000';
+            coverBtn.style.color = '#fff';
+            buttonContainer.style.opacity = '0';
+          }
+        });
+        
+        sliderWrapper.appendChild(nextBtn);
+      }
+      
+      // 인디케이터 (1/5)
+      const indicator = document.createElement('div');
+      indicator.className = 'slider-indicator';
+      indicator.textContent = `1/${imageSrcs.length}`;
+      indicator.style.cssText = `
+        position: absolute;
+        bottom: 12px;
+        left: 50%;
+        transform: translateX(-50%);
+        background: rgba(0, 0, 0, 0.7);
+        color: #fff;
+        padding: 4px 12px;
+        border-radius: 12px;
+        font-family: 'Share Tech Mono', monospace;
+        font-size: 12px;
+        font-weight: 700;
+        z-index: 10;
+      `;
+      sliderWrapper.appendChild(indicator);
+      
+      // 버튼 컨테이너 (COVER만)
+      const buttonContainer = document.createElement('div');
+      buttonContainer.className = 'slider-button-container';
+      buttonContainer.setAttribute('contenteditable', 'false');
+      buttonContainer.style.cssText = `
+        position: absolute;
+        top: 12px;
+        left: 12px;
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+        z-index: 10;
+        opacity: 0;
+        transition: opacity 0.2s;
+      `;
+      
+      // COVER 버튼
+      const coverBtn = document.createElement('button');
+      coverBtn.className = 'slider-cover-btn';
+      coverBtn.textContent = 'COVER';
+      coverBtn.setAttribute('contenteditable', 'false');
+      coverBtn.style.cssText = `
+        width: 70px;
+        padding: 8px;
+        border: 3px solid #000;
+        background: #000;
+        color: #fff;
+        font-family: 'Share Tech Mono', monospace;
+        font-size: 11px;
+        font-weight: 700;
+        cursor: pointer;
+        text-align: center;
+        box-shadow: 3px 3px 0px rgba(0, 0, 0, 0.5);
+        transition: all 0.2s;
+      `;
+      
+      coverBtn.addEventListener('click', (evt) => {
+        evt.preventDefault();
+        evt.stopPropagation();
+        
+        // 모든 커버 버튼 초기화 (검정 배경으로)
+        document.querySelectorAll('.slider-cover-btn, .image-cover-btn').forEach(btn => {
+          (btn as HTMLElement).style.background = '#000';
+          (btn as HTMLElement).style.color = '#fff';
+          const container = (btn as HTMLElement).parentElement;
+          if (container) {
+            container.style.opacity = '0';
+          }
+        });
+        
+        // 현재 보이는 이미지를 커버로 설정
+        const images = imagesContainer.querySelectorAll('img');
+        const currentImg = images[currentIndex] as HTMLImageElement;
+        const currentSrc = currentImg.getAttribute('data-image-src');
+        
+        setSelectedCoverImage(currentSrc);
+        coverBtn.style.background = '#FFD93D';
+        coverBtn.style.color = '#000';
+        buttonContainer.style.opacity = '1'; // 노란색일 때는 항상 보이게
+      });
+      
+      buttonContainer.appendChild(coverBtn);
+      
+      sliderWrapper.appendChild(buttonContainer);
+      
+      // 휴지통 버튼 (오른쪽 상단)
+      const deleteButtonContainer = document.createElement('div');
+      deleteButtonContainer.className = 'slider-delete-container';
+      deleteButtonContainer.setAttribute('contenteditable', 'false');
+      deleteButtonContainer.style.cssText = `
+        position: absolute;
+        top: 12px;
+        right: 12px;
+        z-index: 10;
+        opacity: 0;
+        transition: opacity 0.2s;
+      `;
+      
+      const deleteBtn = document.createElement('button');
+      deleteBtn.className = 'slider-delete-btn';
+      deleteBtn.setAttribute('contenteditable', 'false');
+      deleteBtn.style.cssText = `
+        width: 40px;
+        height: 40px;
+        border: none;
+        background: rgba(0, 0, 0, 0.6);
+        cursor: pointer;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        transition: all 0.2s;
+        border-radius: 4px;
+      `;
+      
+      // 휴지통 SVG 아이콘
+      deleteBtn.innerHTML = `
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <path d="M3 6h18M8 6V4c0-1.1.9-2 2-2h4c1.1 0 2 .9 2 2v2m3 0v14c0 1.1-.9 2-2 2H7c-1.1 0-2-.9-2-2V6h14z" 
+                stroke="white" 
+                stroke-width="2" 
+                stroke-linecap="round" 
+                stroke-linejoin="round"/>
+          <path d="M10 11v6M14 11v6" 
+                stroke="white" 
+                stroke-width="2" 
+                stroke-linecap="round" 
+                stroke-linejoin="round"/>
+        </svg>
+      `;
+      
+      deleteBtn.addEventListener('mouseenter', () => {
+        deleteBtn.style.background = 'rgba(220, 38, 38, 0.9)';
+      });
+      deleteBtn.addEventListener('mouseleave', () => {
+        deleteBtn.style.background = 'rgba(0, 0, 0, 0.6)';
+      });
+      
+      deleteBtn.addEventListener('click', (evt) => {
+        evt.preventDefault();
+        evt.stopPropagation();
+        
+        const images = imagesContainer.querySelectorAll('img');
+        
+        // 이미지가 1장만 남았으면 전체 슬라이더 삭제
+        if (images.length === 1) {
+          const src = (images[0] as HTMLImageElement).getAttribute('data-image-src');
+          if (selectedCoverImage === src) {
+            setSelectedCoverImage(null);
+          }
+          sliderWrapper.remove();
+          return;
+        }
+        
+        // 현재 이미지 삭제
+        const currentImg = images[currentIndex] as HTMLImageElement;
+        const currentSrc = currentImg.getAttribute('data-image-src');
+        
+        // 커버였다면 해제
+        if (selectedCoverImage === currentSrc) {
+          setSelectedCoverImage(null);
+        }
+        
+        currentImg.remove();
+        
+        // 인덱스 조정
+        const remainingImages = imagesContainer.querySelectorAll('img');
+        if (currentIndex >= remainingImages.length) {
+          currentIndex = remainingImages.length - 1;
+        }
+        
+        // 새로운 현재 이미지 표시
+        remainingImages.forEach((img, idx) => {
+          (img as HTMLElement).style.display = idx === currentIndex ? 'block' : 'none';
+        });
+        
+        // 인디케이터 업데이트
+        const indicator = sliderWrapper.querySelector('.slider-indicator') as HTMLElement;
+        if (indicator) {
+          indicator.textContent = `${currentIndex + 1}/${remainingImages.length}`;
+        }
+        
+        // 새로운 현재 이미지의 COVER 상태 확인
+        const newCurrentImg = remainingImages[currentIndex] as HTMLImageElement;
+        const newCurrentSrc = newCurrentImg.getAttribute('data-image-src');
+        if (newCurrentSrc === selectedCoverImage) {
+          coverBtn.style.background = '#FFD93D';
+          coverBtn.style.color = '#000';
+          buttonContainer.style.opacity = '1';
+        } else {
+          coverBtn.style.background = '#000';
+          coverBtn.style.color = '#fff';
+          buttonContainer.style.opacity = '0';
+        }
+        
+        // 이미지가 1장만 남으면 화살표 버튼 숨기기
+        if (remainingImages.length === 1) {
+          const prevBtn = sliderWrapper.querySelector('.slider-prev-btn');
+          const nextBtn = sliderWrapper.querySelector('.slider-next-btn');
+          if (prevBtn) (prevBtn as HTMLElement).style.display = 'none';
+          if (nextBtn) (nextBtn as HTMLElement).style.display = 'none';
+        }
+      });
+      
+      deleteButtonContainer.appendChild(deleteBtn);
+      
+      // 슬라이더에 마우스 올렸을 때 휴지통 버튼도 보이기
+      sliderWrapper.addEventListener('mouseenter', () => {
+        // 노란색(커버로 지정됨)이 아닐 때만 hover로 보이기
+        if (coverBtn.style.background !== 'rgb(255, 217, 61)') {
+          buttonContainer.style.opacity = '1';
+        }
+        deleteButtonContainer.style.opacity = '1';
+      });
+      sliderWrapper.addEventListener('mouseleave', () => {
+        // 노란색(커버로 지정됨)이 아닐 때만 hover 해제 시 숨기기
+        if (coverBtn.style.background !== 'rgb(255, 217, 61)') {
+          buttonContainer.style.opacity = '0';
+        }
+        deleteButtonContainer.style.opacity = '0';
+      });
+      
+      sliderWrapper.appendChild(deleteButtonContainer);
+      
+      // 에디터에 슬라이더 삽입
+      const range = savedRangeRef.current;
+      if (range) {
+        range.deleteContents();
+        range.insertNode(sliderWrapper);
+        
+        const br = document.createElement('br');
+        range.setStartAfter(sliderWrapper);
+        range.insertNode(br);
+        
+        range.setStartAfter(br);
+        range.setEndAfter(br);
+        const selection = window.getSelection();
+        selection?.removeAllRanges();
+        selection?.addRange(range);
+      } else {
+        editor.appendChild(sliderWrapper);
+        const br = document.createElement('br');
+        editor.appendChild(br);
+      }
+      
+      // 첫 번째 이미지를 커버로 설정
+      if (!selectedCoverImage && imageSrcs.length > 0) {
+        setSelectedCoverImage(imageSrcs[0]);
+        coverBtn.style.background = '#FFD93D';
+        coverBtn.style.color = '#000';
+        buttonContainer.style.opacity = '1';
+      }
+    });
+    
+    // input 초기화
+    e.target.value = '';
   };
 
   const execCommand = (command: string, value?: string) => {
-    document.execCommand(command, false, value);
     const editor = document.querySelector('.blog-editor-wysiwyg') as HTMLDivElement;
+    
+    // 먼저 에디터 포커스
+    editor?.focus();
+    
+    // selection 확인 및 설정
+    const selection = window.getSelection();
+    if (!selection || selection.rangeCount === 0) {
+      // selection이 없으면 에디터 끝에 생성
+      const range = document.createRange();
+      range.selectNodeContents(editor);
+      range.collapse(false);
+      selection?.removeAllRanges();
+      selection?.addRange(range);
+    }
+    
+    // 명령 실행
+    document.execCommand(command, false, value);
+    
+    // 다시 포커스
     editor?.focus();
   };
 
+  const toggleHeading = (tag: 'h2' | 'h3') => {
+    const selection = window.getSelection();
+    if (!selection || selection.rangeCount === 0) return;
+
+    const range = selection.getRangeAt(0);
+    let node = range.startContainer as HTMLElement;
+
+    if (node.nodeType === 3) {
+      node = node.parentElement as HTMLElement;
+    }
+
+    const currentTag = node.tagName?.toLowerCase();
+
+    if (currentTag === tag) {
+      document.execCommand('formatBlock', false, 'p');
+      setActiveHeading(null);
+    } else {
+      document.execCommand('formatBlock', false, tag);
+      setActiveHeading(tag);
+    }
+  };
+
   const handleSaveDraftClick = () => {
-    onSaveDraft(); // 임시저장 실행
+    onSaveDraft();
   };
 
   const handlePublishClick = () => {
-    // 필수 필드 검증
     const titleInput = document.querySelector('.title-input') as HTMLInputElement;
     const destinationInput = document.querySelector('.form-input') as HTMLInputElement;
     const editor = document.querySelector('.blog-editor-wysiwyg') as HTMLDivElement;
 
     const title = titleInput?.value.trim();
     const destination = destinationInput?.value.trim();
-    const content = editor?.innerText.trim();
+    const content = editor?.innerHTML.trim();
 
-    // 필수 필드가 비어있는지 확인
     if (!title) {
       alert('제목을 입력해주세요.');
       titleInput?.focus();
@@ -87,678 +685,956 @@ function WritePage({
       return;
     }
 
-    // 모든 검증 통과시 발행
-    onPublish();
+    if (!selectedCoverImage) {
+      alert('사진을 최소 1장 이상 삽입해주세요.');
+      return;
+    }
+
+    // 커버 이미지를 전역 변수에 저장 (handlePublish에서 사용)
+    (window as any).selectedCoverImageForPublish = selectedCoverImage;
+
+    // onPublish 함수 확인 후 호출
+    if (typeof onPublish === 'function') {
+      onPublish();
+    } else {
+      console.error('onPublish is not a function:', onPublish);
+      alert('발행 기능에 문제가 발생했습니다. 페이지를 새로고침 해주세요.');
+    }
   };
 
   return (
-    <div className="write-page-container">
-{/* Header - Mate Style */}
-<div style={{
-  background: '#fff',
-  padding: '24px',
-  marginBottom: '24px',
-  border: '3px solid #000',
-  boxShadow: '8px 8px 0px rgba(0, 0, 0, 1)',
-  display: 'flex',
-  justifyContent: 'space-between',
-  alignItems: 'center',
-  position: 'relative'  // X 버튼 위치 잡기 위해
-}}>
-  <h1 style={{
-    fontFamily: "'Share Tech Mono', monospace",
-    fontSize: '24px',
-    fontWeight: 700,
-    textTransform: 'uppercase',
-    letterSpacing: '2px'
-  }}>
-    {editingStory ? 'EDIT STORY' : 'WRITE NEW STORY'}
-  </h1>
-  
-  <div style={{ display: 'flex', gap: '12px', alignItems: 'center' }}>
-    {/* SAVE DRAFT 버튼 (클릭시 임시저장 + 숫자 배지) */}
-    <div style={{ position: 'relative' }}>
-      <button
-        onClick={handleSaveDraftClick}
-        style={{
-          padding: '10px 20px',
-          border: '3px solid #000',
-          background: '#fff',
-          color: '#000',
-          fontWeight: 700,
-          fontSize: '12px',
-          fontFamily: "'Share Tech Mono', monospace",
-          textTransform: 'uppercase',
-          cursor: 'pointer',
-          boxShadow: '4px 4px 0px rgba(0, 0, 0, 1)',
-          transition: 'all 0.2s',
-          display: 'flex',
-          alignItems: 'center',
-          gap: '8px'
-        }}
-        onMouseEnter={(e) => {
-          e.currentTarget.style.background = '#000';
-          e.currentTarget.style.color = '#fff';
-        }}
-        onMouseLeave={(e) => {
-          e.currentTarget.style.background = '#fff';
-          e.currentTarget.style.color = '#000';
-        }}
-      >
-        SAVE DRAFT
-      </button>
-      
-      {/* 숫자 배지 - SAVE DRAFT 버튼 오른쪽 */}
-      <div
-        onClick={onShowDraftModal}
-        style={{
-          position: 'absolute',
-          top: '-8px',
-          right: '-8px',
-          background: '#000',
-          color: '#fff',
-          padding: '4px 8px',
-          fontSize: '11px',
-          fontWeight: 700,
-          fontFamily: "'Share Tech Mono', monospace",
-          border: '2px solid #000',
-          minWidth: '28px',
-          textAlign: 'center',
-          cursor: 'pointer',
-          boxShadow: '2px 2px 0px rgba(0, 0, 0, 1)',
-          transition: 'all 0.2s'
-        }}
-        onMouseEnter={(e) => {
-          e.currentTarget.style.background = '#fff';
-          e.currentTarget.style.color = '#000';
-          e.currentTarget.style.transform = 'scale(1.1)';
-        }}
-        onMouseLeave={(e) => {
-          e.currentTarget.style.background = '#000';
-          e.currentTarget.style.color = '#fff';
-          e.currentTarget.style.transform = 'scale(1)';
-        }}
-      >
-        {drafts.length}
-      </div>
-    </div>
-    
-    <button
-      onClick={handlePublishClick}
-      style={{
-        padding: '10px 20px',
-        border: '3px solid #000',
-        background: '#000',
-        color: '#fff',
-        fontWeight: 700,
-        fontSize: '12px',
-        fontFamily: "'Share Tech Mono', monospace",
-        textTransform: 'uppercase',
-        cursor: 'pointer',
-        boxShadow: '4px 4px 0px rgba(0, 0, 0, 1)',
-        transition: 'all 0.2s'
-      }}
-      onMouseEnter={(e) => {
-        e.currentTarget.style.background = '#fff';
-        e.currentTarget.style.color = '#000';
-      }}
-      onMouseLeave={(e) => {
-        e.currentTarget.style.background = '#000';
-        e.currentTarget.style.color = '#fff';
-      }}
-    >
-      PUBLISH
-    </button>
-  </div>
-
-  {/* X Button - 헤더 박스 오른쪽 위 */}
-  <button
-    onClick={onBack}
-    style={{
-      position: 'absolute',
-      top: '-15px',
-      right: '-15px',
-      border: 'none',
-      background: '#fff',
-      cursor: 'pointer',
-      padding: '4px',
-      lineHeight: 1,
-      transition: 'all 0.2s',
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'center',
-      borderRadius: '50%',
-      boxShadow: '2px 2px 4px rgba(0, 0, 0, 0.2)',
-      zIndex: 10
-    }}
-    onMouseEnter={(e) => {
-      e.currentTarget.style.background = '#000';
-      const svg = e.currentTarget.querySelector('svg');
-      if (svg) (svg as SVGElement).style.fill = '#fff';
-    }}
-    onMouseLeave={(e) => {
-      e.currentTarget.style.background = '#fff';
-      const svg = e.currentTarget.querySelector('svg');
-      if (svg) (svg as SVGElement).style.fill = '#000';
-    }}
-  >
-    <svg 
-      xmlns="http://www.w3.org/2000/svg" 
-      viewBox="0 0 24 24" 
-      style={{ 
-        width: '24px',
-        height: '24px',
-        fill: '#000',
-        transition: 'fill 0.2s'
-      }}
-    >
-      <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/>
-    </svg>
-  </button>
-</div>
-
-      {/* Form Container - Mate Style */}
-      <div style={{
-        background: '#fff',
-        padding: '40px',
-        border: '3px solid #000',
-        boxShadow: '4px 4px 0px rgba(0, 0, 0, 1)'
-      }}>
-        {/* Title */}
-        <div style={{ marginBottom: '40px' }}>
-          <label style={{
-            display: 'block',
-            fontSize: '11px',
-            fontWeight: 700,
-            marginBottom: '12px',
-            color: 'rgba(0,0,0,0.6)',
-            textTransform: 'uppercase',
-            fontFamily: "'Share Tech Mono', monospace",
-            letterSpacing: '1px'
-          }}>
-            TITLE *
-          </label>
-          <input
-            type="text"
-            className="title-input"
-            placeholder="여행 제목을 입력하세요..."
-            defaultValue={editingStory?.title || currentDraft?.title || ''}
-            style={{
-              width: '100%',
-              padding: '15px',
-              border: '2px solid #000',
-              fontSize: '16px',
-              fontFamily: "'Share Tech Mono', monospace",
-              fontWeight: 700,
-              outline: 'none'
-            }}
-          />
-        </div>
-
-{/* Cover Image */}
-<div style={{ marginBottom: '40px' }}>
-  <label style={{
-    display: 'block',
-    fontSize: '11px',
-    fontWeight: 700,
-    marginBottom: '12px',
-    color: 'rgba(0,0,0,0.6)',
-    textTransform: 'uppercase',
-    fontFamily: "'Share Tech Mono', monospace",
-    letterSpacing: '1px'
-  }}>
-    COVER IMAGE
-  </label>
-  <label style={{
-    display: 'block',
-    width: '100%',
-    height: '350px',
-    border: '3px dashed #000',
-    cursor: 'pointer',
-    position: 'relative',
-    overflow: 'hidden',
-    background: '#fafafa'
-  }}>
-    {coverImage ? (
-      <img 
-        src={coverImage} 
-        alt="cover" 
-        style={{ 
-          width: '100%', 
-          height: '100%', 
-          objectFit: 'cover' 
-        }} 
-      />
-    ) : (
-      <div style={{
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        justifyContent: 'center',
-        height: '100%',
-        color: '#999',
-        gap: '15px'
-      }}>
-        <svg 
-          xmlns="http://www.w3.org/2000/svg" 
-          viewBox="0 0 24 24" 
-          style={{ 
-            width: '64px', 
-            height: '64px',
-            fill: '#999'
-          }}
-        >
-          <path d="M21 19V5c0-1.1-.9-2-2-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2zM8.5 13.5l2.5 3.01L14.5 12l4.5 6H5l3.5-4.5z"/>
-        </svg>
-        <div style={{ 
-          fontSize: '12px',
-          fontFamily: "'Share Tech Mono', monospace",
-          textTransform: 'uppercase',
-          letterSpacing: '1px',
-          fontWeight: 700
-        }}>
-          ADD COVER IMAGE
-        </div>
-      </div>
-    )}
-    <input
-      type="file"
-      accept="image/*"
-      onChange={handleCoverImageUpload}
-      style={{ display: 'none' }}
-    />
-  </label>
-</div>
-
-        {/* Form Grid */}
+    <div className="detail-page-container">
+      <div className="detail-page-content">
+        {/* Header */}
         <div style={{
-          display: 'grid',
-          gridTemplateColumns: 'repeat(2, 1fr)',
-          gap: '20px',
-          marginBottom: '40px'
+          background: '#fff',
+          padding: '24px',
+          marginBottom: '24px',
+          border: '3px solid #000',
+          boxShadow: '8px 8px 0px rgba(0, 0, 0, 1)',
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          position: 'relative'
         }}>
-          {/* Destination */}
-          <div>
-            <label style={{
-              display: 'block',
-              fontSize: '11px',
-              fontWeight: 700,
-              marginBottom: '12px',
-              color: 'rgba(0,0,0,0.6)',
-              textTransform: 'uppercase',
-              fontFamily: "'Share Tech Mono', monospace",
-              letterSpacing: '1px'
-            }}>
-              DESTINATION *
-            </label>
-            <input
-              type="text"
-              className="form-input"
-              placeholder="예: 경주"
-              defaultValue={editingStory?.destination || currentDraft?.destination || ''}
-              style={{
-                width: '100%',
-                padding: '12px',
-                border: '2px solid #000',
-                fontSize: '13px',
-                fontFamily: "'Share Tech Mono', monospace",
-                fontWeight: 700,
-                outline: 'none'
-              }}
-            />
-          </div>
-
-          {/* Duration */}
-          <div>
-            <label style={{
-              display: 'block',
-              fontSize: '11px',
-              fontWeight: 700,
-              marginBottom: '12px',
-              color: 'rgba(0,0,0,0.6)',
-              textTransform: 'uppercase',
-              fontFamily: "'Share Tech Mono', monospace",
-              letterSpacing: '1px'
-            }}>
-              DURATION
-            </label>
-            <select
-              className="form-select"
-              defaultValue={editingStory?.duration || currentDraft?.duration || ''}
-              style={{
-                width: '100%',
-                padding: '12px',
-                border: '2px solid #000',
-                fontSize: '13px',
-                fontFamily: "'Share Tech Mono', monospace",
-                fontWeight: 700,
-                outline: 'none',
-                cursor: 'pointer'
-              }}
-            >
-              <option>선택하세요</option>
-              <option>당일치기</option>
-              <option>1박 2일</option>
-              <option>2박 3일</option>
-              <option>3박 4일</option>
-              <option>4박 5일</option>
-              <option>5박 6일</option>
-              <option>1주일 이상</option>
-            </select>
-          </div>
-
-          {/* Departure Date */}
-          <div>
-            <label style={{
-              display: 'block',
-              fontSize: '11px',
-              fontWeight: 700,
-              marginBottom: '12px',
-              color: 'rgba(0,0,0,0.6)',
-              textTransform: 'uppercase',
-              fontFamily: "'Share Tech Mono', monospace",
-              letterSpacing: '1px'
-            }}>
-              DEPARTURE DATE
-            </label>
-            <input
-              type="date"
-              className="form-input"
-              defaultValue={editingStory?.departureDate || currentDraft?.departureDate || ''}
-              style={{
-                width: '100%',
-                padding: '12px',
-                border: '2px solid #000',
-                fontSize: '13px',
-                fontFamily: "'Share Tech Mono', monospace",
-                fontWeight: 700,
-                outline: 'none'
-              }}
-            />
-          </div>
-
-          {/* Budget */}
-          <div>
-            <label style={{
-              display: 'block',
-              fontSize: '11px',
-              fontWeight: 700,
-              marginBottom: '12px',
-              color: 'rgba(0,0,0,0.6)',
-              textTransform: 'uppercase',
-              fontFamily: "'Share Tech Mono', monospace",
-              letterSpacing: '1px'
-            }}>
-              BUDGET (₩)
-            </label>
-            <input
-              type="number"
-              className="form-input"
-              placeholder="328000"
-              defaultValue={editingStory?.budget || currentDraft?.budget || ''}
-              style={{
-                width: '100%',
-                padding: '12px',
-                border: '2px solid #000',
-                fontSize: '13px',
-                fontFamily: "'Share Tech Mono', monospace",
-                fontWeight: 700,
-                outline: 'none'
-              }}
-            />
-          </div>
-        </div>
-
-        {/* Travel Style */}
-        <div style={{ marginBottom: '40px' }}>
-          <label style={{
-            display: 'block',
-            fontSize: '11px',
-            fontWeight: 700,
-            marginBottom: '12px',
-            color: 'rgba(0,0,0,0.6)',
-            textTransform: 'uppercase',
+          <h1 style={{
             fontFamily: "'Share Tech Mono', monospace",
-            letterSpacing: '1px'
+            fontSize: '24px',
+            fontWeight: 700,
+            textTransform: 'uppercase',
+            letterSpacing: '2px'
           }}>
-            TRAVEL STYLE
-          </label>
-          <div style={{
-            display: 'flex',
-            flexWrap: 'wrap',
-            gap: '10px'
-          }}>
-            {['힐링여행', '액티비티', '맛집투어', '문화탐방', '쇼핑', '사진명소', '가성비', '럭셔리'].map((tag) => (
+            {editingStory ? 'EDIT STORY' : 'WRITE NEW STORY'}
+          </h1>
+          
+          <div style={{ display: 'flex', gap: '12px', alignItems: 'center' }}>
+            <div style={{ position: 'relative' }}>
               <button
-                key={tag}
-                type="button"
-                className="style-tag"
+                onClick={handleSaveDraftClick}
                 style={{
-                  padding: '8px 16px',
-                  border: '2px solid #000',
+                  padding: '10px 20px',
+                  border: '3px solid #000',
                   background: '#fff',
+                  color: '#000',
+                  fontWeight: 700,
+                  fontSize: '12px',
+                  fontFamily: "'Share Tech Mono', monospace",
+                  textTransform: 'uppercase',
+                  cursor: 'pointer',
+                  boxShadow: '4px 4px 0px rgba(0, 0, 0, 1)',
+                  transition: 'all 0.2s',
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '8px'
+                }}
+                onMouseEnter={(e) => {
+                  e.currentTarget.style.background = '#000';
+                  e.currentTarget.style.color = '#fff';
+                }}
+                onMouseLeave={(e) => {
+                  e.currentTarget.style.background = '#fff';
+                  e.currentTarget.style.color = '#000';
+                }}
+              >
+                SAVE DRAFT
+              </button>
+              
+              <div
+                onClick={onOpenDraftModal}
+                style={{
+                  position: 'absolute',
+                  top: '-8px',
+                  right: '-8px',
+                  background: '#000',
+                  color: '#fff',
+                  padding: '4px 8px',
                   fontSize: '11px',
                   fontWeight: 700,
                   fontFamily: "'Share Tech Mono', monospace",
+                  border: '2px solid #000',
+                  minWidth: '28px',
+                  textAlign: 'center',
                   cursor: 'pointer',
+                  boxShadow: '2px 2px 0px rgba(0, 0, 0, 1)',
                   transition: 'all 0.2s'
                 }}
-                onClick={(e) => {
-                  const btn = e.currentTarget;
-                  const isActive = btn.style.background === 'rgb(0, 0, 0)';
-                  btn.style.background = isActive ? '#fff' : '#000';
-                  btn.style.color = isActive ? '#000' : '#fff';
-                  if (!isActive) {
-                    btn.style.boxShadow = '2px 2px 0px rgba(0,0,0,1)';
-                    btn.style.transform = 'translate(-1px, -1px)';
-                  } else {
-                    btn.style.boxShadow = 'none';
-                    btn.style.transform = 'none';
-                  }
+                onMouseEnter={(e) => {
+                  e.currentTarget.style.background = '#fff';
+                  e.currentTarget.style.color = '#000';
+                  e.currentTarget.style.transform = 'scale(1.1)';
+                }}
+                onMouseLeave={(e) => {
+                  e.currentTarget.style.background = '#000';
+                  e.currentTarget.style.color = '#fff';
+                  e.currentTarget.style.transform = 'scale(1)';
                 }}
               >
-                {tag}
+                {drafts.length}
+              </div>
+            </div>
+            
+            <button
+              onClick={handlePublishClick}
+              style={{
+                padding: '10px 20px',
+                border: '3px solid #000',
+                background: '#000',
+                color: '#fff',
+                fontWeight: 700,
+                fontSize: '12px',
+                fontFamily: "'Share Tech Mono', monospace",
+                textTransform: 'uppercase',
+                cursor: 'pointer',
+                boxShadow: '4px 4px 0px rgba(0, 0, 0, 1)',
+                transition: 'all 0.2s'
+              }}
+              onMouseEnter={(e) => {
+                e.currentTarget.style.background = '#fff';
+                e.currentTarget.style.color = '#000';
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.background = '#000';
+                e.currentTarget.style.color = '#fff';
+              }}
+            >
+              PUBLISH
+            </button>
+          </div>
+
+          {/* X Button */}
+          <button
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+
+              // ⭐ 글을 쓴 경우에만 모달 표시
+              if (hasContent()) {
+                setConfirmAction('back');
+                setShowConfirmModal(true);
+              } else {
+                goBack();
+              }
+            }}
+            style={{
+              position: 'absolute',
+              top: '-15px',
+              right: '-15px',
+              width: '40px',
+              height: '40px',
+              border: '2px solid #000',
+              background: '#fff',
+              cursor: 'pointer',
+              padding: 0,
+              lineHeight: 1,
+              transition: 'all 0.2s',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              borderRadius: '50%',
+              boxShadow: '2px 2px 4px rgba(0, 0, 0, 0.2)',
+              zIndex: 100
+            }}
+            onMouseEnter={(e) => {
+              e.currentTarget.style.background = '#000';
+              const svg = e.currentTarget.querySelector('svg');
+              if (svg) (svg as SVGElement).style.fill = '#fff';
+            }}
+            onMouseLeave={(e) => {
+              e.currentTarget.style.background = '#fff';
+              const svg = e.currentTarget.querySelector('svg');
+              if (svg) (svg as SVGElement).style.fill = '#000';
+            }}
+          >
+            <svg 
+              xmlns="http://www.w3.org/2000/svg" 
+              viewBox="0 0 24 24" 
+              style={{ 
+                width: '24px',
+                height: '24px',
+                fill: '#000',
+                transition: 'fill 0.2s',
+                pointerEvents: 'none'
+              }}
+            >
+              <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/>
+            </svg>
+          </button>
+        </div>
+
+        {/* Form Container */}
+        <div style={{
+          background: '#fff',
+          padding: '40px',
+          border: '3px solid #000',
+          boxShadow: '4px 4px 0px rgba(0, 0, 0, 1)'
+        }}>
+          {/* Title */}
+          <div style={{ marginBottom: '40px' }}>
+            <label style={{
+              display: 'block',
+              fontSize: '11px',
+              fontWeight: 700,
+              marginBottom: '12px',
+              color: 'rgba(0,0,0,0.6)',
+              textTransform: 'uppercase',
+              fontFamily: "'Share Tech Mono', monospace",
+              letterSpacing: '1px'
+            }}>
+              TITLE *
+            </label>
+            <input
+              type="text"
+              className="title-input"
+              placeholder="여행 제목을 입력하세요..."
+              defaultValue={editingStory?.title || currentDraft?.title || ''}
+              style={{
+                width: '100%',
+                padding: '15px',
+                border: '2px solid #000',
+                fontSize: '16px',
+                fontFamily: "'Share Tech Mono', monospace",
+                fontWeight: 700,
+                outline: 'none'
+              }}
+            />
+          </div>
+
+          {/* Form Grid */}
+          <div style={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(2, 1fr)',
+            gap: '20px',
+            marginBottom: '40px'
+          }}>
+            <div>
+              <label style={{
+                display: 'block',
+                fontSize: '11px',
+                fontWeight: 700,
+                marginBottom: '12px',
+                color: 'rgba(0,0,0,0.6)',
+                textTransform: 'uppercase',
+                fontFamily: "'Share Tech Mono', monospace",
+                letterSpacing: '1px'
+              }}>
+                DESTINATION *
+              </label>
+              <input
+                type="text"
+                className="form-input"
+                placeholder="예: 경주"
+                defaultValue={editingStory?.destination || currentDraft?.destination || ''}
+                style={{
+                  width: '100%',
+                  padding: '12px',
+                  border: '2px solid #000',
+                  fontSize: '13px',
+                  fontFamily: "'Share Tech Mono', monospace",
+                  fontWeight: 700,
+                  outline: 'none'
+                }}
+              />
+            </div>
+
+            <div>
+              <label style={{
+                display: 'block',
+                fontSize: '11px',
+                fontWeight: 700,
+                marginBottom: '12px',
+                color: 'rgba(0,0,0,0.6)',
+                textTransform: 'uppercase',
+                fontFamily: "'Share Tech Mono', monospace",
+                letterSpacing: '1px'
+              }}>
+                DURATION
+              </label>
+              <select
+                className="form-select"
+                defaultValue={editingStory?.duration || currentDraft?.duration || '선택하세요'}
+                style={{
+                  width: '100%',
+                  padding: '12px',
+                  border: '2px solid #000',
+                  fontSize: '13px',
+                  fontFamily: "'Share Tech Mono', monospace",
+                  fontWeight: 700,
+                  outline: 'none',
+                  cursor: 'pointer'
+                }}
+              >
+                <option>선택하세요</option>
+                <option>당일치기</option>
+                <option>1박 2일</option>
+                <option>2박 3일</option>
+                <option>3박 4일</option>
+                <option>4박 5일</option>
+                <option>5박 6일</option>
+                <option>1주일 이상</option>
+              </select>
+            </div>
+
+            <div>
+              <label style={{
+                display: 'block',
+                fontSize: '11px',
+                fontWeight: 700,
+                marginBottom: '12px',
+                color: 'rgba(0,0,0,0.6)',
+                textTransform: 'uppercase',
+                fontFamily: "'Share Tech Mono', monospace",
+                letterSpacing: '1px'
+              }}>
+                DEPARTURE DATE
+              </label>
+              <input
+                type="date"
+                className="form-input"
+                defaultValue={editingStory?.departureDate || currentDraft?.departureDate || ''}
+                style={{
+                  width: '100%',
+                  padding: '12px',
+                  border: '2px solid #000',
+                  fontSize: '13px',
+                  fontFamily: "'Share Tech Mono', monospace",
+                  fontWeight: 700,
+                  outline: 'none'
+                }}
+              />
+            </div>
+
+            <div>
+              <label style={{
+                display: 'block',
+                fontSize: '11px',
+                fontWeight: 700,
+                marginBottom: '12px',
+                color: 'rgba(0,0,0,0.6)',
+                textTransform: 'uppercase',
+                fontFamily: "'Share Tech Mono', monospace",
+                letterSpacing: '1px'
+              }}>
+                BUDGET (₩)
+              </label>
+              <input
+                type="number"
+                className="form-input"
+                placeholder="328000"
+                defaultValue={editingStory?.budget || currentDraft?.budget || ''}
+                style={{
+                  width: '100%',
+                  padding: '12px',
+                  border: '2px solid #000',
+                  fontSize: '13px',
+                  fontFamily: "'Share Tech Mono', monospace",
+                  fontWeight: 700,
+                  outline: 'none'
+                }}
+              />
+            </div>
+          </div>
+
+          {/* Travel Style */}
+          <div style={{ marginBottom: '40px' }}>
+            <label style={{
+              display: 'block',
+              fontSize: '11px',
+              fontWeight: 700,
+              marginBottom: '12px',
+              color: 'rgba(0,0,0,0.6)',
+              textTransform: 'uppercase',
+              fontFamily: "'Share Tech Mono', monospace",
+              letterSpacing: '1px'
+            }}>
+              TRAVEL STYLE
+            </label>
+            <div style={{
+              display: 'flex',
+              flexWrap: 'wrap',
+              gap: '10px'
+            }}>
+              {['힐링여행', '액티비티', '맛집투어', '문화탐방', '쇼핑', '사진명소', '가성비', '럭셔리'].map((tag) => (
+                <button
+                  key={tag}
+                  type="button"
+                  className="style-tag"
+                  style={{
+                    padding: '8px 16px',
+                    border: '2px solid #000',
+                    background: '#fff',
+                    fontSize: '11px',
+                    fontWeight: 700,
+                    fontFamily: "'Share Tech Mono', monospace",
+                    cursor: 'pointer',
+                    transition: 'all 0.2s'
+                  }}
+                  onClick={(e) => {
+                    const btn = e.currentTarget;
+                    const isActive = btn.style.background === 'rgb(0, 0, 0)';
+                    btn.style.background = isActive ? '#fff' : '#000';
+                    btn.style.color = isActive ? '#000' : '#fff';
+                    if (!isActive) {
+                      btn.style.boxShadow = '2px 2px 0px rgba(0,0,0,1)';
+                      btn.style.transform = 'translate(-1px, -1px)';
+                    } else {
+                      btn.style.boxShadow = 'none';
+                      btn.style.transform = 'none';
+                    }
+                  }}
+                >
+                  {tag}
+                </button>
+              ))}
+            </div>
+          </div>
+
+
+          {/* Content Editor */}
+          <div>
+            <label style={{
+              display: 'block',
+              fontSize: '11px',
+              fontWeight: 700,
+              marginBottom: '12px',
+              color: 'rgba(0,0,0,0.6)',
+              textTransform: 'uppercase',
+              fontFamily: "'Share Tech Mono', monospace",
+              letterSpacing: '1px'
+            }}>
+              CONTENT * 
+            </label>
+
+            {/* Toolbar */}
+            <div style={{
+              display: 'flex',
+              gap: '0',
+              background: '#f5f5f5',
+              border: '2px solid #000',
+              borderBottom: 'none'
+            }}>
+              <button
+                type="button"
+                onClick={() => toggleHeading('h2')}
+                style={{
+                  width: '50px',
+                  height: '50px',
+                  border: 'none',
+                  borderRight: '2px solid #000',
+                  background: 'transparent',
+                  fontSize: '14px',
+                  fontWeight: 700,
+                  fontFamily: "'Share Tech Mono', monospace",
+                  cursor: 'pointer',
+                  transition: 'background 0.2s',
+                  textDecoration: activeHeading === 'h2' ? 'underline' : 'none',
+                  textDecorationThickness: '3px',
+                  textUnderlineOffset: '4px'
+                }}
+                onMouseEnter={(e) => e.currentTarget.style.background = '#fff'}
+                onMouseLeave={(e) => e.currentTarget.style.background = 'transparent'}
+                title="헤딩"
+              >
+                H
               </button>
-            ))}
+              <button
+                type="button"
+                onClick={() => toggleHeading('h3')}
+                style={{
+                  width: '50px',
+                  height: '50px',
+                  border: 'none',
+                  borderRight: '2px solid #000',
+                  background: 'transparent',
+                  fontSize: '12px',
+                  fontWeight: 700,
+                  fontFamily: "'Share Tech Mono', monospace",
+                  cursor: 'pointer',
+                  transition: 'background 0.2s',
+                  textDecoration: activeHeading === 'h3' ? 'underline' : 'none',
+                  textDecorationThickness: '3px',
+                  textUnderlineOffset: '4px'
+                }}
+                onMouseEnter={(e) => e.currentTarget.style.background = '#fff'}
+                onMouseLeave={(e) => e.currentTarget.style.background = 'transparent'}
+                title="서브헤딩"
+              >
+                h
+              </button>
+              <button
+                type="button"
+                onClick={() => execCommand('bold')}
+                style={{
+                  width: '50px',
+                  height: '50px',
+                  border: 'none',
+                  borderRight: '2px solid #000',
+                  background: 'transparent',
+                  fontSize: '14px',
+                  fontWeight: 700,
+                  fontFamily: "'Share Tech Mono', monospace",
+                  cursor: 'pointer',
+                  transition: 'background 0.2s'
+                }}
+                onMouseEnter={(e) => e.currentTarget.style.background = '#fff'}
+                onMouseLeave={(e) => e.currentTarget.style.background = 'transparent'}
+                title="볼드"
+              >
+                B
+              </button>
+
+              <button
+                type="button"
+                onClick={() => {
+                  const editor = document.querySelector('.blog-editor-wysiwyg') as HTMLDivElement;
+                  editor?.focus();
+                  
+                  const selection = window.getSelection();
+                  if (selection && selection.rangeCount > 0) {
+                    const range = selection.getRangeAt(0);
+                    let node = range.startContainer as HTMLElement;
+                    
+                    // 텍스트 노드면 부모 요소로
+                    if (node.nodeType === 3) {
+                      node = node.parentElement as HTMLElement;
+                    }
+                    
+                    // 현재 ol 안에 있는지 확인
+                    let currentList = node.closest('ol');
+                    
+                    if (currentList && currentList.parentElement === editor) {
+                      // 목록 해제: ol을 p로 변환
+                      const listItems = Array.from(currentList.querySelectorAll('li'));
+                      listItems.forEach(li => {
+                        const p = document.createElement('p');
+                        p.innerHTML = li.innerHTML;
+                        currentList!.parentNode!.insertBefore(p, currentList);
+                      });
+                      currentList.remove();
+                      setActiveList(null);
+                    } else {
+                      // 목록 적용
+                      const ol = document.createElement('ol');
+                      ol.style.marginLeft = '20px';
+                      ol.style.marginTop = '10px';
+                      ol.style.marginBottom = '10px';
+                      
+                      const li = document.createElement('li');
+                      li.innerHTML = '<br>';
+                      ol.appendChild(li);
+                      
+                      range.deleteContents();
+                      range.insertNode(ol);
+                      
+                      // 커서를 li 안으로 이동
+                      range.setStart(li, 0);
+                      range.collapse(true);
+                      selection.removeAllRanges();
+                      selection.addRange(range);
+                      
+                      setActiveList('ol');
+                    }
+                  }
+                  
+                  editor?.focus();
+                }}
+                style={{
+                  width: '50px',
+                  height: '50px',
+                  border: 'none',
+                  borderRight: '2px solid #000',
+                  background: 'transparent',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  cursor: 'pointer',
+                  transition: 'background 0.2s',
+                  position: 'relative'
+                }}
+                onMouseEnter={(e) => e.currentTarget.style.background = '#fff'}
+                onMouseLeave={(e) => e.currentTarget.style.background = 'transparent'}
+                title="숫자 목록"
+              >
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none">
+                  <path d="M4 6h2v2H4V6zm0 5h2v2H4v-2zm0 5h2v2H4v-2zM8 6h12M8 11h12M8 16h12"
+                    stroke="#000"
+                    strokeWidth="2"
+                  />
+                </svg>
+                {activeList === 'ol' && (
+                  <div style={{
+                    position: 'absolute',
+                    bottom: '8px',
+                    left: '50%',
+                    transform: 'translateX(-50%)',
+                    width: '30px',
+                    height: '3px',
+                    background: '#000'
+                  }} />
+                )}
+              </button>
+
+
+             <button
+              type="button"
+              onClick={() => {
+                const editor = document.querySelector('.blog-editor-wysiwyg') as HTMLDivElement;
+                editor?.focus();
+                
+                const selection = window.getSelection();
+                if (selection && selection.rangeCount > 0) {
+                  const range = selection.getRangeAt(0);
+                  let node = range.startContainer as HTMLElement;
+                  
+                  // 텍스트 노드면 부모 요소로
+                  if (node.nodeType === 3) {
+                    node = node.parentElement as HTMLElement;
+                  }
+                  
+                  // 현재 ul 안에 있는지 확인
+                  let currentList = node.closest('ul');
+                  
+                  if (currentList && currentList.parentElement === editor) {
+                    // 목록 해제: ul을 p로 변환
+                    const listItems = Array.from(currentList.querySelectorAll('li'));
+                    listItems.forEach(li => {
+                      const p = document.createElement('p');
+                      p.innerHTML = li.innerHTML;
+                      currentList!.parentNode!.insertBefore(p, currentList);
+                    });
+                    currentList.remove();
+                    setActiveList(null);
+                  } else {
+                    // 목록 적용
+                    const ul = document.createElement('ul');
+                    ul.style.marginLeft = '20px';
+                    ul.style.marginTop = '10px';
+                    ul.style.marginBottom = '10px';
+                    
+                    const li = document.createElement('li');
+                    li.innerHTML = '<br>';
+                    ul.appendChild(li);
+                    
+                    range.deleteContents();
+                    range.insertNode(ul);
+                    
+                    // 커서를 li 안으로 이동
+                    range.setStart(li, 0);
+                    range.collapse(true);
+                    selection.removeAllRanges();
+                    selection.addRange(range);
+                    
+                    setActiveList('ul');
+                  }
+                }
+                
+                editor?.focus();
+              }}
+              style={{
+                width: '50px',
+                height: '50px',
+                border: 'none',
+                borderRight: '2px solid #000',
+                background: 'transparent',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                cursor: 'pointer',
+                transition: 'background 0.2s',
+                position: 'relative'
+              }}
+              onMouseEnter={(e) => e.currentTarget.style.background = '#fff'}
+              onMouseLeave={(e) => e.currentTarget.style.background = 'transparent'}
+              title="기호 목록"
+            >
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none">
+                <circle cx="5" cy="6" r="1.5" fill="#000" />
+                <circle cx="5" cy="12" r="1.5" fill="#000" />
+                <circle cx="5" cy="18" r="1.5" fill="#000" />
+                <line x1="9" y1="6" x2="21" y2="6" stroke="#000" strokeWidth="2" />
+                <line x1="9" y1="12" x2="21" y2="12" stroke="#000" strokeWidth="2" />
+                <line x1="9" y1="18" x2="21" y2="18" stroke="#000" strokeWidth="2" />
+              </svg>
+              {activeList === 'ul' && (
+                <div style={{
+                  position: 'absolute',
+                  bottom: '8px',
+                  left: '50%',
+                  transform: 'translateX(-50%)',
+                  width: '30px',
+                  height: '3px',
+                  background: '#000'
+                }} />
+              )}
+            </button>
+
+
+              <label
+                style={{
+                  width: '50px',
+                  height: '50px',
+                  borderRight: '2px solid #000',
+                  cursor: 'pointer',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  transition: 'background 0.2s'
+                }}
+                onMouseEnter={(e) => e.currentTarget.style.background = '#fff'}
+                onMouseLeave={(e) => e.currentTarget.style.background = 'transparent'}
+                title="이미지 삽입 (커서 위치에 삽입됩니다)"
+              >
+                <svg 
+                  xmlns="http://www.w3.org/2000/svg" 
+                  viewBox="0 0 24 24" 
+                  style={{ 
+                    width: '24px', 
+                    height: '24px',
+                    fill: '#000'
+                  }}
+                >
+                  <path d="M21 19V5c0-1.1-.9-2-2-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2zM8.5 13.5l2.5 3.01L14.5 12l4.5 6H5l3.5-4.5z"/>
+                </svg>
+                <input
+                  type="file"
+                  accept="image/*"
+                  multiple
+                  onChange={handleImageInsert}
+                  style={{ display: 'none' }}
+                />
+              </label>
+              
+              <button
+                type="button"
+                onClick={() => execCommand('justifyCenter')}
+                style={{
+                  width: '50px',
+                  height: '50px',
+                  border: 'none',
+                  background: 'transparent',
+                  cursor: 'pointer',
+                  transition: 'background 0.2s',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center'
+                }}
+                onMouseEnter={(e) => e.currentTarget.style.background = '#fff'}
+                onMouseLeave={(e) => e.currentTarget.style.background = 'transparent'}
+                title="가운데 정렬"
+              >
+                <svg 
+                  xmlns="http://www.w3.org/2000/svg" 
+                  viewBox="0 0 24 24" 
+                  style={{ 
+                    width: '20px', 
+                    height: '20px',
+                    fill: '#000'
+                  }}
+                >
+                  <path d="M7 15v2h10v-2H7zm-4 6h18v-2H3v2zm0-8h18v-2H3v2zm4-6v2h10V7H7zM3 3v2h18V3H3z"/>
+                </svg>
+              </button>
+            </div>
+
+            {/* Editor */}
+            <div
+              className="blog-editor-wysiwyg"
+              contentEditable="true"
+
+              onKeyUp={() => {
+                const sel = window.getSelection();
+                if (sel && sel.rangeCount > 0) {
+                  savedRangeRef.current = sel.getRangeAt(0);
+                }
+              }}
+              onMouseUp={() => {
+                const sel = window.getSelection();
+                if (sel && sel.rangeCount > 0) {
+                  savedRangeRef.current = sel.getRangeAt(0);
+                }
+              }}
+
+              dangerouslySetInnerHTML={
+                (editingStory || currentDraft) 
+                  ? { __html: editingStory?.description || currentDraft?.content || '' } 
+                  : undefined
+              }
+              style={{
+                width: '100%',
+                minHeight: '600px',
+                padding: '30px',
+                border: '2px solid #000',
+                fontSize: '15px',
+                lineHeight: '1.8',
+                fontFamily: "'Share Tech Mono', monospace",
+                outline: 'none',
+                background: '#fff'
+              }}
+            ></div>
           </div>
         </div>
 
-{/* Content Editor */}
-<div>
-  <label style={{
-    display: 'block',
-    fontSize: '11px',
-    fontWeight: 700,
-    marginBottom: '12px',
-    color: 'rgba(0,0,0,0.6)',
-    textTransform: 'uppercase',
-    fontFamily: "'Share Tech Mono', monospace",
-    letterSpacing: '1px'
-  }}>
-    CONTENT *
-  </label>
+        <style>{`
+          .blog-editor-wysiwyg:empty:before {
+            content: "여행 이야기를 자유롭게 작성해주세요...";
+            color: #999;
+          }
+          .blog-editor-wysiwyg h2 {
+            font-size: 24px;
+            font-weight: 700;
+            margin: 30px 0 15px 0;
+            padding-bottom: 10px;
+            border-bottom: 3px solid #000;
+          }
+          .blog-editor-wysiwyg h3 {
+            font-size: 18px;
+            font-weight: 700;
+            margin: 25px 0 12px 0;
+          }
+          .blog-editor-wysiwyg p {
+            margin: 15px 0;
+          }
+          .blog-editor-wysiwyg ol {
+            margin: 15px 0;
+            padding-left: 30px;
+            list-style-type: decimal;
+          }
+          .blog-editor-wysiwyg ul {
+            margin: 15px 0;
+            padding-left: 30px;
+            list-style-type: disc;
+          }
+          .blog-editor-wysiwyg li {
+            margin: 8px 0;
+            line-height: 1.8;
+          }
+          .blog-editor-wysiwyg img {
+            width: 693px;
+            height: 619px;
+            max-width: 100%;
+            object-fit: cover;
+            display: block;
+            margin: 0 auto;
+          }
+          .blog-editor-wysiwyg hr {
+            border: none;
+            border-top: 3px solid #000;
+            margin: 30px 0;
+          }
+          .blog-editor-wysiwyg .inserted-image-wrapper {
+            position: relative;
+            text-align: center;
+            margin: 20px auto;
+            display: flex;
+            align-items: flex-start;
+            justify-content: center;
+            gap: 10px;
+            max-width: 100%;
+            overflow: visible;
+          }
+          .blog-editor-wysiwyg .image-slider-wrapper {
+            position: relative;
+            width: 693px;
+            max-width: 100%;
+            margin: 20px auto;
+            background: #f5f5f5;
+            border: 3px solid #000;
+            box-shadow: 4px 4px 0px rgba(0, 0, 0, 1);
+          }
+          .blog-editor-wysiwyg .slider-images-container {
+            position: relative;
+            width: 100%;
+            height: 619px;
+            overflow: hidden;
+          }
+          .blog-editor-wysiwyg .slider-prev-btn,
+          .blog-editor-wysiwyg .slider-next-btn {
+            position: absolute;
+            top: 50%;
+            transform: translateY(-50%);
+            width: 40px;
+            height: 40px;
+            background: rgba(0, 0, 0, 0.5);
+            color: #fff;
+            border: 2px solid #fff;
+            font-size: 28px;
+            font-weight: 700;
+            cursor: pointer;
+            z-index: 10;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            transition: all 0.2s;
+          }
+          .blog-editor-wysiwyg .slider-prev-btn {
+            left: 12px;
+          }
+          .blog-editor-wysiwyg .slider-next-btn {
+            right: 12px;
+          }
+          .blog-editor-wysiwyg .slider-prev-btn:hover,
+          .blog-editor-wysiwyg .slider-next-btn:hover {
+            background: rgba(0, 0, 0, 0.8);
+          }
+          .blog-editor-wysiwyg .slider-indicator {
+            position: absolute;
+            bottom: 12px;
+            left: 50%;
+            transform: translateX(-50%);
+            background: rgba(0, 0, 0, 0.7);
+            color: #fff;
+            padding: 4px 12px;
+            border-radius: 12px;
+            font-family: 'Share Tech Mono', monospace;
+            font-size: 12px;
+            font-weight: 700;
+            z-index: 10;
+          }
+          .blog-editor-wysiwyg .image-button-container {
+            user-select: none;
+            -webkit-user-select: none;
+          }
+          .blog-editor-wysiwyg .image-cover-btn:hover,
+          .blog-editor-wysiwyg .image-delete-btn:hover {
+            transform: translate(-1px, -1px);
+          }
+        `}</style>
 
-  {/* Toolbar */}
-  <div style={{
-    display: 'flex',
-    gap: '0',
-    background: '#f5f5f5',
-    border: '2px solid #000',
-    borderBottom: 'none'
-  }}>
-    <button
-      type="button"
-      onClick={() => execCommand('formatBlock', '<h2>')}
-      style={{
-        width: '50px',
-        height: '50px',
-        border: 'none',
-        borderRight: '2px solid #000',
-        background: 'transparent',
-        fontSize: '14px',
-        fontWeight: 700,
-        fontFamily: "'Share Tech Mono', monospace",
-        cursor: 'pointer',
-        transition: 'background 0.2s'
-      }}
-      onMouseEnter={(e) => e.currentTarget.style.background = '#fff'}
-      onMouseLeave={(e) => e.currentTarget.style.background = 'transparent'}
-      title="헤딩"
-    >
-      H
-    </button>
-    <button
-      type="button"
-      onClick={() => execCommand('formatBlock', '<h3>')}
-      style={{
-        width: '50px',
-        height: '50px',
-        border: 'none',
-        borderRight: '2px solid #000',
-        background: 'transparent',
-        fontSize: '12px',
-        fontWeight: 700,
-        fontFamily: "'Share Tech Mono', monospace",
-        cursor: 'pointer',
-        transition: 'background 0.2s'
-      }}
-      onMouseEnter={(e) => e.currentTarget.style.background = '#fff'}
-      onMouseLeave={(e) => e.currentTarget.style.background = 'transparent'}
-      title="서브헤딩"
-    >
-      h
-    </button>
-    <button
-      type="button"
-      onClick={() => execCommand('bold')}
-      style={{
-        width: '50px',
-        height: '50px',
-        border: 'none',
-        borderRight: '2px solid #000',
-        background: 'transparent',
-        fontSize: '14px',
-        fontWeight: 700,
-        fontFamily: "'Share Tech Mono', monospace",
-        cursor: 'pointer',
-        transition: 'background 0.2s'
-      }}
-      onMouseEnter={(e) => e.currentTarget.style.background = '#fff'}
-      onMouseLeave={(e) => e.currentTarget.style.background = 'transparent'}
-      title="볼드"
-    >
-      B
-    </button>
-    <label
-      style={{
-        width: '50px',
-        height: '50px',
-        borderRight: '2px solid #000',
-        cursor: 'pointer',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        transition: 'background 0.2s'
-      }}
-      onMouseEnter={(e) => e.currentTarget.style.background = '#fff'}
-      onMouseLeave={(e) => e.currentTarget.style.background = 'transparent'}
-      title="이미지 삽입"
-    >
-      <svg 
-        xmlns="http://www.w3.org/2000/svg" 
-        viewBox="0 0 24 24" 
-        style={{ 
-          width: '24px', 
-          height: '24px',
-          fill: '#000'
-        }}
-      >
-        <path d="M21 19V5c0-1.1-.9-2-2-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2zM8.5 13.5l2.5 3.01L14.5 12l4.5 6H5l3.5-4.5z"/>
-      </svg>
-      <input
-        type="file"
-        accept="image/*"
-        onChange={handleImageInsert}
-        style={{ display: 'none' }}
-      />
-    </label>
-    <button
-      type="button"
-      onClick={() => execCommand('insertHorizontalRule')}
-      style={{
-        width: '50px',
-        height: '50px',
-        border: 'none',
-        background: 'transparent',
-        fontSize: '18px',
-        fontFamily: "'Share Tech Mono', monospace",
-        cursor: 'pointer',
-        transition: 'background 0.2s'
-      }}
-      onMouseEnter={(e) => e.currentTarget.style.background = '#fff'}
-      onMouseLeave={(e) => e.currentTarget.style.background = 'transparent'}
-      title="구분선"
-    >
-      —
-    </button>
-  </div>
-
-  {/* Editor */}
-  <div
-    className="blog-editor-wysiwyg"
-    contentEditable="true"
-    dangerouslySetInnerHTML={
-      (editingStory || currentDraft) 
-        ? { __html: editingStory?.description || currentDraft?.content || '' } 
-        : undefined
-    }
-    style={{
-      width: '100%',
-      minHeight: '400px',
-      padding: '30px',
-      border: '2px solid #000',
-      fontSize: '15px',
-      lineHeight: '1.8',
-      fontFamily: "'Share Tech Mono', monospace",
-      outline: 'none',
-      background: '#fff'
-    }}
-  ></div>
-</div>
+        {/* 확인 모달 */}
+        <ConfirmModal
+          show={showConfirmModal}
+          title="페이지 나가기"
+          message={`지금 나가시겠습니까?\n변경사항이 저장되지 않을 수 있습니다.`}
+          confirmText="나가기"
+          cancelText="취소"
+          onConfirm={() => {
+            setShowConfirmModal(false);
+            goBack();
+          }}
+          onCancel={() => {
+            setShowConfirmModal(false);
+          }}
+        />
       </div>
-
-      <style>{`
-        .blog-editor-wysiwyg:empty:before {
-          content: "여행 이야기를 자유롭게 작성해주세요...";
-          color: #999;
-        }
-        .blog-editor-wysiwyg h2 {
-          font-size: 24px;
-          font-weight: 700;
-          margin: 30px 0 15px 0;
-          padding-bottom: 10px;
-          border-bottom: 3px solid #000;
-        }
-        .blog-editor-wysiwyg h3 {
-          font-size: 18px;
-          font-weight: 700;
-          margin: 25px 0 12px 0;
-        }
-        .blog-editor-wysiwyg p {
-          margin: 15px 0;
-        }
-        .blog-editor-wysiwyg img {
-          max-width: 100%;
-          margin: 20px auto;
-          display: block;
-          border: 3px solid #000;
-        }
-        .blog-editor-wysiwyg hr {
-          border: none;
-          border-top: 3px solid #000;
-          margin: 30px 0;
-        }
-      `}</style>
     </div>
   );
 }

--- a/src/hooks/useTravelStory.ts
+++ b/src/hooks/useTravelStory.ts
@@ -5,6 +5,7 @@ interface Story {
   title: string;
   description: string;
   image: string;
+  images?: string[];
   author: string;
   authorAvatar: string;
   destination: string;
@@ -14,175 +15,36 @@ interface Story {
   date: string;
   likes: number;
   comments: number;
-  bookmarks: number;
   follows: number;
   views: string;
   tags: string[];
 }
 
-// 전체 여행기 데이터 (메인 페이지용 - 다양한 작성자)
-const allStoriesData = [
-  {
-    id: 1,
-    title: "강릉 바다 힐링 3박4일",
-    description: "동해의 푸른 바다와 함께한 힐링 여행",
-    image: "https://images.unsplash.com/photo-1506929562872-bb421503ef21?w=800",
-    author: "여행러버",
-    authorAvatar: "여",
-    destination: "강릉",
-    duration: "3박4일",
-    budget: "500000",
-    departureDate: "2024-03-15",
-    date: "2023.1.28",
-    likes: 128,
-    comments: 45,
-    bookmarks: 89,
-    follows: 34,
-    views: "120",
-    tags: ["힐링여행", "바다", "맛집투어"]
-  },
-  {
-    id: 2,
-    title: "경주 역사 탐방 2박3일",
-    description: "천년 고도 경주의 역사와 문화를 체험하다",
-    image: "https://images.unsplash.com/photo-1578662996442-48f60103fc96?w=800",
-    author: "역사덕후",
-    authorAvatar: "역",
-    destination: "경주",
-    duration: "2박3일",
-    budget: "328000",
-    departureDate: "2024-02-10",
-    date: "2023.2.15",
-    likes: 95,
-    comments: 23,
-    bookmarks: 67,
-    follows: 28,
-    views: "85",
-    tags: ["문화탐방", "역사", "사진명소"]
-  },
-  {
-    id: 3,
-    title: "제주도 완전정복 4박5일",
-    description: "제주의 숨은 명소와 맛집을 찾아서",
-    image: "https://images.unsplash.com/photo-1559827260-dc66d52bef19?w=800",
-    author: "제주매니아",
-    authorAvatar: "제",
-    destination: "제주",
-    duration: "4박5일",
-    budget: "850000",
-    departureDate: "2024-03-01",
-    date: "2023.3.10",
-    likes: 203,
-    comments: 67,
-    bookmarks: 145,
-    follows: 56,
-    views: "156",
-    tags: ["자연", "맛집투어", "렌터카"]
-  },
-  {
-    id: 4,
-    title: "부산 해운대 맛집투어",
-    description: "부산의 숨은 맛집들을 찾아다닌 여행",
-    image: "https://images.unsplash.com/photo-1583470790878-4f89a7bf9b7f?w=800",
-    author: "맛집헌터",
-    authorAvatar: "맛",
-    destination: "부산",
-    duration: "2박3일",
-    budget: "420000",
-    departureDate: "2024-02-20",
-    date: "2023.2.25",
-    likes: 167,
-    comments: 52,
-    bookmarks: 98,
-    follows: 41,
-    views: "134",
-    tags: ["맛집투어", "해변", "도시여행"]
-  },
-  {
-    id: 5,
-    title: "전주 한옥마을 당일치기",
-    description: "전주 비빔밥과 한옥마을의 매력",
-    image: "https://images.unsplash.com/photo-1583474679704-34e8e3a6c180?w=800",
-    author: "한식러버",
-    authorAvatar: "한",
-    destination: "전주",
-    duration: "당일치기",
-    budget: "150000",
-    departureDate: "2024-03-05",
-    date: "2023.3.08",
-    likes: 82,
-    comments: 19,
-    bookmarks: 45,
-    follows: 22,
-    views: "67",
-    tags: ["문화탐방", "맛집투어", "가성비"]
-  }
-];
-
-// 내 여행기 데이터 (마이 스토리 페이지용 - 모두 같은 작성자)
-const myStoriesData = [
-  {
-    id: 101,
-    title: "강릉 바다 힐링 3박4일",
-    description: "동해의 푸른 바다와 함께한 힐링 여행. 정동진 해돋이부터 주문진 수산시장까지, 강릉의 모든 것을 경험했습니다.",
-    image: "https://images.unsplash.com/photo-1506929562872-bb421503ef21?w=800",
-    author: "채원",
-    authorAvatar: "채",
-    destination: "강릉",
-    duration: "3박4일",
-    budget: "500000",
-    departureDate: "2024-03-15",
-    date: "2023.1.28",
-    likes: 128,
-    comments: 45,
-    bookmarks: 89,
-    follows: 34,
-    views: "120",
-    tags: ["힐링여행", "바다", "맛집투어"]
-  },
-  {
-    id: 102,
-    title: "경주 역사 탐방 2박3일",
-    description: "천년 고도 경주의 역사와 문화를 체험하다. 불국사, 석굴암, 첨성대 등 역사적인 장소들을 둘러보았습니다.",
-    image: "https://images.unsplash.com/photo-1578662996442-48f60103fc96?w=800",
-    author: "채원",
-    authorAvatar: "채",
-    destination: "경주",
-    duration: "2박3일",
-    budget: "328000",
-    departureDate: "2024-02-10",
-    date: "2023.2.15",
-    likes: 95,
-    comments: 23,
-    bookmarks: 67,
-    follows: 28,
-    views: "85",
-    tags: ["문화탐방", "역사", "사진명소"]
-  },
-  {
-    id: 103,
-    title: "제주도 완전정복 4박5일",
-    description: "제주의 숨은 명소와 맛집을 찾아서. 한라산 등반부터 우도 여행까지 알찬 일정이었습니다.",
-    image: "https://images.unsplash.com/photo-1559827260-dc66d52bef19?w=800",
-    author: "채원",
-    authorAvatar: "채",
-    destination: "제주",
-    duration: "4박5일",
-    budget: "850000",
-    departureDate: "2024-03-01",
-    date: "2023.3.10",
-    likes: 203,
-    comments: 67,
-    bookmarks: 145,
-    follows: 56,
-    views: "156",
-    tags: ["자연", "맛집투어", "렌터카"]
-  }
-];
+interface Draft {
+  id: number;
+  title: string;
+  content: string;
+  date: string;
+}
 
 function useTravelStory() {
-  const [currentPage, setCurrentPage] = useState('main');
-  const [selectedStory, setSelectedStory] = useState<any>(null);
+  const [currentPage, setCurrentPageState] = useState(() => {
+    // URL 해시를 먼저 체크 (#main, #detail 등)
+    const hash = window.location.hash.slice(1);
+    if (hash) return hash;
+    
+    // 없으면 localStorage에서
+    const saved = localStorage.getItem('currentPage');
+    return saved || 'main';
+  });
+  const [previousPage, setPreviousPage] = useState('main');
+  
+  // selectedStoryId만 저장 (story 전체는 너무 큼)
+  const [selectedStoryId, setSelectedStoryId] = useState<number | null>(() => {
+    const saved = localStorage.getItem('selectedStoryId');
+    return saved ? parseInt(saved) : null;
+  });
+  
   const [filters, setFilters] = useState({
     searchTerm: '',
     destination: '',
@@ -191,99 +53,255 @@ function useTravelStory() {
     maxBudget: '',
     tags: [] as string[]
   });
-  const [bookmarkedIds, setBookmarkedIds] = useState<number[]>([]);
-  const [likedStories, setLikedStories] = useState<number[]>([]);
-  const [followedStories, setFollowedStories] = useState<number[]>([]);
+  
+  const [likedStories, setLikedStories] = useState<number[]>(() => {
+    const saved = localStorage.getItem('likedStories');
+    return saved ? JSON.parse(saved) : [];
+  });
+  
+  const [followedStories, setFollowedStories] = useState<number[]>(() => {
+    const saved = localStorage.getItem('followedStories');
+    return saved ? JSON.parse(saved) : [];
+  });
+  
   const [showAlert, setShowAlert] = useState(false);
   const [alertMessage, setAlertMessage] = useState('');
-  const [openDropdown, setOpenDropdown] = useState<string | null>(null);
+  
   const [showDraftModal, setShowDraftModal] = useState(false);
   const [showLikesModal, setShowLikesModal] = useState(false);
-  const [drafts, setDrafts] = useState<any[]>([]);
+  
+  const [drafts, setDraftsState] = useState<Draft[]>(() => {
+    const saved = localStorage.getItem('drafts');
+    return saved ? JSON.parse(saved) : [];
+  });
+  
   const [editingStory, setEditingStory] = useState<any>(null);
-  const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [currentDraft, setCurrentDraft] = useState<any>(null);
+  const [currentDraftId, setCurrentDraftId] = useState<number | null>(null);
+  
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [deletingStoryId, setDeletingStoryId] = useState<number | null>(null);
-  const [newStories, setNewStories] = useState<any[]>([]);
+  
+  const [myStories, setMyStoriesState] = useState<Story[]>(() => {
+    const saved = localStorage.getItem('myStories');
+    return saved ? JSON.parse(saved) : [];
+  });
 
-  // 브라우저 히스토리 관리
-  useEffect(() => {
-    // 초기 상태 설정
-    const initialState = { page: 'main' };
-    window.history.replaceState(initialState, '', window.location.href);
-
-    // 브라우저 뒤로가기/앞으로가기 이벤트 리스너
-    const handlePopState = (event: PopStateEvent) => {
-      if (event.state && event.state.page) {
-        setCurrentPage(event.state.page);
-        if (event.state.story) {
-          setSelectedStory(event.state.story);
-        }
+  // setMyStories wrapper - 이미지 최대 3개까지 저장 시도
+  const setMyStories = (newStories: Story[] | ((prev: Story[]) => Story[])) => {
+    try {
+      if (typeof newStories === 'function') {
+        setMyStoriesState(prev => {
+          const updated = newStories(prev);
+          
+          try {
+            // 이미지 3개까지만 저장 시도
+            const limitedImages = updated.map(s => ({
+              ...s,
+              images: s.images?.slice(0, 3) || []
+            }));
+            localStorage.setItem('myStories', JSON.stringify(limitedImages));
+          } catch (e) {
+            console.warn('이미지 포함 저장 실패, 기본 이미지로 대체');
+            try {
+              // 실패하면 기본 이미지로 대체
+              const withoutImages = updated.map(s => ({
+                ...s,
+                image: 'https://images.unsplash.com/photo-1469854523086-cc02fe5d8800?w=800',
+                images: []
+              }));
+              localStorage.setItem('myStories', JSON.stringify(withoutImages));
+            } catch (e2) {
+              console.error('localStorage 저장 완전 실패:', e2);
+            }
+          }
+          
+          return updated;
+        });
       } else {
-        // 상태가 없으면 메인으로
-        setCurrentPage('main');
+        setMyStoriesState(newStories);
+        
+        try {
+          // 이미지 3개까지만 저장 시도
+          const limitedImages = newStories.map(s => ({
+            ...s,
+            images: s.images?.slice(0, 3) || []
+          }));
+          localStorage.setItem('myStories', JSON.stringify(limitedImages));
+        } catch (e) {
+          console.warn('이미지 포함 저장 실패, 기본 이미지로 대체');
+          try {
+            // 실패하면 기본 이미지로 대체
+            const withoutImages = newStories.map(s => ({
+              ...s,
+              image: 'https://images.unsplash.com/photo-1469854523086-cc02fe5d8800?w=800',
+              images: []
+            }));
+            localStorage.setItem('myStories', JSON.stringify(withoutImages));
+          } catch (e2) {
+            console.error('localStorage 저장 완전 실패:', e2);
+          }
+        }
+      }
+    } catch (error) {
+      console.error('Error in setMyStories:', error);
+      if (typeof newStories === 'function') {
+        setMyStoriesState(prev => newStories(prev));
+      } else {
+        setMyStoriesState(newStories);
+      }
+    }
+  };
+
+  // myStories에서 실제 story 찾기 (id만 저장해서 용량 절약)
+  const selectedStory = selectedStoryId 
+    ? myStories.find(s => s.id === selectedStoryId) || null
+    : null;
+  
+  const setSelectedStory = (story: any) => {
+    if (story) {
+      setSelectedStoryId(story.id);
+      localStorage.setItem('selectedStoryId', story.id.toString());
+    } else {
+      setSelectedStoryId(null);
+      localStorage.removeItem('selectedStoryId');
+    }
+  };
+
+  // setDrafts wrapper
+  const setDrafts = (newDrafts: Draft[] | ((prev: Draft[]) => Draft[])) => {
+    if (typeof newDrafts === 'function') {
+      setDraftsState(prev => {
+        const updated = newDrafts(prev);
+        localStorage.setItem('drafts', JSON.stringify(updated));
+        return updated;
+      });
+    } else {
+      setDraftsState(newDrafts);
+      localStorage.setItem('drafts', JSON.stringify(newDrafts));
+    }
+  };
+
+  // localStorage 동기화
+  useEffect(() => {
+    localStorage.setItem('likedStories', JSON.stringify(likedStories));
+  }, [likedStories]);
+
+  useEffect(() => {
+    localStorage.setItem('followedStories', JSON.stringify(followedStories));
+  }, [followedStories]);
+
+  // 브라우저 뒤로가기/앞으로가기 버튼 지원
+  useEffect(() => {
+    // 초기 로드 시 history state 설정
+    if (!window.history.state?.page) {
+      window.history.replaceState({ page: currentPage }, '', `#${currentPage}`);
+    }
+
+    const handlePopState = (event: PopStateEvent) => {
+      const page = event.state?.page || 'main';
+      setCurrentPageState(page);
+      localStorage.setItem('currentPage', page);
+      
+      // write 페이지에서 벗어나면 상태 초기화
+      if (page !== 'write') {
+        setCurrentDraftId(null);
+        setCurrentDraft(null);
+        setEditingStory(null);
+      }
+      
+      // detail 페이지가 아니면 selectedStory 초기화
+      if (page !== 'detail') {
+        setSelectedStory(null);
       }
     };
 
     window.addEventListener('popstate', handlePopState);
-
+    
     return () => {
       window.removeEventListener('popstate', handlePopState);
     };
   }, []);
 
+  // Alert 함수들
   const showCustomAlert = (message: string) => {
     setAlertMessage(message);
     setShowAlert(true);
-    setTimeout(() => {
-      setShowAlert(false);
-    }, 2000);
   };
 
-  // 페이지 이동 시 브라우저 히스토리에 추가
-  const navigateToPage = (newPage: string, story?: any) => {
-    const state = { page: newPage, story: story || null };
-    window.history.pushState(state, '', window.location.href);
-    setCurrentPage(newPage);
-    if (story) {
-      setSelectedStory(story);
+  const closeAlert = () => {
+    setShowAlert(false);
+    setAlertMessage('');
+  };
+
+  // 페이지 네비게이션
+  const setCurrentPage = (page: string) => {
+    setCurrentPageState(page);
+    localStorage.setItem('currentPage', page);
+    window.history.pushState({ page }, '', `#${page}`);
+  };
+
+  const navigateToPage = (newPage: string) => {
+    if (currentPage === 'write' && newPage !== 'write') {
+      setCurrentDraftId(null);
+      setCurrentDraft(null);
+      setEditingStory(null);
     }
+
+    if (currentPage !== newPage) {
+      setPreviousPage(currentPage);
+    }
+
+    setCurrentPageState(newPage);
+    localStorage.setItem('currentPage', newPage);
+    window.history.pushState({ page: newPage }, '', `#${newPage}`);
   };
 
-  // 뒤로가기 - 브라우저 히스토리 사용
   const goBack = () => {
-    window.history.back();
-  };
-
-  // 네비게이션 바에서 직접 페이지 설정 (히스토리 추가)
-  const setPageDirectly = (page: string) => {
-    const state = { page: page };
-    window.history.pushState(state, '', window.location.href);
-    setCurrentPage(page);
+    const targetPage = previousPage || 'main';
+    setCurrentPage(targetPage);
+    setCurrentDraftId(null);
+    setCurrentDraft(null);
+    setEditingStory(null);
     setSelectedStory(null);
+    setPreviousPage('main');
   };
 
+  // 필터링
   const getFilteredStories = () => {
-    let stories = currentPage === 'myStories' 
-      ? [...myStoriesData, ...newStories]
-      : [...allStoriesData, ...newStories];
-    
-    return stories.filter((story) => {
-      const matchesSearch = story.title.toLowerCase().includes(filters.searchTerm.toLowerCase()) ||
-                          story.description.toLowerCase().includes(filters.searchTerm.toLowerCase());
-      const matchesDestination = !filters.destination || story.destination === filters.destination;
-      const matchesDuration = !filters.duration || story.duration === filters.duration;
-      const matchesBudget = (!filters.minBudget || parseInt(story.budget) >= parseInt(filters.minBudget)) &&
-                           (!filters.maxBudget || parseInt(story.budget) <= parseInt(filters.maxBudget));
-      const matchesTags = filters.tags.length === 0 || 
-                         filters.tags.some(tag => story.tags.includes(tag));
+    return myStories.filter(story => {
+      const matchesSearch =
+        story.title.toLowerCase().includes(filters.searchTerm.toLowerCase()) ||
+        story.description.toLowerCase().includes(filters.searchTerm.toLowerCase());
 
-      return matchesSearch && matchesDestination && matchesDuration && matchesBudget && matchesTags;
+      const matchesDestination =
+        !filters.destination || story.destination === filters.destination;
+
+      const matchesDuration =
+        !filters.duration || story.duration === filters.duration;
+
+      const matchesBudget =
+        (!filters.minBudget || parseInt(story.budget) >= parseInt(filters.minBudget)) &&
+        (!filters.maxBudget || parseInt(story.budget) <= parseInt(filters.maxBudget));
+
+      const matchesTags =
+        filters.tags.length === 0 ||
+        filters.tags.some(tag => story.tags.includes(tag));
+
+      return (
+        matchesSearch &&
+        matchesDestination &&
+        matchesDuration &&
+        matchesBudget &&
+        matchesTags
+      );
     });
   };
 
+  // 스토리 관련 함수들
   const handleStoryClick = (story: any) => {
-    navigateToPage('detail', story);
+    setSelectedStory(story);
+    navigateToPage('detail');
   };
 
   const handleEdit = (story: any) => {
@@ -298,18 +316,20 @@ function useTravelStory() {
 
   const confirmDelete = () => {
     if (deletingStoryId) {
-      setNewStories(newStories.filter(story => story.id !== deletingStoryId));
+      setMyStories(myStories.filter(story => story.id !== deletingStoryId));
       showCustomAlert('여행기가 삭제되었습니다.');
     }
     setShowDeleteModal(false);
     setDeletingStoryId(null);
   };
 
+  // 발행 함수
   const handlePublish = () => {
     const titleInput = document.querySelector('.title-input') as HTMLInputElement;
     const destinationInput = document.querySelector('.form-input') as HTMLInputElement;
     const durationSelect = document.querySelector('.form-select') as HTMLSelectElement;
     const budgetInput = document.querySelectorAll('.form-input')[2] as HTMLInputElement;
+    const departureDateInput = document.querySelectorAll('.form-input')[1] as HTMLInputElement;
     const editor = document.querySelector('.blog-editor-wysiwyg') as HTMLDivElement;
     
     const selectedTags: string[] = [];
@@ -320,65 +340,145 @@ function useTravelStory() {
       }
     });
 
-    const coverImageElement = document.querySelector('.story-image') as HTMLImageElement;
-    const coverImage = coverImageElement?.src || 'https://images.unsplash.com/photo-1469854523086-cc02fe5d8800?w=800';
-
-    const newStory = {
-      id: Date.now(),
-      title: titleInput?.value || '제목 없음',
-      description: editor?.innerText || '내용 없음',
-      image: coverImage,
-      author: "채원",
-      authorAvatar: "채",
-      destination: destinationInput?.value || '미정',
-      duration: durationSelect?.value || '선택하세요',
-      budget: budgetInput?.value || '0',
-      departureDate: '',
-      date: new Date().toLocaleDateString('ko-KR').replace(/\. /g, '.').slice(0, -1),
-      likes: 0,
-      comments: 0,
-      bookmarks: 0,
-      follows: 0,
-      views: "0",
-      tags: selectedTags
-    };
-
-    setNewStories([newStory, ...newStories]);
-    showCustomAlert('여행기가 발행되었습니다!');
-    setEditingStory(null);
+    // 커버 이미지 가져오기
+    const coverImage = (window as any).selectedCoverImageForPublish || 'https://images.unsplash.com/photo-1469854523086-cc02fe5d8800?w=800';
     
-    // 발행 후 myStories로 이동
-    setPageDirectly('myStories');
+    // 업로드된 이미지들 가져오기 (최대 5개로 제한)
+    const uploadedImages = (window as any).uploadedImagesForPublish || [];
+    const limitedImages = uploadedImages.slice(0, 5);
+    const finalImages = limitedImages.length > 0 ? limitedImages : [coverImage];
+
+    if (editingStory) {
+      const updatedStory: Story = {
+        ...editingStory,
+        title: titleInput?.value || '제목 없음',
+        description: editor?.innerHTML || '내용 없음',
+        image: coverImage,
+        images: finalImages,
+        destination: destinationInput?.value || '미정',
+        duration: durationSelect?.value || '선택하세요',
+        budget: budgetInput?.value || '0',
+        departureDate: departureDateInput?.value || '',
+        tags: selectedTags
+      };
+
+      setMyStories(myStories.map(story => 
+        story.id === editingStory.id ? updatedStory : story
+      ));
+      
+      showCustomAlert('여행기가 수정되었습니다!');
+    } else {
+      const newStory: Story = {
+        id: Date.now(),
+        title: titleInput?.value || '제목 없음',
+        description: editor?.innerHTML || '내용 없음',
+        image: coverImage,
+        images: finalImages,
+        author: "나",
+        authorAvatar: "나",
+        destination: destinationInput?.value || '미정',
+        duration: durationSelect?.value || '선택하세요',
+        budget: budgetInput?.value || '0',
+        departureDate: departureDateInput?.value || '',
+        date: new Date().toLocaleDateString('ko-KR').replace(/\. /g, '.').slice(0, -1),
+        likes: 0,
+        comments: 0,
+        follows: 0,
+        views: "0",
+        tags: selectedTags
+      };
+
+      setMyStories([newStory, ...myStories]);
+      showCustomAlert('여행기가 발행되었습니다!');
+      
+      if (uploadedImages.length > 5) {
+        setTimeout(() => {
+          showCustomAlert('이미지가 너무 많아 최신 5개만 저장되었습니다.');
+        }, 2000);
+      }
+    }
+
+    setEditingStory(null);
+    setCurrentDraftId(null);
+    
+    if (previousPage === 'myStories') {
+      navigateToPage('myStories');
+    } else {
+      navigateToPage('main');
+    }
   };
 
+  // 임시저장 함수
   const handleSaveDraft = () => {
     const titleInput = document.querySelector('.title-input') as HTMLInputElement;
-    
-    const newDraft = {
-      id: Date.now(),
-      title: titleInput?.value || '제목 없음',
-      date: new Date().toLocaleDateString()
-    };
-    setDrafts([...drafts, newDraft]);
+    const editor = document.querySelector('.blog-editor-wysiwyg') as HTMLDivElement;
+
+    const title = titleInput?.value?.trim() || '';
+    const content = editor?.innerHTML?.trim() || '';
+
+    if (!title && !content) {
+      showCustomAlert('제목과 본문을 작성해주세요.');
+      return;
+    }
+
+    const now = new Date().toLocaleDateString('ko-KR').replace(/\. /g, '.').slice(0, -1);
+
+    if (currentDraftId) {
+      setDrafts(
+        drafts.map(d =>
+          d.id === currentDraftId ? { ...d, title, content, date: now } : d
+        )
+      );
+    } else {
+      const newDraftId = Date.now();
+      setDrafts([
+        { id: newDraftId, title, content, date: now },
+        ...drafts
+      ]);
+      setCurrentDraftId(newDraftId);
+    }
+
     showCustomAlert('임시저장되었습니다.');
   };
 
-  const handleShare = () => {
-    showCustomAlert('링크가 복사되었습니다!');
+  // 좋아요 토글
+  const toggleLike = (storyId: number) => {
+    setMyStories(prev =>
+      prev.map(story =>
+        story.id === storyId
+          ? { ...story, likes: likedStories.includes(storyId) ? story.likes - 1 : story.likes + 1 }
+          : story
+      )
+    );
+
+    setLikedStories(prev =>
+      prev.includes(storyId)
+        ? prev.filter(id => id !== storyId)
+        : [...prev, storyId]
+    );
+  };
+
+  // 조회수 증가
+  const incrementViews = (storyId: number) => {
+    setMyStories(prev =>
+      prev.map(story =>
+        story.id === storyId
+          ? { ...story, views: String(parseInt(story.views || '0') + 1) }
+          : story
+      )
+    );
   };
 
   return {
     currentPage,
-    setCurrentPage: setPageDirectly,
+    setCurrentPage,
     navigateToPage,
     goBack,
-    previousPage: 'main', // 더 이상 사용하지 않지만 호환성을 위해 유지
+    previousPage,
     selectedStory,
     setSelectedStory,
     filters,
     setFilters,
-    bookmarkedIds,
-    setBookmarkedIds,
     likedStories,
     setLikedStories,
     followedStories,
@@ -386,8 +486,7 @@ function useTravelStory() {
     showAlert,
     alertMessage,
     showCustomAlert,
-    openDropdown,
-    setOpenDropdown,
+    closeAlert,
     showDraftModal,
     setShowDraftModal,
     showLikesModal,
@@ -400,6 +499,8 @@ function useTravelStory() {
     setShowDeleteModal,
     currentDraft,
     setCurrentDraft,
+    currentDraftId,
+    setCurrentDraftId,
     getFilteredStories,
     handleStoryClick,
     handleEdit,
@@ -407,7 +508,10 @@ function useTravelStory() {
     confirmDelete,
     handlePublish,
     handleSaveDraft,
-    handleShare
+    toggleLike,
+    incrementViews,
+    myStories,
+    setMyStories
   };
 }
 

--- a/src/pages/TravelStory.tsx
+++ b/src/pages/TravelStory.tsx
@@ -1,1093 +1,236 @@
+import { useState } from 'react';
 import FilterSection from '../components/travelStory/FilterSection';
 import StoryCard from '../components/travelStory/StoryCard';
-import WritePage from "../components/travelStory/WritePage";
-import CommentSection from "../components/travelStory/CommentSection";
+import WritePage from '../components/travelStory/WritePage';
+import DetailPage from '../components/travelStory/DetailPage';
+import MyStoriesPage from '../components/travelStory/MyStoriesPage';
+import DraftModal from '../components/travelStory/DraftModal';
+import LikesModal from '../components/travelStory/LikesModal';
+import CustomAlert from '../components/travelStory/CustomAlert';
+import DeleteModal from '../components/travelStory/DeleteModal';
 import useTravelStory from '../hooks/useTravelStory';
 import '../styles/travelStory/travelStory.css';
 
-interface Story {
-  id: number;
-  title: string;
-  description: string;
-  image: string;
-  author: string;
-  authorAvatar: string;
-  destination: string;
-  duration: string;
-  budget: string;
-  departureDate?: string;
-  date: string;
-  likes: number;
-  comments: number;
-  bookmarks: number;
-  follows: number;
-  views: string;
-  tags: string[];
-}
-
 function TravelStory() {
-  const {
-    currentPage,
-    setCurrentPage,
-    navigateToPage,
-    goBack,
-    previousPage,
-    selectedStory,
-    setSelectedStory,
-    filters,
-    setFilters,
-    bookmarkedIds,
-    setBookmarkedIds,
-    likedStories,
-    setLikedStories,
-    followedStories,
-    setFollowedStories,
-    showAlert,
-    alertMessage,
-    showCustomAlert,
-    openDropdown,
-    setOpenDropdown,
-    showDraftModal,
-    setShowDraftModal,
-    showLikesModal,
-    setShowLikesModal,
-    drafts,
-    setDrafts,
-    editingStory,
-    setEditingStory,
-    showDeleteModal,
-    setShowDeleteModal,
-    currentDraft,
-    setCurrentDraft,
-    getFilteredStories,
-    handleStoryClick,
-    handleEdit,
-    handleDelete,
-    confirmDelete,
-    handlePublish,
-    handleSaveDraft,
-    handleShare
-  } = useTravelStory();
+  const hook = useTravelStory();
+
+  const [hoveredDraftId, setHoveredDraftId] = useState<number | null>(null);
+  const [deleteHoverId, setDeleteHoverId] = useState<number | null>(null);
+
+  // LikesModal을 위한 좋아요한 스토리 필터링
+  const getLikedStoriesList = () => {
+    return hook.myStories.filter(story => hook.likedStories.includes(story.id));
+  };
 
   return (
     <>
       {/* Main Page */}
-      {currentPage === 'main' && (
+      {hook.currentPage === 'main' && (
         <div className="container">
-          {/* VERIFIED DATA Header - Mate Style */}
-          <div style={{ 
-            marginBottom: '32px',
-            background: '#fff',
-            padding: '24px',
-            border: '3px solid #000',
-            boxShadow: '8px 8px 0px rgba(0, 0, 0, 1)'
-          }}>
-            <div style={{ 
-              display: 'flex', 
-              alignItems: 'center', 
-              justifyContent: 'space-between',
-              flexWrap: 'wrap',
-              gap: '16px'
-            }}>
-              <div>
-                <h1 style={{ 
-                  fontSize: '32px', 
-                  fontWeight: 700, 
-                  letterSpacing: '2px',
-                  fontFamily: "'Share Tech Mono', monospace",
-                  textTransform: 'uppercase',
-                  marginBottom: '8px'
-                }}>
-                  VERIFIED DATA
-                </h1>
-                <p style={{ 
-                  fontSize: '14px', 
-                  color: '#666',
-                  fontFamily: "'Share Tech Mono', monospace"
-                }}>
-                  검증된 여행 작진 로그를 확인하십시오.
-                </p>
-              </div>
-              
-              <div style={{ display: 'flex', gap: '12px' }}>
-                <button 
-                  onClick={() => navigateToPage('myStories')}
-                  style={{
-                    padding: '10px 20px',
-                    border: '3px solid #000',
-                    background: '#fff',
-                    color: '#000',
-                    fontWeight: 700,
-                    fontSize: '14px',
-                    fontFamily: "'Share Tech Mono', monospace",
-                    textTransform: 'uppercase',
-                    cursor: 'pointer',
-                    boxShadow: '4px 4px 0px rgba(0, 0, 0, 1)',
-                    transition: 'all 0.2s'
-                  }}
-                  onMouseEnter={(e) => {
-                    e.currentTarget.style.background = '#000';
-                    e.currentTarget.style.color = '#fff';
-                  }}
-                  onMouseLeave={(e) => {
-                    e.currentTarget.style.background = '#fff';
-                    e.currentTarget.style.color = '#000';
-                  }}
-                >
-                  MY STORIES
-                </button>
-                <button 
-                  onClick={() => navigateToPage('write')}
-                  style={{
-                    padding: '10px 20px',
-                    border: '3px solid #000',
-                    background: '#000',
-                    color: '#fff',
-                    fontWeight: 700,
-                    fontSize: '14px',
-                    fontFamily: "'Share Tech Mono', monospace",
-                    textTransform: 'uppercase',
-                    cursor: 'pointer',
-                    boxShadow: '4px 4px 0px rgba(0, 0, 0, 1)',
-                    transition: 'all 0.2s'
-                  }}
-                  onMouseEnter={(e) => {
-                    e.currentTarget.style.background = '#fff';
-                    e.currentTarget.style.color = '#000';
-                  }}
-                  onMouseLeave={(e) => {
-                    e.currentTarget.style.background = '#000';
-                    e.currentTarget.style.color = '#fff';
-                  }}
-                >
-                  WRITE
-                </button>
-              </div>
-            </div>
-          </div>
-
-          <FilterSection filters={filters} setFilters={setFilters} />
-
-          {getFilteredStories().length === 0 ? (
-            <div className="no-results-fullpage">
-              <div className="no-results-text">검색 결과가 없습니다.</div>
-              <div className="no-results-subtext">다른 조건으로 검색해보세요.</div>
-            </div>
-          ) : (
-            <div className="posts-grid">
-              {getFilteredStories().map((story: Story) => (
-                <StoryCard
-                  key={story.id}
-                  story={story}
-                  onCardClick={handleStoryClick}
-                />
-              ))}
-            </div>
-          )}
-        </div>
-      )}
-
-      {/* My Stories Page */}
-      {currentPage === 'myStories' && (
-        <div className="container">
-          {/* 통계 섹션 - VERIFIED DATA와 같은 여백 */}
+          {/* 헤더 섹션 */}
           <div style={{
-            marginBottom: '32px',
-            display: 'grid',
-            gridTemplateColumns: 'repeat(4, 1fr)',
-            gap: '15px',
-            padding: '12px 20px',
             background: '#fff',
+            padding: '24px 40px',
+            marginBottom: '24px',
             border: '3px solid #000',
             boxShadow: '8px 8px 0px rgba(0, 0, 0, 1)',
-            position: 'relative'
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center'
           }}>
-            {/* X 버튼 - 통계 박스 오른쪽 위 */}
-            <button 
-              onClick={goBack}
-              style={{
-                position: 'absolute',
-                top: '-15px',
-                right: '-15px',
-                border: 'none',
-                background: '#fff',
-                cursor: 'pointer',
-                padding: '4px',
-                lineHeight: 1,
-                transition: 'all 0.2s',
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                borderRadius: '50%',
-                boxShadow: '2px 2px 4px rgba(0, 0, 0, 0.2)',
-                zIndex: 10
-              }}
-              onMouseEnter={(e) => {
-                e.currentTarget.style.background = '#000';
-                const svg = e.currentTarget.querySelector('svg');
-                if (svg) (svg as SVGElement).style.fill = '#fff';
-              }}
-              onMouseLeave={(e) => {
-                e.currentTarget.style.background = '#fff';
-                const svg = e.currentTarget.querySelector('svg');
-                if (svg) (svg as SVGElement).style.fill = '#000';
-              }}
-            >
-              <svg 
-                xmlns="http://www.w3.org/2000/svg" 
-                viewBox="0 0 24 24" 
-                style={{ 
-                  width: '24px',
-                  height: '24px',
-                  fill: '#000',
-                  transition: 'fill 0.2s'
+            <div>
+              <h1 style={{
+                fontFamily: "'Share Tech Mono', monospace",
+                fontSize: '28px',
+                fontWeight: 900,
+                letterSpacing: '2px',
+                marginBottom: '4px',
+                margin: 0
+              }}>
+                VERIFIED DATA
+              </h1>
+              <p style={{
+                fontFamily: "'Share Tech Mono', monospace",
+                fontSize: '12px',
+                color: '#666',
+                fontWeight: 600,
+                margin: 0
+              }}>
+                검증된 여행 작진 로그를 확인하십시오.
+              </p>
+            </div>
+            <div style={{ display: 'flex', gap: '12px' }}>
+              <button
+                onClick={() => hook.navigateToPage('myStories')}
+                style={{
+                  background: '#fff',
+                  border: '3px solid #000',
+                  padding: '10px 20px',
+                  fontSize: '12px',
+                  fontWeight: 900,
+                  fontFamily: "'Share Tech Mono', monospace",
+                  cursor: 'pointer',
+                  transition: 'all 0.2s',
+                  boxShadow: '4px 4px 0px rgba(0, 0, 0, 1)'
+                }}
+                onMouseEnter={(e) => {
+                  e.currentTarget.style.transform = 'translate(-2px, -2px)';
+                  e.currentTarget.style.boxShadow = '6px 6px 0px rgba(0, 0, 0, 1)';
+                }}
+                onMouseLeave={(e) => {
+                  e.currentTarget.style.transform = 'none';
+                  e.currentTarget.style.boxShadow = '4px 4px 0px rgba(0, 0, 0, 1)';
                 }}
               >
-                <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/>
-              </svg>
-            </button>
-
-            {/* 작성한 여행기 */}
-            <div style={{
-              padding: '12px 15px',
-              border: '2px solid #000',
-              background: '#fff',
-              textAlign: 'center',
-              transition: 'all 0.2s'
-            }}>
-              <div style={{
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                marginBottom: '4px'
-              }}>
-                <svg 
-                  xmlns="http://www.w3.org/2000/svg" 
-                  viewBox="0 0 24 24" 
-                  style={{ 
-                    width: '20px',
-                    height: '20px',
-                    fill: '#000'
-                  }}
-                >
-                  <path d="M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z"/>
-                </svg>
-              </div>
-              <div style={{
-                fontSize: '22px',
-                fontWeight: 700,
-                marginBottom: '4px',
-                fontFamily: "'Share Tech Mono', monospace"
-              }}>3</div>
-              <div style={{
-                fontSize: '10px',
-                color: '#666',
-                fontFamily: "'Share Tech Mono', monospace",
-                textTransform: 'uppercase',
-                letterSpacing: '0.5px'
-              }}>작성한 여행기</div>
-            </div>
-
-            {/* 총 조회수 */}
-            <div style={{
-              padding: '12px 15px',
-              border: '2px solid #000',
-              background: '#fff',
-              textAlign: 'center',
-              transition: 'all 0.2s'
-            }}>
-              <div style={{
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                marginBottom: '4px'
-              }}>
-                <svg 
-                  xmlns="http://www.w3.org/2000/svg" 
-                  viewBox="0 0 24 24" 
-                  style={{ 
-                    width: '20px',
-                    height: '20px',
-                    fill: '#000'
-                  }}
-                >
-                  <path d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z"/>
-                </svg>
-              </div>
-              <div style={{
-                fontSize: '22px',
-                fontWeight: 700,
-                marginBottom: '4px',
-                fontFamily: "'Share Tech Mono', monospace"
-              }}>125</div>
-              <div style={{
-                fontSize: '10px',
-                color: '#666',
-                fontFamily: "'Share Tech Mono', monospace",
-                textTransform: 'uppercase',
-                letterSpacing: '0.5px'
-              }}>총 조회수</div>
-            </div>
-
-            {/* 받은 좋아요 */}
-            <div style={{
-              padding: '12px 15px',
-              border: '2px solid #000',
-              background: '#fff',
-              textAlign: 'center',
-              transition: 'all 0.2s'
-            }}>
-              <div style={{
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                marginBottom: '4px'
-              }}>
-                <svg 
-                  xmlns="http://www.w3.org/2000/svg" 
-                  viewBox="0 0 24 24" 
-                  style={{ 
-                    width: '20px',
-                    height: '20px',
-                    fill: '#ff4757'
-                  }}
-                >
-                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/>
-                </svg>
-              </div>
-              <div style={{
-                fontSize: '22px',
-                fontWeight: 700,
-                marginBottom: '4px',
-                fontFamily: "'Share Tech Mono', monospace"
-              }}>48</div>
-              <div style={{
-                fontSize: '10px',
-                color: '#666',
-                fontFamily: "'Share Tech Mono', monospace",
-                textTransform: 'uppercase',
-                letterSpacing: '0.5px'
-              }}>받은 좋아요</div>
-            </div>
-
-            {/* 좋아요 목록 - 클릭 가능 */}
-            <div 
-              onClick={() => setShowLikesModal(true)}
-              style={{ 
-                padding: '12px 15px',
-                border: '2px solid #000',
-                background: '#fff',
-                textAlign: 'center',
-                cursor: 'pointer',
-                transition: 'all 0.2s'
-              }}
-              onMouseEnter={(e) => {
-                e.currentTarget.style.transform = 'translateY(-3px)';
-                e.currentTarget.style.boxShadow = '4px 4px 0px rgba(0, 0, 0, 1)';
-              }}
-              onMouseLeave={(e) => {
-                e.currentTarget.style.transform = 'translateY(0)';
-                e.currentTarget.style.boxShadow = 'none';
-              }}
-            >
-              <div style={{
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                marginBottom: '4px'
-              }}>
-                <svg 
-                  xmlns="http://www.w3.org/2000/svg" 
-                  viewBox="0 0 24 24" 
-                  style={{ 
-                    width: '20px',
-                    height: '20px',
-                    fill: likedStories.length > 0 ? '#ff4757' : '#000'
-                  }}
-                >
-                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/>
-                </svg>
-              </div>
-              <div style={{
-                fontSize: '22px',
-                fontWeight: 700,
-                marginBottom: '4px',
-                fontFamily: "'Share Tech Mono', monospace"
-              }}>{likedStories.length}</div>
-              <div style={{
-                fontSize: '10px',
-                color: '#666',
-                fontFamily: "'Share Tech Mono', monospace",
-                textTransform: 'uppercase',
-                letterSpacing: '0.5px'
-              }}>좋아요 목록</div>
+                MY STORIES
+              </button>
+              <button
+                onClick={() => hook.navigateToPage('write')}
+                style={{
+                  background: '#000',
+                  color: '#fff',
+                  border: '3px solid #000',
+                  padding: '10px 20px',
+                  fontSize: '12px',
+                  fontWeight: 900,
+                  fontFamily: "'Share Tech Mono', monospace",
+                  cursor: 'pointer',
+                  transition: 'all 0.2s',
+                  boxShadow: '4px 4px 0px rgba(0, 0, 0, 1)'
+                }}
+                onMouseEnter={(e) => {
+                  e.currentTarget.style.background = '#fff';
+                  e.currentTarget.style.color = '#000';
+                  e.currentTarget.style.transform = 'translate(-2px, -2px)';
+                  e.currentTarget.style.boxShadow = '6px 6px 0px rgba(0, 0, 0, 1)';
+                }}
+                onMouseLeave={(e) => {
+                  e.currentTarget.style.background = '#000';
+                  e.currentTarget.style.color = '#fff';
+                  e.currentTarget.style.transform = 'none';
+                  e.currentTarget.style.boxShadow = '4px 4px 0px rgba(0, 0, 0, 1)';
+                }}
+              >
+                WRITE
+              </button>
             </div>
           </div>
 
-          {/* My Stories Grid */}
-          <div className="posts-grid">
-            {getFilteredStories().slice(0, 3).map((story: Story) => (
-              <div key={story.id} className="story-card">
-                {/* Story Image */}
-                <div style={{ position: 'relative' }} onClick={() => handleStoryClick(story)}>
-                  <img src={story.image} alt={story.title} className="story-image" style={{
-                    width: '100%',
-                    height: '250px',
-                    objectFit: 'cover',
-                    display: 'block'
-                  }} />
-                  <div className="story-stats-badge">{story.views}</div>
-                </div>
-
-                {/* Story Content */}
-                <div className="story-content">
-                  <div className="story-header" onClick={() => handleStoryClick(story)}>
-                    <div className="author-avatar">{story.authorAvatar}</div>
-                    <div className="author-info">
-                      <div className="author-name">{story.author}</div>
-                    </div>
-                  </div>
-
-                  <h3 className="story-title" onClick={() => handleStoryClick(story)}>
-                    {story.title}
-                  </h3>
-                  <p className="story-description" onClick={() => handleStoryClick(story)}>
-                    {story.description}
-                  </p>
-
-                  <div className="story-tags">
-                    {story.tags.map((tag, index) => (
-                      <span key={index} className="story-tag">{tag}</span>
-                    ))}
-                  </div>
-
-                  {/* Stats */}
-                  <div className="story-stats-simple">
-                    <div className="stat-simple-item">
-                      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-                        <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/>
-                      </svg>
-                      {story.likes}
-                    </div>
-                    <div className="stat-simple-item">
-                      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-                        <path d="M12 2C6.48 2 2 6.48 2 12c0 1.54.36 3 .97 4.29L2 22l5.71-.97C9 21.64 10.46 22 12 22c5.52 0 10-4.48 10-10S17.52 2 12 2zm0 18c-1.38 0-2.68-.3-3.86-.83l-.28-.15-2.86.49.49-2.86-.15-.28C4.3 14.68 4 13.38 4 12c0-4.41 3.59-8 8-8s8 3.59 8 8-3.59 8-8 8z"/>
-                      </svg>
-                      {story.comments}
-                    </div>
-                  </div>
-
-                  {/* Edit/Delete Buttons */}
-                  <div style={{
-                    display: 'flex',
-                    gap: '8px',
-                    marginTop: '12px',
-                    paddingTop: '12px',
-                    borderTop: '2px dashed rgba(0,0,0,0.2)'
-                  }}>
-                    <button
-                      onClick={() => handleEdit(story)}
-                      style={{
-                        flex: 1,
-                        padding: '10px',
-                        border: '2px solid #000',
-                        background: '#fff',
-                        color: '#000',
-                        fontSize: '11px',
-                        fontWeight: 700,
-                        fontFamily: "'Share Tech Mono', monospace",
-                        textTransform: 'uppercase',
-                        cursor: 'pointer',
-                        transition: 'all 0.2s'
-                      }}
-                      onMouseEnter={(e) => {
-                        e.currentTarget.style.background = '#000';
-                        e.currentTarget.style.color = '#fff';
-                      }}
-                      onMouseLeave={(e) => {
-                        e.currentTarget.style.background = '#fff';
-                        e.currentTarget.style.color = '#000';
-                      }}
-                    >
-                      EDIT
-                    </button>
-                    <button
-                      onClick={() => handleDelete(story.id)}
-                      style={{
-                        flex: 1,
-                        padding: '10px',
-                        border: '2px solid #dc3545',
-                        background: '#fff',
-                        color: '#dc3545',
-                        fontSize: '11px',
-                        fontWeight: 700,
-                        fontFamily: "'Share Tech Mono', monospace",
-                        textTransform: 'uppercase',
-                        cursor: 'pointer',
-                        transition: 'all 0.2s'
-                      }}
-                      onMouseEnter={(e) => {
-                        e.currentTarget.style.background = '#dc3545';
-                        e.currentTarget.style.color = '#fff';
-                      }}
-                      onMouseLeave={(e) => {
-                        e.currentTarget.style.background = '#fff';
-                        e.currentTarget.style.color = '#dc3545';
-                      }}
-                    >
-                      DELETE
-                    </button>
-                  </div>
-                </div>
-              </div>
+          <FilterSection 
+            filters={hook.filters}
+            setFilters={hook.setFilters}
+          />
+          <div className="card-grid">
+            {hook.getFilteredStories().map((story) => (
+              <StoryCard
+                key={story.id}
+                story={story}
+                onCardClick={hook.handleStoryClick}
+                likedStories={hook.likedStories}
+                setLikedStories={hook.setLikedStories}
+                followedStories={hook.followedStories}
+                setFollowedStories={hook.setFollowedStories}
+              />
             ))}
           </div>
-
-          {/* No Stories */}
-          {getFilteredStories().length === 0 && (
-            <div className="no-results-fullpage">
-              <div className="no-results-text">작성한 여행기가 없습니다.</div>
-              <div className="no-results-subtext">첫 여행기를 작성해보세요!</div>
-            </div>
-          )}
         </div>
-      )}
-
-      {/* Bookmarks Page */}
-      {currentPage === 'bookmarks' && (
-        <div className="container">
-          <div style={{ padding: '0 0 40px 0' }}>
-            <h2 style={{ fontSize: '24px', fontWeight: 700, marginBottom: '30px' }}>
-              즐겨찾기
-            </h2>
-            {bookmarkedIds.length === 0 ? (
-              <div className="bookmarks-empty">
-                <div className="bookmarks-empty-text">즐겨찾기한 여행기가 없습니다.</div>
-              </div>
-            ) : (
-              <div className="posts-grid">
-                {/* Implement bookmarked stories here */}
-              </div>
-            )}
-          </div>
-        </div>
-      )}
-
-      {/* Write Page */}
-      {currentPage === 'write' && (
-        <WritePage
-          editingStory={editingStory}
-          currentDraft={currentDraft}
-          onBack={goBack}
-          onSaveDraft={handleSaveDraft}
-          onPublish={handlePublish}
-          drafts={drafts}
-          onShowDraftModal={() => setShowDraftModal(true)}
-        />
       )}
 
       {/* Detail Page */}
-      {currentPage === 'detail' && selectedStory && (
-        <div className="detail-page-container">
-          {/* Content */}
-          <div className="detail-page-content">
-            
-            {/* Title과 X Button - 같은 라인 */}
-            <div style={{
-              display: 'flex',
-              justifyContent: 'space-between',
-              alignItems: 'center',
-              marginBottom: '15px'
-            }}>
-              {/* Title */}
-              <h1 style={{
-                fontSize: '32px',
-                fontWeight: 700,
-                lineHeight: 1.4,
-                margin: 0,
-                fontFamily: "'Share Tech Mono', monospace"
-              }}>
-                {selectedStory.title}
-              </h1>
-
-              {/* X Button */}
-              <button
-                onClick={goBack}
-                style={{
-                  border: 'none',
-                  background: 'transparent',
-                  cursor: 'pointer',
-                  padding: 0,
-                  lineHeight: 1,
-                  transition: 'opacity 0.2s',
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  flexShrink: 0
-                }}
-                onMouseEnter={(e) => {
-                  e.currentTarget.style.opacity = '0.5';
-                }}
-                onMouseLeave={(e) => {
-                  e.currentTarget.style.opacity = '1';
-                }}
-              >
-                <svg 
-                  xmlns="http://www.w3.org/2000/svg" 
-                  viewBox="0 0 24 24" 
-                  style={{ 
-                    width: '40px',
-                    height: '40px',
-                    fill: '#000'
-                  }}
-                >
-                  <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/>
-                </svg>
-              </button>
-            </div>
-
-            {/* Info Tags와 Author Info - 같은 라인 */}
-            <div style={{
-              display: 'flex',
-              justifyContent: 'space-between',
-              alignItems: 'center',
-              paddingBottom: '25px',
-              borderBottom: '2px solid #000',
-              marginBottom: '30px'
-            }}>
-              {/* Info Tags */}
-              <div style={{
-                display: 'flex',
-                flexWrap: 'wrap',
-                gap: '10px'
-              }}>
-                <div style={{
-                  padding: '8px 16px',
-                  background: '#f5f5f5',
-                  border: '2px solid #000',
-                  fontSize: '11px',
-                  fontWeight: 700,
-                  fontFamily: "'Share Tech Mono', monospace",
-                  textTransform: 'uppercase'
-                }}>
-                  {selectedStory.destination}
-                </div>
-                <div style={{
-                  padding: '8px 16px',
-                  background: '#f5f5f5',
-                  border: '2px solid #000',
-                  fontSize: '11px',
-                  fontWeight: 700,
-                  fontFamily: "'Share Tech Mono', monospace",
-                  textTransform: 'uppercase'
-                }}>
-                  {selectedStory.duration}
-                </div>
-                <div style={{
-                  padding: '8px 16px',
-                  background: '#f5f5f5',
-                  border: '2px solid #000',
-                  fontSize: '11px',
-                  fontWeight: 700,
-                  fontFamily: "'Share Tech Mono', monospace",
-                  textTransform: 'uppercase'
-                }}>
-                  {parseInt(selectedStory.budget).toLocaleString()}원
-                </div>
-              </div>
-
-              {/* Author Info */}
-              <div style={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: '12px',
-                flexShrink: 0,
-                marginRight: '20px'
-              }}>
-                {/* 프로필 사진 */}
-                <div style={{
-                  width: '40px',
-                  height: '40px',
-                  background: '#000',
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  fontSize: '16px',
-                  color: '#fff',
-                  fontWeight: 700,
-                  fontFamily: "'Share Tech Mono', monospace"
-                }}>
-                  {selectedStory.authorAvatar}
-                </div>
-
-                {/* 닉네임 */}
-                <div style={{
-                  fontSize: '16px',
-                  fontWeight: 700,
-                  fontFamily: "'Share Tech Mono', monospace",
-                  textTransform: 'uppercase'
-                }}>
-                  {selectedStory.author}
-                </div>
-
-                {/* 날짜, 조회수 */}
-                <div style={{
-                  display: 'flex',
-                  flexDirection: 'column',
-                  gap: '3px',
-                  fontSize: '11px',
-                  color: '#999',
-                  fontFamily: "'Share Tech Mono', monospace"
-                }}>
-                  <div>{selectedStory.date}</div>
-                  <div>{selectedStory.views} VIEWS</div>
-                </div>
-              </div>
-            </div>
-
-            {/* Cover Image */}
-            <div style={{
-              width: '100%',
-              maxWidth: '700px',
-              marginBottom: '40px',
-              border: '3px solid #000',
-              margin: '0 auto 40px auto'
-            }}>
-              <img 
-                src={selectedStory.image} 
-                alt={selectedStory.title}
-                style={{
-                  width: '100%',
-                  height: 'auto',
-                  display: 'block'
-                }}
-              />
-            </div>
-
-            {/* Description */}
-            <div style={{
-              fontSize: '15px',
-              lineHeight: '1.8',
-              color: '#333',
-              marginBottom: '30px',
-              fontFamily: "'Share Tech Mono', monospace"
-            }}>
-              {selectedStory.description}
-            </div>
-
-            {/* 여행 경비 총정리 */}
-            <div style={{
-              background: '#fff',
-              border: '2px solid #000',
-              padding: '20px 25px',
-              marginBottom: '30px',
-              maxWidth: '700px',
-              margin: '0 auto 30px auto'
-            }}>
-              <h3 style={{
-                fontSize: '15px',
-                fontWeight: 700,
-                fontFamily: "'Share Tech Mono', monospace",
-                textTransform: 'uppercase',
-                marginBottom: '15px',
-                paddingBottom: '10px',
-                borderBottom: '3px solid #000',
-                color: '#000'
-              }}>
-                여행 경비 총정리
-              </h3>
-
-              <div style={{
-                display: 'flex',
-                flexDirection: 'column',
-                gap: '0'
-              }}>
-                <div style={{
-                  display: 'flex',
-                  justifyContent: 'space-between',
-                  alignItems: 'center',
-                  padding: '12px 0',
-                  borderBottom: '1px solid #e0e0e0',
-                  fontFamily: "'Share Tech Mono', monospace"
-                }}>
-                  <span style={{ fontSize: '13px', color: '#333' }}>교통비 (렌터카)</span>
-                  <span style={{ fontSize: '13px', fontWeight: 700 }}>95,000원</span>
-                </div>
-
-                <div style={{
-                  display: 'flex',
-                  justifyContent: 'space-between',
-                  alignItems: 'center',
-                  padding: '12px 0',
-                  borderBottom: '1px solid #e0e0e0',
-                  fontFamily: "'Share Tech Mono', monospace"
-                }}>
-                  <span style={{ fontSize: '13px', color: '#333' }}>숙박비</span>
-                  <span style={{ fontSize: '13px', fontWeight: 700 }}>85,000원</span>
-                </div>
-
-                <div style={{
-                  display: 'flex',
-                  justifyContent: 'space-between',
-                  alignItems: 'center',
-                  padding: '12px 0',
-                  borderBottom: '1px solid #e0e0e0',
-                  fontFamily: "'Share Tech Mono', monospace"
-                }}>
-                  <span style={{ fontSize: '13px', color: '#333' }}>식비</span>
-                  <span style={{ fontSize: '13px', fontWeight: 700 }}>98,000원</span>
-                </div>
-
-                <div style={{
-                  display: 'flex',
-                  justifyContent: 'space-between',
-                  alignItems: 'center',
-                  padding: '12px 0',
-                  borderBottom: '1px solid #e0e0e0',
-                  fontFamily: "'Share Tech Mono', monospace"
-                }}>
-                  <span style={{ fontSize: '13px', color: '#333' }}>관광/입장료</span>
-                  <span style={{ fontSize: '13px', fontWeight: 700 }}>15,000원</span>
-                </div>
-
-                <div style={{
-                  display: 'flex',
-                  justifyContent: 'space-between',
-                  alignItems: 'center',
-                  padding: '12px 0',
-                  borderBottom: '1px solid #e0e0e0',
-                  fontFamily: "'Share Tech Mono', monospace"
-                }}>
-                  <span style={{ fontSize: '13px', color: '#333' }}>쇼핑/기타</span>
-                  <span style={{ fontSize: '13px', fontWeight: 700 }}>35,000원</span>
-                </div>
-
-                <div style={{
-                  display: 'flex',
-                  justifyContent: 'space-between',
-                  alignItems: 'center',
-                  padding: '16px 25px',
-                  background: '#000',
-                  color: '#fff',
-                  marginTop: '12px',
-                  fontFamily: "'Share Tech Mono', monospace"
-                }}>
-                  <span style={{ fontSize: '14px', fontWeight: 700 }}>총 합계</span>
-                  <span style={{ fontSize: '16px', fontWeight: 700 }}>328,000원</span>
-                </div>
-              </div>
-            </div>
-
-            {/* Tags */}
-            <div style={{
-              display: 'flex',
-              flexWrap: 'wrap',
-              gap: '8px',
-              paddingTop: '30px',
-              borderTop: '2px dashed rgba(0,0,0,0.2)'
-            }}>
-              {selectedStory.tags.map((tag, index) => (
-                <span 
-                  key={index}
-                  style={{
-                    padding: '6px 12px',
-                    background: '#000',
-                    color: '#fff',
-                    fontSize: '11px',
-                    fontWeight: 700,
-                    fontFamily: "'Share Tech Mono', monospace",
-                    textTransform: 'uppercase'
-                  }}
-                >
-                  {tag}
-                </span>
-              ))}
-            </div>
-
-            {/* Stats - COMMENTS 제거 */}
-            <div style={{
-              display: 'flex',
-              gap: '30px',
-              paddingTop: '30px',
-              marginTop: '30px',
-              borderTop: '2px solid #000'
-            }}>
-              <button 
-                className={`detail-stat-button ${likedStories.includes(selectedStory.id) ? 'active' : ''}`}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  if (likedStories.includes(selectedStory.id)) {
-                    setLikedStories(likedStories.filter(id => id !== selectedStory.id));
-                  } else {
-                    setLikedStories([...likedStories, selectedStory.id]);
-                  }
-                }}
-              >
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-                  <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/>
-                </svg>
-                <span className="detail-stat-number">{selectedStory.likes}</span>
-                <span className="detail-stat-tooltip">LIKES</span>
-              </button>
-              
-              <button 
-                className={`detail-stat-button ${followedStories.includes(selectedStory.id) ? 'active' : ''}`}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  if (followedStories.includes(selectedStory.id)) {
-                    setFollowedStories(followedStories.filter(id => id !== selectedStory.id));
-                  } else {
-                    setFollowedStories([...followedStories, selectedStory.id]);
-                  }
-                }}
-              >
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-                  <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/>
-                </svg>
-                <span className="detail-stat-number">{selectedStory.follows || 45}</span>
-                <span className="detail-stat-tooltip">FOLLOW THIS</span>
-              </button>
-            </div>
-          </div>
-
-          {/* Comments Section */}
-          <CommentSection />
-        </div>
+      {hook.currentPage === 'detail' && hook.selectedStory && (
+        <DetailPage
+          story={hook.selectedStory}
+          goBack={hook.goBack}
+          likedStories={hook.likedStories}
+          toggleLike={hook.toggleLike}
+          followedStories={hook.followedStories}
+          setFollowedStories={hook.setFollowedStories}
+          incrementViews={hook.incrementViews}
+        />
       )}
 
-      {/* Custom Alert */}
-      {showAlert && (
-        <div className="custom-alert" onClick={() => showCustomAlert('')}>
-          <div className="custom-alert-content" onClick={(e) => e.stopPropagation()}>
-            <div className="custom-alert-message">{alertMessage}</div>
-            <button className="custom-alert-btn" onClick={() => showCustomAlert('')}>확인</button>
-          </div>
-        </div>
+      {/* Write Page */}
+      {hook.currentPage === 'write' && (
+        <WritePage
+          goBack={hook.goBack}
+          onPublish={hook.handlePublish}
+          onSaveDraft={hook.handleSaveDraft}
+          onOpenDraftModal={() => hook.setShowDraftModal(true)}
+          editingStory={hook.editingStory}
+          currentDraft={hook.currentDraft}
+          drafts={hook.drafts}
+        />
+      )}
+
+      {/* My Stories Page */}
+      {hook.currentPage === 'myStories' && (
+        <MyStoriesPage
+          goBack={hook.goBack}
+          navigateToPage={hook.navigateToPage}
+          getFilteredStories={hook.getFilteredStories}
+          handleStoryClick={hook.handleStoryClick}
+          handleEdit={hook.handleEdit}
+          handleDelete={hook.handleDelete}
+          likedStories={hook.likedStories}
+          setLikedStories={hook.setLikedStories}
+          followedStories={hook.followedStories}
+          setFollowedStories={hook.setFollowedStories}
+          setShowLikesModal={hook.setShowLikesModal}
+        />
       )}
 
       {/* Draft Modal */}
-      {showDraftModal && (
-        <div className="draft-modal-overlay" onClick={() => setShowDraftModal(false)}>
-          <div className="draft-modal-content" onClick={(e) => e.stopPropagation()}>
-            <div className="draft-modal-header">
-              <h2 className="draft-modal-title">임시저장 목록</h2>
-              <button className="draft-close-btn" onClick={() => setShowDraftModal(false)}>&times;</button>
-            </div>
-            <div className="draft-list">
-              {drafts.map((draft: any) => (
-                <div 
-                  key={draft.id} 
-                  className="draft-item"
-                  onClick={() => {
-                    setCurrentDraft(draft);
-                    setShowDraftModal(false);
-                    setCurrentPage('write');
-                  }}
-                >
-                  <div className="draft-item-title">{draft.title}</div>
-                  <div className="draft-item-date">{draft.date}</div>
-                </div>
-              ))}
-              {drafts.length === 0 && (
-                <div className="draft-empty">임시저장된 글이 없습니다.</div>
-              )}
-            </div>
-          </div>
-        </div>
+      {hook.showDraftModal && (
+        <DraftModal
+          show={hook.showDraftModal}
+          drafts={hook.drafts}
+          onClose={() => hook.setShowDraftModal(false)}
+          onSelectDraft={(draft) => {
+            hook.setCurrentDraft(draft);
+            hook.setCurrentDraftId(draft.id);
+            hook.setShowDraftModal(false);
+          }}
+          onDeleteDraft={(id) => {
+            hook.setDrafts(hook.drafts.filter(d => d.id !== id));
+          }}
+          hoveredDraftId={hoveredDraftId}
+          setHoveredDraftId={setHoveredDraftId}
+          deleteHoverId={deleteHoverId}
+          setDeleteHoverId={setDeleteHoverId}
+        />
       )}
 
-      {/* Likes Modal - 좋아요 목록 */}
-      {showLikesModal && (
-        <div className="draft-modal-overlay" onClick={() => setShowLikesModal(false)}>
-          <div className="draft-modal-content" onClick={(e) => e.stopPropagation()}>
-            <div className="draft-modal-header">
-              <h2 className="draft-modal-title">
-                <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
-                  <svg 
-                    xmlns="http://www.w3.org/2000/svg" 
-                    viewBox="0 0 24 24" 
-                    style={{ 
-                      width: '24px', 
-                      height: '24px',
-                      fill: '#ff4757'
-                    }}
-                  >
-                    <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/>
-                  </svg>
-                  좋아요 목록
-                </div>
-              </h2>
-              <button className="draft-close-btn" onClick={() => setShowLikesModal(false)}>&times;</button>
-            </div>
-            <div className="draft-list">
-              {getFilteredStories().filter(story => likedStories.includes(story.id)).map((story: Story) => (
-                <div 
-                  key={story.id} 
-                  className="draft-item"
-                  onClick={() => {
-                    handleStoryClick(story);
-                    setShowLikesModal(false);
-                  }}
-                  style={{
-                    display: 'flex',
-                    gap: '15px',
-                    alignItems: 'center'
-                  }}
-                >
-                  <img 
-                    src={story.image} 
-                    alt={story.title}
-                    style={{
-                      width: '80px',
-                      height: '80px',
-                      objectFit: 'cover',
-                      border: '2px solid #000'
-                    }}
-                  />
-                  <div style={{ flex: 1 }}>
-                    <div className="draft-item-title">{story.title}</div>
-                    <div style={{
-                      fontSize: '12px',
-                      color: '#666',
-                      marginTop: '5px',
-                      fontFamily: "'Share Tech Mono', monospace"
-                    }}>
-                      {story.destination} · {story.duration} · {parseInt(story.budget).toLocaleString()}원
-                    </div>
-                  </div>
-                </div>
-              ))}
-              {likedStories.length === 0 && (
-                <div className="draft-empty">좋아요한 여행기가 없습니다.</div>
-              )}
-            </div>
-          </div>
-        </div>
+      {/* Likes Modal */}
+      {hook.showLikesModal && (
+        <LikesModal
+          show={hook.showLikesModal}
+          onClose={() => hook.setShowLikesModal(false)}
+          stories={getLikedStoriesList()}
+          onStoryClick={(story) => {
+            hook.handleStoryClick(story);
+            hook.setShowLikesModal(false);
+          }}
+        />
       )}
 
-      {/* Delete Confirmation Modal */}
-      {showDeleteModal && (
-        <div className="delete-modal-overlay" onClick={() => setShowDeleteModal(false)}>
-          <div className="delete-modal-content" onClick={(e) => e.stopPropagation()}>
-            <div className="delete-modal-header">
-              <h2 className="delete-modal-title">여행기 삭제</h2>
-            </div>
-            <div className="delete-modal-body">
-              <p className="delete-modal-message">
-                정말 삭제하시겠습니까?<br />
-                삭제된 여행기는 복구할 수 없습니다.
-              </p>
-              <div className="delete-modal-buttons">
-                <button className="delete-btn-cancel" onClick={() => setShowDeleteModal(false)}>
-                  취소
-                </button>
-                <button className="delete-btn-confirm" onClick={confirmDelete}>
-                  삭제
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
+      {/* Custom Alert */}
+      {hook.showAlert && (
+        <CustomAlert 
+          show={hook.showAlert}
+          message={hook.alertMessage}
+          onClose={hook.closeAlert}
+        />
+      )}
+
+      {/* Delete Modal */}
+      {hook.showDeleteModal && (
+        <DeleteModal
+          show={hook.showDeleteModal}
+          onClose={() => hook.setShowDeleteModal(false)}
+          onConfirm={hook.confirmDelete}
+          title="여행기 삭제"
+          message="여행기를 삭제하시겠습니까?\n삭제된 여행기는 복구할 수 없습니다."
+        />
       )}
     </>
   );

--- a/src/styles/travelStory/travelStory.css
+++ b/src/styles/travelStory/travelStory.css
@@ -656,5 +656,65 @@ body {
     }
 }
 
+/* ===== modals.css 스타일 (좋아요/임시저장 모달용) ===== */
+
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
+}
+
+.modal-overlay.active {
+  display: flex;
+}
+
+.modal-content {
+  background: white;
+  padding: 24px;
+  border-radius: 12px;
+  width: 100%;
+  max-width: 400px;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.1);
+}
+
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 20px;
+}
+
+.modal-header h2 {
+  font-size: 20px;
+  font-weight: 800;
+  margin: 0;
+}
+
+.close-btn {
+  background: none;
+  border: none;
+  font-size: 24px;
+  cursor: pointer;
+}
+
+.modal-body {
+  background: #fff;
+}
+
+.modal-body input,
+.modal-body textarea,
+.modal-body select {
+  background: #fff !important;
+  border: 2px solid #ddd !important;
+  font-family: inherit;
+}
+
 
 


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #57 

---

## 🎨 작업 내용 (What)

- TravelStory 페이지 전반 구조 리팩터링
- 페이지 상태/네비게이션 로직을 useTravelStory 훅으로 통합
- 여행기 작성/상세/목록/내 글 페이지 컴포넌트 책임 정리
- Draft / Like / Delete / Confirm 등 모달 UI 패턴 통일
- 댓글, 이미지 슬라이더, 에디터 관련 DOM 제어 코드 정리
- 스타일 및 인라인 스타일 중복 제거 및 정돈

---

## 🧭 작업 목적 (Why)
<!-- 왜 이 작업이 필요한지, 어떤 문제를 해결하는지 -->

- 페이지별로 분산되어 있던 상태 관리 로직을 중앙화하여 유지보수성 개선
- 기능 추가 시 사이드 이펙트가 발생하던 구조를 명확한 데이터 흐름으로 정리
- 중복된 UI/로직을 제거하여 코드 가독성과 확장성 확보
- TravelStory 기능 전반을 하나의 흐름으로 이해 가능하도록 구조 개선

---

## 🧩 변경 범위
- [x] UI / Layout
- [x] 컴포넌트 구조
- [x] 상태 관리 로직
- [ ] API 연동
- [x] 스타일

---

## 🧪 테스트 방법
- [x] 로컬 실행 확인
- [x] 주요 화면 렌더링 확인
- [x] 에러 콘솔 확인

---

## ⚠️ 참고 사항
<!-- 리뷰어가 알아야 할 내용 -->

- 기능 동작 변경 없음 (리팩터링 전용 PR)
- 이미지 슬라이더, 에디터, 댓글 등 DOM 직접 제어 로직은
- 추후 단계적 분리를 고려한 구조로 정리됨
- PR 사이즈가 다소 크지만, TravelStory 기능을 기준으로 한 단일 리팩터링 단위임

---

## ✅ 체크리스트
- [x] main 브랜치 직접 push 하지 않음
- [x] feature 브랜치에서 작업함
- [x] 불필요한 console.log 제거
- [x] PR 단위가 과도하게 크지 않음
