### PR TITLE
[FE] refactor: Mate Sent/Received Modal UI 개편 및 신청자 데이터 렌더링 로직 수정

### DIFF
--- a/src/features/mate/components/MateDetailModal.tsx
+++ b/src/features/mate/components/MateDetailModal.tsx
@@ -1,0 +1,205 @@
+import { useState, useEffect, useRef } from "react";
+import { 
+  Heart, Calendar, Users, Wallet, MapPin, X, Info 
+} from "lucide-react";
+import type { Post, ApplicationRequest, ApplicationResponse } from "../hooks/mate.types";
+import { getCurrentUserId, calculateDuration } from "../hooks/mate.constants";
+import { useMate } from "../hooks/useMate";
+import "../styles/MateModals.css"; // 기존 모달 스타일 재사용
+
+interface MateDetailModalProps {
+  postId: number;
+  onClose: () => void;
+}
+
+export default function MateDetailModal({ postId, onClose }: MateDetailModalProps) {
+  const { toggleLike, fetchPostDetail } = useMate();
+  const [post, setPost] = useState<Post | null>(null);
+  const [showApplyForm, setShowApplyForm] = useState(false);
+  const [applyMessage, setApplyMessage] = useState("");
+  const [isLoading, setIsLoading] = useState(true);
+  
+  const token = localStorage.getItem("accessToken");
+  const currentUserId = getCurrentUserId();
+
+  useEffect(() => {
+    const loadPost = async () => {
+      try {
+        setIsLoading(true);
+        const postDetail = await fetchPostDetail(postId);
+        if (postDetail) setPost(postDetail);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    loadPost();
+  }, [postId, fetchPostDetail]);
+
+  const onLikeClick = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (!post) return;
+    // ... 기존 좋아요 로직 동일 ...
+    const result = await toggleLike(post.id);
+    if (result) setPost(prev => prev ? { ...prev, isLiked: result.liked, likesCount: result.count } : null);
+  };
+
+  const handleApplySubmit = async () => {
+    if (!applyMessage.trim() || !post) return;
+    try {
+      const response = await fetch(`http://localhost:8080/api/mate/${postId}/apply/applicant`, {
+        method: 'POST',
+        headers: { "Content-Type": "application/json", "Authorization": `Bearer ${token}` },
+        body: JSON.stringify({ content: applyMessage }),
+      });
+      if (!response.ok) throw new Error('신청 실패');
+      alert("신청이 완료되었습니다!");
+      onClose(); // 성공 시 모달 닫기
+    } catch (error) {
+      alert("신청 중 오류가 발생했습니다.");
+    }
+  };
+
+  if (isLoading || !post) return null;
+
+  const isAuthor = post.author.id === currentUserId;
+  const isLiked = post.isLiked || false;
+  const hasApplied = post.hasApplied || false;
+
+  return (
+    <div className="modal-overlay active" onMouseDown={(e) => e.target === e.currentTarget && onClose()}>
+      <div className="modal-window" style={{ maxWidth: "900px", width: "95%", height: "85vh", display: "flex", flexDirection: "column" }}>
+        
+        {/* 헤더 */}
+        <div className="modal-header">
+          <span className="mh-title">&gt;&gt; MATE_DETAIL_VIEW</span>
+          <div className="flex items-center gap-4">
+            <button onClick={onLikeClick} className={`flex items-center gap-1.5 text-xs font-bold ${isLiked ? "text-red-500" : "text-white/50"}`}>
+              <Heart size={14} fill={isLiked ? "currentColor" : "none"} />
+              {post.likesCount}
+            </button>
+            <button className="mh-close" onClick={onClose}>CLOSE [X]</button>
+          </div>
+        </div>
+
+        {/* 바디 (스크롤 가능) */}
+        <div className="modal-body" style={{ flex: 1, overflowY: "auto", background: "#f8f9fa", padding: "32px" }}>
+          <div className="flex flex-col md:flex-row gap-8">
+            
+            {/* 왼쪽 컬럼: 여행 정보 */}
+            <div className="flex-1 space-y-6">
+              {/* 여정 카드 */}
+              <div className="bg-black text-white p-6 rounded-2xl shadow-lg">
+                <div className="flex justify-between items-center text-center">
+                  <div>
+                    <p className="text-white/50 text-xs font-mono mb-1">DEPARTURE</p>
+                    <p className="text-sm font-bold">{post.startDate}</p>
+                  </div>
+                  <div className="flex-1 px-4">
+                    <div className="relative border-t border-dashed border-white/30 my-2">
+                      <span className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-black px-2 text-xl text-indigo-400">✈</span>
+                    </div>
+                    <p className="text-xl font-black tracking-tighter uppercase">{post.destination}</p>
+                  </div>
+                  <div>
+                    <p className="text-white/50 text-xs font-mono mb-1">ARRIVAL</p>
+                    <p className="text-sm font-bold">{post.endDate}</p>
+                  </div>
+                </div>
+              </div>
+
+              {/* 그리드 정보 */}
+              <div className="grid grid-cols-2 gap-3">
+                {[
+                  { icon: <Calendar size={18}/>, label: "기간", value: calculateDuration(post.startDate, post.endDate) },
+                  { icon: <Wallet size={18}/>, label: "예산", value: `${post.budget.toLocaleString()}원` },
+                  { icon: <Users size={18}/>, label: "인원", value: `${post.currentParticipant}/${post.maxParticipant}` },
+                  { icon: <Info size={18}/>, label: "조회", value: post.viewsCount },
+                ].map((item, idx) => (
+                  <div key={idx} className="bg-white p-4 rounded-xl border border-gray-100 flex items-center gap-3">
+                    <div className="text-indigo-500">{item.icon}</div>
+                    <div>
+                      <p className="text-[10px] text-gray-400 font-bold uppercase">{item.label}</p>
+                      <p className="text-sm font-bold text-gray-800">{item.value}</p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+
+              {/* 소개 본문 */}
+              <div className="bg-white p-6 rounded-2xl border border-gray-100 min-h-[200px]">
+                <h3 className="text-xs font-black text-gray-300 uppercase mb-4 tracking-widest">// Introduction</h3>
+                <p className="text-gray-700 leading-relaxed whitespace-pre-wrap">{post.content}</p>
+                <div className="mt-6 flex flex-wrap gap-2">
+                  {post.author?.travelStyles?.map(tag => (
+                    <span key={tag} className="text-[11px] font-bold px-2.5 py-1 bg-indigo-50 text-indigo-600 rounded-md">#{tag}</span>
+                  ))}
+                </div>
+              </div>
+            </div>
+
+            {/* 오른쪽 컬럼: 유저 & 신청 (고정 느낌) */}
+            <div className="w-full md:w-[320px] space-y-4">
+              {/* 작성자 카드 */}
+              <div className="bg-white p-5 rounded-2xl border border-gray-100 shadow-sm">
+                <p className="text-[10px] font-black text-gray-300 uppercase mb-4 tracking-widest">Host Info</p>
+                <div className="flex items-center gap-3">
+                  <div className="w-12 h-12 rounded-full bg-gray-100 flex items-center justify-center text-2xl border-2 border-white shadow-inner">
+                    {post.author.profileImage || "👤"}
+                  </div>
+                  <div>
+                    <p className="font-bold text-gray-900 leading-none mb-1">{post.author.nickname}</p>
+                    <p className="text-xs text-gray-400">{post.author.email}</p>
+                  </div>
+                </div>
+                <div className="mt-4 pt-4 border-t border-gray-50 flex justify-between text-xs font-medium text-gray-500">
+                  <span>{post.author.age}세 · {post.author.gender}</span>
+                  <span className="text-indigo-500">신뢰도 99%</span>
+                </div>
+              </div>
+
+              {/* 신청 액션 영역 */}
+              <div className="bg-white p-5 rounded-2xl border-2 border-black shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]">
+                {isAuthor ? (
+                  <p className="text-center py-2 text-sm font-bold text-gray-400">내 게시글입니다</p>
+                ) : !showApplyForm ? (
+                  <button
+                    disabled={hasApplied || post.currentParticipant >= post.maxParticipant}
+                    onClick={() => setShowApplyForm(true)}
+                    className={`w-full py-4 rounded-xl font-black transition-all ${
+                      hasApplied || post.currentParticipant >= post.maxParticipant
+                        ? "bg-gray-100 text-gray-400 cursor-not-allowed"
+                        : "bg-indigo-600 text-white hover:bg-indigo-700 active:scale-95"
+                    }`}
+                  >
+                    {hasApplied ? "APPLIED" : post.currentParticipant >= post.maxParticipant ? "CLOSED" : "APPLY NOW"}
+                  </button>
+                ) : (
+                  <div className="space-y-3">
+                    <textarea
+                      className="w-full p-4 bg-gray-50 border-none rounded-xl text-sm focus:ring-2 ring-indigo-500 outline-none resize-none"
+                      rows={4}
+                      value={applyMessage}
+                      onChange={(e) => setApplyMessage(e.target.value)}
+                      placeholder="함께하고 싶은 이유를 적어주세요!"
+                    />
+                    <div className="flex gap-2">
+                      <button onClick={() => setShowApplyForm(false)} className="flex-1 py-3 text-xs font-bold text-gray-400">취소</button>
+                      <button 
+                        onClick={handleApplySubmit} 
+                        disabled={!applyMessage.trim()}
+                        className="flex-[2] py-3 bg-black text-white rounded-lg text-xs font-bold disabled:opacity-30"
+                      >
+                        신청서 보내기
+                      </button>
+                    </div>
+                  </div>
+                )}
+              </div>
+            </div>
+
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/mate/components/MateReceiveModal.tsx
+++ b/src/features/mate/components/MateReceiveModal.tsx
@@ -1,7 +1,8 @@
-import { Send, Check, XCircle, ArrowLeft } from "lucide-react";
+import { Send, Check, XCircle, ArrowLeft, MessageSquare } from "lucide-react";
 import { useState } from "react";
 import "../styles/MateModals.css";
 import type { ApplicationResponse, SelectedApplicant } from "../hooks/mate.types";
+import { getApplicantAvatar } from "../hooks/mate.util.ts";
 
 interface ReceivedModalProps {
   applications: ApplicationResponse[];
@@ -9,6 +10,19 @@ interface ReceivedModalProps {
   onApprove: (id: string, postId: number, applicantId: number, e?: React.MouseEvent<HTMLButtonElement>) => void;
   onReject: (id: string, e?: React.MouseEvent<HTMLButtonElement>) => void;
   onClose: () => void;
+}
+
+function AvatarDisplay({ profileImage, avatarEmoji, className }: {
+  profileImage: string | null;
+  avatarEmoji: string | null;
+  className?: string;
+}) {
+  const avatar = getApplicantAvatar(profileImage, avatarEmoji);
+  
+  if (avatar.type === "image") {
+    return <img src={avatar.src} className={`object-cover rounded-2xl ${className}`} />;
+  }
+  return <span>{avatar.value}</span>;
 }
 
 export function MateReceivedModal({ 
@@ -19,8 +33,6 @@ export function MateReceivedModal({
   onClose,
 }: ReceivedModalProps){
   const [selectedApplicant, setSelectedApplicant] = useState<SelectedApplicant | null>(null);
-
-  const safeApplications = applications || [];
 
   const groupedByPost = applications.reduce((acc, app) => {
     if (!acc[app.matePostId]) {
@@ -37,118 +49,103 @@ export function MateReceivedModal({
 
   // 신청자 상세 보기
   if (selectedApplicant) {
-    const rawStatus = getApplicantStatus(selectedApplicant.id);
-    const status = String(rawStatus);
+    const status = (
+      applications.find(a => String(a.id) === String(selectedApplicant.id))?.status?.toLowerCase()
+      ?? "pending"
+    ) as "approved" | "rejected" | "pending";
     
     return (
       <div className="modal-overlay active" onMouseDown={(e) => { if (e.target === e.currentTarget) onClose(); }}>
         <div className="modal-window detail-window" onMouseDown={(e) => e.stopPropagation()}>
-          <div className="modal-header">
+          <div className="modal-header" style={{ marginBottom: "0px" }}>
             <span className="mh-title">&gt;&gt; APPLICANT DETAIL</span>
             <button className="mh-close" onClick={onClose}>CLOSE [X]</button>
           </div>
 
-          <div className="modal-body" style={{ background: "white", padding: "32px", paddingTop: "0px" }}>
-            {/* 뒤로가기 버튼 */}
+          <div className="modal-body" style={{ background: "#f9f9f9", padding: "24px" }}>
             <button 
               onClick={() => setSelectedApplicant(null)}
-              className="flex items-center gap-2 mb-4 border-2 border-black bg-white hover:bg-[#eee] font-bold text-sm transition-colors"
+              className="flex items-center gap-2 mb-5 px-3 py-1.5 text-sm font-semibold text-gray-600 bg-white border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors shadow-sm"
             >
               <ArrowLeft className="w-4 h-4" />
               BACK TO LIST
             </button>
 
-            {/* Trip Info */}
-            <div className="p-4 mb-6 infoBoxLarge bgBlack">
-              <div className="text-xs text-white/50 uppercase font-bold mb-1">Applying for</div>
-              <div className="text-2xl font-bold">{selectedApplicant.postDestination}</div>
-            </div>
-
-            {/* Applicant Info */}
-            <div className="flex items-center gap-4 mb-6">
-              <div className="w-20 h-20 text-5xl flex items-center justify-center infoBox bgBlack">
-                {selectedApplicant.applicant.avatar}
+            <div className="bg-white border border-gray-200 rounded-xl p-6 shadow-sm overflow-hidden">
+              {/* Trip Info Section */}
+              <div className="mb-6 pb-6 border-b border-gray-100 text-center">
+                <span className="text-[11px] text-indigo-500 font-bold tracking-widest uppercase mb-1 block">Applying for</span>
+                <h2 className="text-2xl font-black text-gray-900">{selectedApplicant.postDestination}</h2>
               </div>
-              <div className="flex-1">
-                <div className="text-xl font-bold text-black mb-1">{selectedApplicant.applicant.name}</div>
-                <div className="text-sm text-black/60 font-mono mb-2">{selectedApplicant.applicant.email}</div>
+
+              {/* Applicant Profile */}
+              <div className="flex flex-col items-center mb-8">
+                <div className="w-24 h-24 text-5xl flex items-center justify-center bg-gray-50 border border-gray-200 rounded-2xl mb-4 shadow-inner">
+                  <AvatarDisplay profileImage={selectedApplicant.applicant.profileImage} avatarEmoji={selectedApplicant.applicant.avatarEmoji} />
+                </div>
+                <h3 className="text-xl font-bold text-gray-900">{selectedApplicant.applicant.name}</h3>
+                <p className="text-sm text-gray-400 font-mono mb-3">{selectedApplicant.applicant.email}</p>
                 <div className="flex gap-2">
-                  <span className="bg-white px-3 py-1 text-xs font-bold infoBox">{selectedApplicant.applicant.age}세</span>
-                  <span className="bg-white px-3 py-1 text-xs font-bold infoBox">{selectedApplicant.applicant.gender}</span>
+                  <span className="bg-gray-100 px-3 py-1 text-xs font-bold text-gray-600 rounded-full">{selectedApplicant.applicant.age}세</span>
+                  <span className="bg-gray-100 px-3 py-1 text-xs font-bold text-gray-600 rounded-full">{selectedApplicant.applicant.gender}</span>
                 </div>
               </div>
-            </div>
 
-            {/* Details */}
-            <div className="space-y-4 mb-6">
-              <div className="bg-[#f5f5f5] p-4 infoBox">
-                <div className="text-xs text-black/50 uppercase font-bold mb-2">Travel Style</div>
-                <div className="flex flex-wrap gap-2">
-                  {selectedApplicant.applicant.travelStyle?.map((s) => (
-                    <span key={s} className="px-2 py-1 text-xs font-bold badge">{s}</span>
-                  ))}
-                </div>
-              </div>
-              
-              {selectedApplicant.applicant.preferredActivities && selectedApplicant.applicant.preferredActivities.length > 0 && (
-                <div className="bg-[#f5f5f5] p-4 infoBox">
-                  <div className="text-xs text-black/50 uppercase font-bold mb-2">Preferred Activities</div>
+              {/* Details grid */}
+              <div className="grid grid-cols-1 gap-4 mb-8">
+                <div className="bg-gray-50 p-4 rounded-xl border border-gray-100">
+                  <div className="text-[11px] text-gray-400 uppercase font-bold mb-2">Travel Style</div>
                   <div className="flex flex-wrap gap-2">
-                    {selectedApplicant.applicant.preferredActivities.map((a) => (
-                      <span key={a} className="px-2 py-1 text-xs font-bold badge">{a}</span>
+                    {selectedApplicant.applicant.travelStyles?.map((s) => (
+                      <span key={s} className="px-2.5 py-1 text-[11px] font-bold bg-white border border-gray-200 rounded-md text-gray-700">{s}</span>
                     ))}
                   </div>
                 </div>
-              )}
-              
-              {selectedApplicant.applicant.budget && (
-                <div className="bg-[#f5f5f5] p-4 infoBox">
-                  <div className="text-xs text-black/50 uppercase font-bold mb-2">Budget</div>
-                  <div className="font-bold font-mono text-lg">{selectedApplicant.applicant.budget}</div>
+                
+                <div className="bg-gray-50 p-4 rounded-xl border border-gray-100">
+                  <div className="text-[11px] text-gray-400 uppercase font-bold mb-2">Message</div>
+                  <div className="text-sm text-gray-700 leading-relaxed italic">"{selectedApplicant.applicant.message}"</div>
                 </div>
-              )}
-            </div>
-
-            {/* Message */}
-            <div className="mb-6">
-              <div className="text-xs text-black/50 uppercase font-bold mb-2">Message</div>
-              <div className="bg-[#eee] p-4 text-sm leading-relaxed infoBoxLarge">{selectedApplicant.applicant.message}</div>
-            </div>
-
-            {/* Actions */}
-            <div className="flex gap-4">
-              {status === "pending" ? (
-                <>
-                  <button onClick={() => onReject(selectedApplicant.id)}
-                    className="flex-1 py-3 font-bold uppercase transition-colors button bg-white text-black hover:bg-[#eee]">
-                    REJECT
-                  </button>
-                  <button onClick={() => onApprove(selectedApplicant.id, selectedApplicant.postId, selectedApplicant.applicantId)}
-                    className="flex-1 py-3 font-bold uppercase transition-colors flex items-center justify-center gap-2 button bgBlack text-white">
-                    <Check className="w-4 h-4" /> APPROVE
-                  </button>
-                </>
-              ):(
-                <div className={`flex-1 py-4 text-center font-black border-4 border-black shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] ${status === "approved" ? "bgGreen" : "bgRed"}`}>
-                  {status.toUpperCase()}
-                </div>
-              )}
-            </div>
-
-            {/* {status === "approved" && (
-              <div className="mt-4 p-4 bg-green-50 border-2 border-dashed border-green-500 rounded-lg animate-fade-in">
-                <p className="text-sm text-green-700 font-bold text-center mb-3">
-                  매칭이 완료되었습니다! 이제 채팅으로 세부 일정을 조율해보세요.
-                </p>
-                <button 
-                  onClick={() => window.location.href = '/chat'} // 채팅 페이지 경로에 맞게 수정
-                  className="w-full py-3 bg-[#8B5CF6] text-white font-bold flex items-center justify-center gap-2 hover:bg-[#7C3AED] transition-all shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] active:shadow-none active:translate-x-1 active:translate-y-1"
-                >
-                  <Send className="w-4 h-4" />
-                  채팅하기
-                </button>
               </div>
-            )} */}
+
+              {/* Actions */}
+              <div className="flex gap-3">
+                {status === "pending" ? (
+                  <>
+                    <button
+                      onClick={() => onReject(selectedApplicant.id)}
+                      className="flex-1 py-3.5 font-bold text-gray-500 bg-white border border-gray-200 rounded-xl hover:bg-red-50 hover:text-red-500 hover:border-red-200 transition-all"
+                    >
+                      REJECT
+                    </button>
+                    <button
+                      onClick={() => onApprove(selectedApplicant.id, selectedApplicant.postId, selectedApplicant.applicantId)}
+                      className="flex-[2] py-3.5 font-bold flex items-center justify-center gap-2 rounded-xl hover:scale-[1.02] active:scale-[0.98] transition-all"
+                      style={{ background: "linear-gradient(135deg, #6366f1, #4f46e5)", color: "white", boxShadow: "0 4px 14px rgba(99,102,241,0.4)" }}
+                    >
+                      <Check className="w-5 h-5" /> APPROVE
+                    </button>
+                  </>
+                ) : status === "approved" ? (
+                  <>
+                    <button
+                      disabled
+                      className="flex-[2] py-3.5 font-bold flex items-center justify-center gap-2 rounded-xl cursor-not-allowed opacity-80"
+                      style={{ background: "linear-gradient(135deg, #6366f1, #4f46e5)", color: "white" }}
+                    >
+                      <Check className="w-5 h-5" /> APPROVED
+                    </button>
+                  </>
+                ) : (
+                  <button
+                    disabled
+                    className="w-full py-3.5 font-bold text-red-400 bg-red-50 border-2 border-red-200 rounded-xl cursor-not-allowed"
+                  >
+                    REJECTED
+                  </button>
+                )}
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -159,50 +156,49 @@ export function MateReceivedModal({
   return (
     <div className="modal-overlay active" onMouseDown={(e) => { if (e.target === e.currentTarget) onClose(); }}>
       <div className="modal-window received-window" onMouseDown={(e) => e.stopPropagation()}>
-        <div className="modal-header">
+        <div className="modal-header" style={{ marginBottom: "0px"}}>
           <span className="mh-title">&gt;&gt; RECEIVED APPLICATIONS</span>
           <button className="mh-close" onClick={onClose}>CLOSE [X]</button>
         </div>
 
-        <div className="modal-body" style={{ 
-          background: "white", 
-          padding: "32px", 
-         }}>
+        <div className="modal-body" style={{ background: "#f9f9f9", padding: "24px" }}>
           {Object.keys(groupedByPost).length === 0 ? (
-            <div className="text-center py-12">
-              <Send className="w-16 h-16 mx-auto mb-4 text-black/30" />
-              <p className="font-bold text-black/60">NO APPLICATIONS</p>
-              <p className="text-sm text-black/40 mt-2">// 아직 받은 신청이 없습니다</p>
+            <div className="flex flex-col items-center justify-center py-20 bg-white border-2 border-dashed border-gray-200 rounded-xl">
+              <Send className="w-12 h-12 mb-3 text-gray-300" />
+              <p className="text-gray-500 font-medium">받은 신청이 없습니다.</p>
             </div>
           ) : (
-            <div className="space-y-10">
+            <div className="flex flex-col gap-8">
               {Object.entries(groupedByPost).map(([postId, data]) => {
-                const hasApprovedApplicants = data.applicants.some(app => getApplicantStatus(app.id)?.toLowerCase() === "approved");
-                
+                const hasApproved = data.applicants.some((app: any) => getApplicantStatus(app.id) === "approved");
+
                 return (
-                  <div key={postId} className="card">
-                    <div className="bg-[#eee] p-5">
-                      <div className="flex items-center justify-between flex-wrap gap-3">
-                        <div className="flex-1">
-                          <div className="text-lg font-bold text-black">{data.destination}</div>
-                          <div className="text-sm text-black/60 font-mono mt-1">{data.startDate} ~ {data.endDate}</div>
-                        </div>
-                        <div className="flex items-center gap-2">
-                          <span className="px-3 py-1 text-sm font-bold badge">{data.applicants.length} applicants</span>
-                          
-                          {hasApprovedApplicants && (
-                            <span className="px-3 py-1 text-xs font-bold bg-purple-200 border-2 border-black">
-                              💬 채팅 가능
-                            </span>
-                          )}
-                        </div>
+                  <div key={postId} className="group flex flex-col">
+                    {/* Post Title Section */}
+                    <div className="flex items-center justify-between mb-3 px-1">
+                      <div>
+                        <h3 className="text-lg font-black text-gray-900">{data.destination}</h3>
+                        <p className="text-xs text-gray-400 font-mono">{data.startDate} — {data.endDate}</p>
+                      </div>
+                      <div className="flex gap-2">
+                        <span className="px-3 py-1 text-xs font-bold bg-white border border-gray-200 rounded-full text-gray-500">
+                          {data.applicants.length} Applicants
+                        </span>
+                        {hasApproved && (
+                          <span className="px-3 py-1 text-xs font-bold bg-indigo-50 border border-indigo-100 rounded-full text-indigo-600 flex items-center gap-1">
+                            <MessageSquare className="w-3 h-3" /> 채팅 가능
+                          </span>
+                        )}
                       </div>
                     </div>
-                    <div className="p-5 space-y-4">
-                      {data.applicants.map((app) => {
-                        const status = getApplicantStatus(app.id)?.toLowerCase();
+
+                    {/* Applicants List inside the post */}
+                    <div className="flex flex-col gap-3">
+                      {data.applicants.map((app: any) => {
+                        const status = getApplicantStatus(app.id);
                         return (
-                          <div key={app.id}
+                          <div 
+                            key={app.id}
                             onClick={() => setSelectedApplicant({ 
                               id: String(app.id),
                               postId: app.matePostId,
@@ -211,48 +207,61 @@ export function MateReceivedModal({
                               applicant: {
                                 name: app.applicantName,
                                 email: app.applicantEmail,
-                                avatar: app.avatar ?? "👤",
+                                profileImage: app.profileImage,
+                                avatarEmoji: app.avatar,
                                 age: app.age,
                                 gender: app.gender,
                                 message: app.content,
-                                travelStyles: [],
+                                travelStyles: app.travelStyles ?? [],
                                 appliedDate: "",
                               }
                             })}
-                            className={`border-2 border-black p-5 cursor-pointer transition-colors ${status === "pending" ? "bg-[#eee] hover:bg-[#ddd]" : status === "approved" ? "bg-green-100" : "bg-red-100"}`}>
-                            <div className="flex items-center justify-between flex-wrap gap-4">
-                              <div className="flex items-center gap-4">
-                                <div className="w-12 h-12 text-2xl flex items-center justify-center infoBox bgBlack">
-                                  {app.avatar}
-                                </div>
-                                <div>
-                                  <div className="font-bold text-black flex items-center gap-2 flex-wrap">
-                                    {app.name}
-                                    {status !== "pending" && (
-                                      <span className={`text-xs px-2 py-0.5 text-white ${status === "approved" ? "bgGreen" : "bgRed"}`}>
-                                        {status === "approved" ? "APPROVED" : "REJECTED"}
-                                      </span>
-                                    )}
-                                  </div>
-                                  <div className="text-xs text-black/60 font-mono mt-1">{app.email}</div>
-                                  <div className="flex gap-2 mt-2">
-                                    <span className="text-xs bg-white px-2 py-0.5 font-bold infoBox">{app.age}세</span>
-                                    <span className="text-xs bg-white px-2 py-0.5 font-bold infoBox">{app.gender}</span>
-                                  </div>
-                                </div>
+                            className="bg-white border border-gray-100 rounded-xl p-4 flex items-center justify-between hover:border-indigo-300 hover:shadow-md transition-all cursor-pointer group/item"
+                          >
+                            <div className="flex items-center gap-4">
+                              <div className="w-12 h-12 text-2xl flex items-center justify-center bg-gray-50 rounded-lg group-hover/item:bg-indigo-50 transition-colors">
+                                <AvatarDisplay profileImage={app.profileImage} avatarEmoji={app.avatar} />
                               </div>
-                              <div className="flex gap-2">
-                                <button onClick={(e) => { e.stopPropagation(); onApprove(String(app.id), app.matePostId, app.applicantId, e); }}
-                                  className={`px-4 py-2 border-2 border-black text-sm font-bold transition-colors ${status === "approved" ? "bgGreen" : "bgBlack"}`}>
-                                  <Check className="w-4 h-4" />
-                                </button>
-                                <button onClick={(e) => { e.stopPropagation(); onReject(app.id, e); }}
-                                  className={`px-4 py-2 border-2 border-black text-sm font-bold transition-colors ${status === "rejected" ? "bgRed" : "bg-white text-black hover:bg-[#ddd]"}`}>
-                                  <XCircle className="w-4 h-4" />
-                                </button>
+                              <div>
+                                <div className="flex items-center gap-2">
+                                  <span className="font-bold text-gray-900">{app.applicantName}</span>
+                                  {status !== "pending" && (
+                                    <div className="flex gap-1.5 items-center">
+                                      <span className={`text-[10px] px-1.5 py-0.5 rounded-md font-bold uppercase ${
+                                        status === "approved" ? "bg-green-100 text-green-600" : "bg-red-100 text-red-500"
+                                      }`}>
+                                        {status}
+                                      </span>
+                                      {status === "approved" && (
+                                        <span className="text-[10px] px-1.5 py-0.5 rounded-md font-bold bg-indigo-100 text-indigo-600 flex items-center gap-1">
+                                          <span className="w-1 h-1 bg-indigo-500 rounded-full animate-pulse" />
+                                          채팅가능
+                                        </span>
+                                      )}
+                                    </div>
+                                  )}
+                                </div>
+                                <p className="text-[11px] text-gray-400 font-mono leading-none mt-1">{app.applicantEmail}</p>
                               </div>
                             </div>
-                            <p className="mt-4 text-sm text-black/70 line-clamp-2">{app.message}</p>
+                            
+                            {/* 대기 중(pending)일 때만 액션 버튼 노출 */}
+                            {status === "pending" && (
+                              <div className="flex gap-2" onClick={(e) => e.stopPropagation()}>
+                                <button 
+                                  onClick={(e) => onReject(app.id, e)}
+                                  className="p-2 rounded-lg border border-gray-200 text-gray-400 bg-white hover:bg-red-50 hover:text-red-500 hover:border-red-200 transition-all"
+                                >
+                                  <XCircle className="w-5 h-5" />
+                                </button>
+                                <button 
+                                  onClick={(e) => onApprove(String(app.id), app.matePostId, app.applicantId, e)}
+                                  className="p-2 rounded-lg border border-gray-200 text-gray-400 bg-white hover:bg-green-50 hover:text-green-500 hover:border-green-200 transition-all"
+                                >
+                                  <Check className="w-5 h-5" />
+                                </button>
+                              </div>
+                            )}
                           </div>
                         );
                       })}

--- a/src/features/mate/components/MateSentModal.tsx
+++ b/src/features/mate/components/MateSentModal.tsx
@@ -16,49 +16,83 @@ export function MateSentModal({
   return (
     <div className="modal-overlay active" onMouseDown={(e) => { if (e.target === e.currentTarget) onClose(); }}>
       <div className="modal-window sent-window" onMouseDown={(e) => e.stopPropagation()}>
-        <div className="modal-header">
+        <div className="modal-header" style={{ marginBottom: "0px"}}>
           <span className="mh-title">&gt;&gt; MY SENT APPLICATIONS</span>
           <button className="mh-close" onClick={onClose}>CLOSE [X]</button>
         </div>
 
-        <div className="modal-body" style={{ background: "white", padding: "32px", paddingTop:"5px" }}>
+        <div className="modal-body" style={{ background: "#f9f9f9", padding: "24px" }}>
           {applications.length === 0 ? (
-            <div className="text-center py-12">
-              <Send className="w-16 h-16 mx-auto mb-4 text-black/30" />
-              <p className="font-bold text-black/60">NO APPLICATIONS YET</p>
-              <p className="text-sm text-black/40 mt-2">// 아직 신청한 여행이 없습니다</p>
+            <div className="flex flex-col items-center justify-center py-20 bg-white border-2 border-dashed border-gray-200 rounded-xl">
+              <Send className="w-12 h-12 mb-3 text-gray-300" />
+              <p className="text-gray-500 font-medium">신청 내역이 없습니다.</p>
             </div>
           ) : (
-            <div className="space-y-4">
+            <div className="flex flex-col gap-4">
               {applications.map((app) => {
                 const status = getApplicantStatus(app.id);
+                
+                // 상태별 스타일 정의
+                const statusStyles = {
+                  approved: { label: "승인됨", color: "text-green-600", dot: "bg-green-500" },
+                  rejected: { label: "거절됨", color: "text-red-500", dot: "bg-red-500" },
+                  pending: { label: "대기중", color: "text-gray-500", dot: "bg-gray-400" }
+                }[status];
+
                 return (
-                  <div key={app.id} className={`card ${status === "approved" ? "cardApproved" : status === "rejected" ? "cardRejected" : ""}`}>
-                    <div className="bg-white p-4">
-                      <div className="flex items-center justify-between flex-wrap gap-2">
+                  <div key={app.id} className="group bg-white border border-gray-200 rounded-xl overflow-hidden transition-all hover:border-black shadow-sm">
+                    {/* 상단 정보 영역 */}
+                    <div className="p-5">
+                      <div className="flex justify-between items-start mb-3">
                         <div>
-                          <div className="text-lg font-bold text-black">{app.postDestination}</div>
-                          <div className="text-sm text-black/60 font-mono">{app.startDate} ~ {app.endDate}</div>
-                          <div className="text-xs text-black/40 mt-1">by {app.postAuthor.name}</div>
+                          <h4 className="text-lg font-bold text-gray-900 leading-tight mb-1">
+                            {app.postDestination}
+                          </h4>
+                          <p className="text-sm text-gray-500">
+                            {app.startDate} — {app.endDate}
+                          </p>
                         </div>
-                        <span className={`px-3 py-1 text-sm font-bold ${status === "approved" ? "bgGreen" : status === "rejected" ? "bgRed" : "bgBlack"}`}>
-                          {status === "approved" ? "APPROVED" : status === "rejected" ? "REJECTED" : "PENDING"}
-                        </span>
+                        <div className={`flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-gray-50 border border-gray-100 ${statusStyles.color}`}>
+                          <span className={`w-2 h-2 rounded-full ${statusStyles.dot}`} />
+                          <span className="text-xs font-bold uppercase tracking-wider">{statusStyles.label}</span>
+                        </div>
                       </div>
-                    </div>
-                    <div className="p-4">
-                      <div className="p-3 text-sm mb-3 infoBox">{app.applicant.message || "메시지 없음"}</div>
-                      <div className="flex items-center justify-between text-xs text-black/60 flex-wrap gap-2">
-                        <span>신청일: {app.applicant.appliedDate}</span>
-                        <span>예산: {app.applicant.budget}</span>
+
+                      {/* 신청 메시지 */}
+                      <div className="bg-gray-50 rounded-lg p-3 text-sm text-gray-600 italic border border-gray-100 mb-1">
+                        "{app.content || "보낸 메시지가 없습니다."}"
                       </div>
                       
+                      <div className="mt-2 text-[11px] text-gray-400 font-mono">
+                        HOST: {app.postAuthorName}
+                      </div>
+
+                      {/* 승인 시 채팅 안내 */}
                       {status === "approved" && (
-                        <div className="mt-3 px-4 py-2 bg-purple-50 border-2 border-purple-300 rounded-lg text-center">
-                          <span className="text-purple-700 text-sm font-bold">
-                            💬 채팅에 참여할 수 있습니다.
-                          </span>
-                        </div>
+                        <button 
+                          style={{ 
+                            width: "100%", 
+                            marginTop: "16px", 
+                            padding: "12px", 
+                            // 포인트 컬러: 약간 보라색이 섞인 세련된 블루 또는 브랜드 컬러 추천
+                            background: "linear-gradient(135deg, #6366f1 0%, #4f46e5 100%)", 
+                            color: "#fff", 
+                            border: "none", 
+                            borderRadius: "8px", 
+                            fontWeight: "bold", 
+                            fontSize: "13px",
+                            cursor: "pointer",
+                            boxShadow: "0 4px 12px rgba(79, 70, 229, 0.2)", // 은은한 그림자 효과
+                            display: "flex",
+                            alignItems: "center",
+                            justifyContent: "center",
+                            gap: "8px"
+                          }}
+                          // onClick={() => {/* 채팅 연결 로직 */}}
+                        >
+                          <span style={{ fontSize: "16px" }}>💬</span>
+                          채팅에 참여할 수 있어요
+                        </button>
                       )}
                     </div>
                   </div>

--- a/src/features/mate/hooks/mate.types.ts
+++ b/src/features/mate/hooks/mate.types.ts
@@ -51,7 +51,8 @@ export interface Applicant {
   age: number;
   gender: string;
   email: string;
-  avatar: string;
+  profileImage: string | null;
+  avatarEmoji: string | null;
   travelStyles: string[];
   message: string;
   appliedDate: string;
@@ -59,15 +60,24 @@ export interface Applicant {
   budget?: string;
 }
 
-// export interface MyApplication {
-//   id: string;
-//   postId: number;
-//   postDestination: string;
-//   startDate: string;
-//   endDate: string;
-//   postAuthor: Author;
-//   applicant: Applicant;
-// }
+export interface MyApplication {
+  id: string;
+  matePostId: number;
+  applicantId: number;
+  applicantName: string;
+  applicantEmail: string;
+  postAuthorName: string;
+  postAuthorEmail: string;
+  postAuthorAvatar: string | null;
+  postDestination: string;
+  startDate: string;
+  endDate: string;
+  content: string;
+  status: "approved" | "rejected" | "pending";
+  gender: string;
+  age: number;
+  avatar: string | null;
+}
 
 // export interface ReceivedApplication {
 //   id: string;
@@ -112,7 +122,9 @@ export interface ApplicationResponse {
   content: string;
   matePostId: number;
   postDestination: string;
+  profileImage: string | null;
   avatar: string | null;
+  travelStyles: string[];
   age: number;
   gender: string;
 }
@@ -128,7 +140,7 @@ export interface User {
   age: number | null;
 }
 
-export type ApplyStatus = 'PENDING' | 'APPROVED' | 'REJECTED';
+export type ApplyStatus = 'pending' | 'approved' | 'rejected';
 
 export interface LikeResponse {
   liked: boolean;

--- a/src/features/mate/hooks/mate.util.ts
+++ b/src/features/mate/hooks/mate.util.ts
@@ -1,0 +1,10 @@
+// mate.util.ts
+
+export function getApplicantAvatar(
+  profileImage: string | null,
+  avatarEmoji: string | null
+): { type: "image"; src: string } | { type: "emoji"; value: string } {
+  if (profileImage) return { type: "image", src: profileImage };
+  if (avatarEmoji) return { type: "emoji", value: avatarEmoji };
+  return { type: "emoji", value: "👤" };
+}

--- a/src/features/mate/pages/Mate.tsx
+++ b/src/features/mate/pages/Mate.tsx
@@ -17,6 +17,7 @@ import {
   MatePagination,
   MateWriteModal,
   MateReceivedModal,
+  MateSentModal,
 } from "../components";
 
 import "../styles/Mate.css";
@@ -27,8 +28,8 @@ export default function Mate() {
 
   const [writeError, setWriteError] = useState<string | null>(null);
   const [showWriteModal, setShowWriteModal] = useState(false);
-  const [showApplicantsModal, setShowApplicantsModal] = useState(false);
   const [showReceivedModal, setShowReceivedModal] = useState(false);
+  const [showSentModal, setShowSentModal] = useState(false);
   const [showSortDropdown, setShowSortDropdown] = useState(false);
 
   const [startDate, setStartDate] = useState<Date | null>(null);
@@ -82,6 +83,12 @@ export default function Mate() {
       fetchReceivedApplications();
     }
   }, [showReceivedModal]);
+
+  useEffect(() => {
+    if (showSentModal) {
+      fetchSentApplications();
+    }
+  }, [showSentModal]);
 
   const handleCardClick = (post: any) => {
     navigate(`/mate/${post.id}`);
@@ -179,7 +186,7 @@ export default function Mate() {
         <div style={{ marginBottom: "35px" }}>
           <MateHeader
             onWriteClick={() => setShowWriteModal(true)}
-            onMySentClick={() => setShowApplicantsModal(true)}
+            onMySentClick={() => setShowSentModal(true)}
             onReceivedClick={() => setShowReceivedModal(true)}
             onChatListClick={() => {}}
             mySentCount={0}
@@ -335,6 +342,16 @@ export default function Mate() {
           setSelectedAgeGroup={setSelectedAgeGroup}
           selectedGender={selectedGender}
           setSelectedGender={setSelectedGender}
+        />
+      )}
+      {showSentModal && (
+        <MateSentModal
+         applications={applications}
+         getApplicantStatus={(id) => {
+          const app = applications.find(a => a.id === id);
+          return app?.status || "pending";
+         }}
+         onClose={() => setShowSentModal(false)}
         />
       )}
 


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #77

---
## 🎨 작업 내용 (What)
- `MateReceivedModal` UI를 `MateSentModal`과 일관된 화이트 & 그레이 톤으로 전면 개편
- `AvatarDisplay` 컴포넌트 추가 — `profileImage` → `avatarEmoji` → `👤` 순 fallback 렌더링
- `getApplicantAvatar` 유틸 함수 추가 (`mate.util.ts`)
- 신청 상태(`pending` / `approved` / `rejected`)에 따른 액션 버튼 분기 처리
- 상세 뷰 status를 `applications` prop에서 직접 읽도록 변경 (stale closure 방지)
- `Applicant` 인터페이스 필드 정리: `avatar` → `profileImage` + `avatarEmoji` 분리, `travelStyle` → `travelStyles` 오타 수정
- `ApplicationResponse` 인터페이스에 `profileImage`, `travelStyles` 필드 추가
- `setSelectedApplicant` 매핑 시 `app.travelStyles` 실데이터 연동

---
## 🧭 작업 목적 (Why)
- 서버 응답의 `avatar`가 `null`로 내려오는 경우 화면이 깨지는 문제 수정
- `travelStyle` 오타 및 status 대소문자 불일치로 인해 데이터가 렌더링되지 않는 문제 수정
- `getApplicantStatus`가 stale한 클로저 값을 참조해 상세 뷰에서 상태가 잘못 표시되는 문제 수정
- `MateSentModal`과 UI 일관성 확보

---
## 🧩 변경 범위
- [x] UI / Layout
- [x] 컴포넌트 구조
- [x] 상태 관리 로직
- [x] API 연동
- [x] 스타일

---
## 🧪 테스트 방법
- [x] 로컬 실행 확인
- [x] 주요 화면 렌더링 확인
  - 소셜 로그인 유저 프로필 이미지 정상 출력 확인
  - 이미지 없을 시 avatarEmoji, 둘 다 없을 시 `👤` 출력 확인
  - `pending` 상태: 승인/거절 버튼 노출 확인
  - `approved` 상태: APPROVED 버튼(비활성) + 채팅 버튼 노출 확인
  - `rejected` 상태: REJECTED 버튼(비활성)만 노출 확인
  - `travelStyles` 데이터 정상 렌더링 확인
- [x] 에러 콘솔 확인

---
## ⚠️ 참고 사항
- 백엔드 PR (#53) 과 함께 병합 필요 — `profileImage`, `travelStyles` 응답 필드 추가에 의존
- Tailwind v4 환경에서 `bg-gradient` 미적용 이슈로 일부 버튼에 인라인 스타일 혼용

---
## ✅ 체크리스트
- [x] main 브랜치 직접 push 하지 않음
- [x] refactor 브랜치에서 작업함
- [ ] 불필요한 console.log 제거
- [x] PR 단위가 과도하게 크지 않음