### PR TITLE
[FE] feature: Mate 신청 시스템 API 연동 및 예외 처리

### DIFF
--- a/src/features/mate/components/MateReceiveModal.tsx
+++ b/src/features/mate/components/MateReceiveModal.tsx
@@ -12,13 +12,15 @@ interface ReceivedModalProps {
 }
 
 export function MateReceivedModal({ 
-  applications, 
+  applications = [], 
   getApplicantStatus, 
   onApprove, 
-  onReject, 
+  onReject,
   onClose,
 }: ReceivedModalProps){
   const [selectedApplicant, setSelectedApplicant] = useState<SelectedApplicant | null>(null);
+
+  const safeApplications = applications || [];
 
   const groupedByPost = applications.reduce((acc, app) => {
     if (!acc[app.postId]) {
@@ -31,11 +33,12 @@ export function MateReceivedModal({
     }
     acc[app.postId].applicants.push(app);
     return acc;
-  }, {} as Record<string, { destination: string; startDate: string; endDate: string; applicants: ReceivedApplication[] }>);
+  }, {} as Record<string, any>);
 
   // 신청자 상세 보기
   if (selectedApplicant) {
-    const status = getApplicantStatus(selectedApplicant.id);
+    const rawStatus = getApplicantStatus(selectedApplicant.id);
+    const status = String(rawStatus);
     
     return (
       <div className="modal-overlay active" onMouseDown={(e) => { if (e.target === e.currentTarget) onClose(); }}>
@@ -114,15 +117,38 @@ export function MateReceivedModal({
 
             {/* Actions */}
             <div className="flex gap-4">
-              <button onClick={() => onReject(selectedApplicant.id)}
-                className={`flex-1 py-3 font-bold uppercase tracking-wide transition-colors button ${status === "rejected" ? "bgRed" : "bg-white text-black hover:bg-[#eee]"}`}>
-                {status === "rejected" ? "REJECTED" : "REJECT"}
-              </button>
-              <button onClick={() => onApprove(selectedApplicant.id)}
-                className={`flex-1 py-3 font-bold uppercase tracking-wide transition-colors flex items-center justify-center gap-2 button ${status === "approved" ? "bgGreen" : "bgBlack"}`}>
-                {status === "approved" ? "APPROVED" : <><Check className="w-4 h-4" />APPROVE</>}
-              </button>
+              {status === "pending" ? (
+                <>
+                  <button onClick={() => onReject(selectedApplicant.id)}
+                    className="flex-1 py-3 font-bold uppercase transition-colors button bg-white text-black hover:bg-[#eee]">
+                    REJECT
+                  </button>
+                  <button onClick={() => onApprove(selectedApplicant.id)}
+                    className="flex-1 py-3 font-bold uppercase transition-colors flex items-center justify-center gap-2 button bgBlack text-white">
+                    <Check className="w-4 h-4" /> APPROVE
+                  </button>
+                </>
+              ):(
+                <div className={`flex-1 py-4 text-center font-black border-4 border-black shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] ${status === "approved" ? "bgGreen" : "bgRed"}`}>
+                  {status.toUpperCase()}
+                </div>
+              )}
             </div>
+
+            {/* {status === "approved" && (
+              <div className="mt-4 p-4 bg-green-50 border-2 border-dashed border-green-500 rounded-lg animate-fade-in">
+                <p className="text-sm text-green-700 font-bold text-center mb-3">
+                  매칭이 완료되었습니다! 이제 채팅으로 세부 일정을 조율해보세요.
+                </p>
+                <button 
+                  onClick={() => window.location.href = '/chat'} // 채팅 페이지 경로에 맞게 수정
+                  className="w-full py-3 bg-[#8B5CF6] text-white font-bold flex items-center justify-center gap-2 hover:bg-[#7C3AED] transition-all shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] active:shadow-none active:translate-x-1 active:translate-y-1"
+                >
+                  <Send className="w-4 h-4" />
+                  채팅하기
+                </button>
+              </div>
+            )} */}
           </div>
         </div>
       </div>
@@ -138,7 +164,10 @@ export function MateReceivedModal({
           <button className="mh-close" onClick={onClose}>CLOSE [X]</button>
         </div>
 
-        <div className="modal-body" style={{ background: "white", padding: "32px" }}>
+        <div className="modal-body" style={{ 
+          background: "white", 
+          padding: "32px", 
+         }}>
           {Object.keys(groupedByPost).length === 0 ? (
             <div className="text-center py-12">
               <Send className="w-16 h-16 mx-auto mb-4 text-black/30" />
@@ -148,7 +177,7 @@ export function MateReceivedModal({
           ) : (
             <div className="space-y-10">
               {Object.entries(groupedByPost).map(([postId, data]) => {
-                const hasApprovedApplicants = data.applicants.some(app => getApplicantStatus(app.id) === "approved");
+                const hasApprovedApplicants = data.applicants.some(app => getApplicantStatus(app.id)?.toLowerCase() === "approved");
                 
                 return (
                   <div key={postId} className="card">
@@ -171,7 +200,7 @@ export function MateReceivedModal({
                     </div>
                     <div className="p-5 space-y-4">
                       {data.applicants.map((app) => {
-                        const status = getApplicantStatus(app.id);
+                        const status = getApplicantStatus(app.id)?.toLowerCase();
                         return (
                           <div key={app.id}
                             onClick={() => setSelectedApplicant({ 

--- a/src/features/mate/hooks/useMate.ts
+++ b/src/features/mate/hooks/useMate.ts
@@ -11,6 +11,8 @@ const API_BASE_URL = "http://localhost:8080/api";
 export function useMate() {
   const [posts, setPosts] = useState<Post[]>([]);
   const [loading, setLoading] = useState(false);
+  const [applications, setApplications] = useState<any[]>([]);
+  const [receivedApplications, setReceivedApplications] = useState<any[]>([]);
   const [error, setError] = useState<string | null>(null);
   const token = localStorage.getItem("accessToken");
 
@@ -158,7 +160,7 @@ export function useMate() {
     }
   }, []);
 
-  const toggleLike = useCallback(async (postId: number): Promise<boolean> => {
+  const toggleLike = useCallback(async (postId: number): Promise<LikeResponse | null> => {
     try {
       const response = await fetch(`${API_BASE_URL}/mate/${postId}/like`, {
         method: "POST",
@@ -186,12 +188,62 @@ export function useMate() {
         )
       );
 
-      return true;
+      return likeResponse;
     } catch (err) {
       setError(err instanceof Error ? err.message : "알 수 없는 오류가 발생했습니다.");
       return false;
     }
   }, []);
+
+  // 1. 받은 신청 목록 불러오기
+  const fetchReceivedApplications = useCallback(async () => {
+    try {
+      const response = await fetch(`${API_BASE_URL}/mate/applications/received`, {
+        headers: { "Authorization": `Bearer ${token}` }
+      });
+      if (!response.ok) throw new Error("데이터 로딩 실패");
+      const data = await response.json();
+      
+      const mappedData = data.map((app: any) => ({
+        id: app.id,
+        postId: app.matePostId,
+        postDestination: app.postDestination,
+        status: app.status,
+        applicant: {
+          name: app.applicantName,
+          email: app.applicantEmail,
+          message: app.content,
+          avatar: app.avatar || "👤",
+          age: app.age,
+          gender: app.gender,
+        }
+      }));
+      setReceivedApplications(mappedData);
+    } catch (err) {
+      console.error("신청 목록 로딩 실패", err);
+    }
+  }, [token]);
+
+  // 2. 승인/거절 처리 (상태 업데이트 로직 포함)
+  const handleApplicationStatus = async (applyId: string, type: 'approve' | 'reject') => {
+    try {
+      const response = await fetch(`${API_BASE_URL}/mate/applications/${applyId}/${type}`, {
+        method: "PUT",
+        headers: { "Authorization": `Bearer ${token}` }
+      });
+
+      const errorData = await response.json();
+      
+      if (response.ok) {
+        alert(type === 'approve' ? "승인되었습니다." : "거절되었습니다.");
+        fetchReceivedApplications(); // 목록 새로고침
+      } else {
+        alert(errorData.message || "이미 처리가 완료된 신청서입니다.");
+      }
+    } catch (err) {
+      console.error(err);
+    }
+  };
 
   return {
     posts,
@@ -202,5 +254,13 @@ export function useMate() {
     fetchPostDetail,
     deletePost,
     toggleLike,
+    applications,
+    fetchReceivedApplications,
+    receivedApplications,
+    handleApplicationStatus,
+    getApplicantStatus: (id: string) => {
+      const app = receivedApplications.find(a => String(a.id) === String(id));
+      return app?.status || "pending"; 
+    }
   };
 }

--- a/src/features/mate/pages/Mate.tsx
+++ b/src/features/mate/pages/Mate.tsx
@@ -13,6 +13,7 @@ import {
   MatePostCard,
   MatePagination,
   MateWriteModal,
+  MateReceivedModal,
 } from "../components";
 
 import "../styles/Mate.css";
@@ -32,7 +33,9 @@ export default function Mate() {
   const [selectedGender, setSelectedGender] = useState("");
   const [selectedAgeGroup, setSelectedAgeGroup] = useState("");
 
-  const { posts, loading, error, fetchPosts, createPost, deletePost, toggleLike } = useMate();
+  const { posts, loading, error, fetchPosts, createPost, deletePost, toggleLike,
+    applications, receivedApplications, fetchReceivedApplications, handleApplicationStatus, getApplicantStatus
+   } = useMate();
 
   const {
     locationFilter,
@@ -66,6 +69,12 @@ export default function Mate() {
   useEffect(() => {
     fetchPosts();
   }, [fetchPosts]);
+
+  useEffect(() => {
+    if (showReceivedModal) {
+      fetchReceivedApplications();
+    }
+  }, [showReceivedModal]);
 
   const handleCardClick = (post: any) => {
     navigate(`/mate/${post.id}`);
@@ -321,6 +330,21 @@ export default function Mate() {
           setSelectedGender={setSelectedGender}
         />
       )}
+
+      {showReceivedModal && (
+        <MateReceivedModal
+          applications={receivedApplications}
+          getApplicantStatus={(id) => {
+              const app = receivedApplications.find(a => a.id === id);
+              return app?.status || "pending";
+          }}
+          onApprove={(id) => handleApplicationStatus(id, 'approve')}
+          onReject={(id) => handleApplicationStatus(id, 'reject')}
+          onClose={() => setShowReceivedModal(false)}
+        />
+      )}
+
+
     </section>
   );
 }

--- a/src/features/mate/pages/MateDetail.tsx
+++ b/src/features/mate/pages/MateDetail.tsx
@@ -23,6 +23,7 @@ export default function MateDetail() {
 
   const currentUserId = getCurrentUserId();
   const isAuthor = post?.author.id === currentUserId;
+  const token = localStorage.getItem("accessToken");
 
   useEffect(() => {
     const loadPost = async () => {
@@ -94,9 +95,12 @@ export default function MateDetail() {
         content: applyMessage,
       };
 
-      const response = await fetch(`http://localhost:8080/api/mate/${postId}/apply`, {
+      const response = await fetch(`http://localhost:8080/api/mate/${postId}/apply/applicant`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 
+          "Content-Type": "application/json",
+          "Authorization": `Bearer ${token}`
+        },
         body: JSON.stringify(requestBody),
       });
 
@@ -112,7 +116,7 @@ export default function MateDetail() {
       setApplyMessage("");
       alert("신청이 완료되었습니다!");
       
-      navigate("/mate", { replace: true });
+      navigate(`/mate/${postId}`, { replace: true });
     } catch (error) {
       console.error('신청 오류:', error);
       alert(error instanceof Error ? error.message : "신청 중 오류가 발생했습니다.");


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #68

---

## 🎨 작업 내용 (What)
- 동행(Mate) 게시글 상세 페이지 내 '신청하기' 모달 및 API 연동
- 마이페이지 내 '받은 신청 관리' 목록 렌더링 및 승인/거절 기능 구현
- 백엔드 공통 예외 처리 체계(`BusinessException`)에 따른 에러 메시지 팝업 연동
- 신청 상태(`PENDING`, `APPROVED`, `REJECTED`)에 따른 UI 분기 처리

---

## 🧭 작업 목적 (Why)
- 사용자가 게시글을 보고 실제 참여 신청을 할 수 있는 핵심 비즈니스 로직 구현
- 중복 신청이나 이미 처리된 신청서에 대해 "서버 내부 오류"가 아닌 "이미 처리된 신청서입니다"와 같은 사용자 친화적인 에러 메시지를 제공하여 UX 개선
- 도메인 검증 로직을 강화하여 시스템 데이터 정합성 유지

---

## 🧩 변경 범위
- [ ] UI / Layout
- [ ] 컴포넌트 구조
- [x] 상태 관리 로직
- [x] API 연동
- [ ] 스타일

---

## 🧪 테스트 방법
- [x] 로컬 실행 확인: 신청/승인/거절 시 DB 상태 값 변경 확인
- [x] 주요 화면 렌더링 확인: 신청 후 상태값에 따른 버튼 비활성화 확인
- [x] 에러 콘솔 확인: `BusinessException` 발생 시 의도한 `ErrorCode` 메시지가 `alert`으로 뜨는지 확인

---

## ⚠️ 참고 사항
- **에러 핸들링 핵심**: 이제 서버에서 `500` 에러가 아닌 커스텀 에러(`MATE_400_013` 등)를 반환합니다. 프론트엔드에서는 `catch` 블록이나 응답 조건문에서 `result.message`를 그대로 사용자에게 보여주도록 처리되어 있습니다.
- **엔티티 검증**: `MateApplication` 엔티티 내 `validatePending()` 로직이 추가되어 있어, 이미 처리된 데이터에 대한 중복 요청은 프론트/백 양쪽에서 방어됩니다.

---

## ✅ 체크리스트
- [x] main 브랜치 직접 push 하지 않음
- [x] feature 브랜치에서 작업함
- [x] 불필요한 console.log 제거
- [x] PR 단위가 과도하게 크지 않음