### PR TITLE
[FE] refactor: MateDetail 페이지 UI/UX 개선 및 데이터 연동 고도화

### DIFF
--- a/src/features/mate/components/MatePostCard.tsx
+++ b/src/features/mate/components/MatePostCard.tsx
@@ -2,7 +2,6 @@ import type { MouseEvent } from "react";
 import { Heart, X, Eye, RotateCcw, Trash2 } from "lucide-react";
 import type { Post } from "../hooks/mate.types";
 import { 
-  getAirportDisplay, 
   getCurrentUserId,
   TRANSPORT_REVERSE_MAP,
   GENDER_PREFERENCE_REVERSE_MAP,
@@ -63,7 +62,7 @@ export function MatePostCard({
       >
         <div className="flex items-center justify-between mb-4">
           <div className="flex items-center gap-4">
-            <div className="text-2xl text-black/60 mx-2">✈</div>
+            {/* <div className="text-2xl text-black/60 mx-2">✈</div> */}
 
             <div className="text-left">
               <div className="text-xs text-black/50 uppercase font-bold mb-1">To</div>

--- a/src/features/mate/hooks/mate.constants.ts
+++ b/src/features/mate/hooks/mate.constants.ts
@@ -11,7 +11,7 @@ export const GENDER_OPTIONS = ["남성", "여성", "무관"];
 export const AGE_OPTIONS = ["전체", "20대", "30대", "40대", "50대+"];
 export const TRANSPORT_OPTIONS = ["비행기", "버스", "기차", "자차", "도보", "렌트카", "택시"];
 export const TRAVEL_TYPE_OPTIONS = ["맛집탐방", "액티비티", "힐링", "문화탐방", "쇼핑", "자연", "사진", "야경"];
-export const AGE_GROUP_OPTIONS = ["20대", "30대", "40대", "50대+"];
+export const AGE_GROUP_OPTIONS = ["전체", "20대", "30대", "40대", "50대+"];
 
 // 백엔드 enum 매핑 (한글 -> 영문 enum)
 export const TRANSPORT_MAP: { [key: string]: string } = {
@@ -38,40 +38,55 @@ export const AGE_GROUP_MAP: { [key: string]: string } = {
   "50대+": "50s+"
 };
 
-// 역매핑 (영문 enum -> 한글)
+// 역매핑 (서버의 소문자 enum -> 한글)
 export const TRANSPORT_REVERSE_MAP: { [key: string]: string } = {
-  "AIRPLANE": "비행기",
-  "BUS": "버스",
-  "TRAIN": "기차",
-  "CAR": "자차",
-  "WALK": "도보"
+  "airplane": "비행기",
+  "bus": "버스",
+  "train": "기차",
+  "mycar": "자차",
+  "walk": "도보",
+  "rentalcar": "렌트카",
+  "taxi": "택시"
 };
 
 export const GENDER_PREFERENCE_REVERSE_MAP: { [key: string]: string } = {
-  "MALE": "남성",
-  "FEMALE": "여성",
-  "ANY": "무관"
+  "male": "남성",
+  "female": "여성",
+  "any": "무관"
 };
 
 export const AGE_GROUP_REVERSE_MAP: { [key: string]: string } = {
-  "TWENTIES": "20대",
-  "THIRTIES": "30대",
-  "FORTIES": "40대",
-  "FIFTIES_PLUS": "50대+"
+  "20s": "20대",
+  "30s": "30대",
+  "40s": "40대",
+  "50s+": "50대+",
+  "all": "전체"
 };
 
-// 공항 코드 매핑 (필요한 경우 사용)
-export const AIRPORT_MAP: { [key: string]: string } = {
-  ICN: "인천",
-  GMP: "김포",
-  PUS: "부산",
-  CJU: "제주",
-  SEL: "서울",
+export const getTransportLabel = (value: string): string => {
+  return TRANSPORT_REVERSE_MAP[value] || value || "정보 없음";
 };
 
-export const getAirportDisplay = (code: string): string => {
-  return AIRPORT_MAP[code] || code;
+export const getGenderPreferenceLabel = (value: string): string => {
+  return GENDER_PREFERENCE_REVERSE_MAP[value] || value || "무관";
 };
+
+export const getAgeGroupLabel = (value: string): string => {
+  return AGE_GROUP_REVERSE_MAP[value] || value || "전체";
+};
+
+// // 공항 코드 매핑 (필요한 경우 사용)
+// export const AIRPORT_MAP: { [key: string]: string } = {
+//   ICN: "인천",
+//   GMP: "김포",
+//   PUS: "부산",
+//   CJU: "제주",
+//   SEL: "서울",
+// };
+
+// export const getAirportDisplay = (code: string): string => {
+//   return AIRPORT_MAP[code] || code;
+// };
 
 // 현재 사용자 정보 가져오기 (API에서 가져오는 것으로 변경 필요)
 export const getCurrentUserId = (): number => {

--- a/src/features/mate/hooks/mate.types.ts
+++ b/src/features/mate/hooks/mate.types.ts
@@ -7,7 +7,7 @@ export interface Author {
   profileImage: string | null;
   avatarEmoji: string | null;
   avatarColor: string | null;
-  gender: string | null;
+  gender: string;
   age: number | null;
   travelStyles: string[] | null;
 }
@@ -22,8 +22,8 @@ export interface Post {
   maxParticipant: number;
   budget: number;
   transport: string;
-  genderPreference: string | null;
-  ageGroup: string | null;
+  genderPreference: string;
+  ageGroup: string;
   likesCount: number;
   viewsCount: number;
   createdAt: string;
@@ -42,8 +42,8 @@ export interface MateCreateRequest {
   maxParticipant: number;
   budget: number;
   transport: string;
-  genderPreference: string | null;
-  ageGroup: string | null;
+  genderPreference: string;
+  ageGroup: string;
 }
 
 export interface Applicant {

--- a/src/features/mate/hooks/useMate.ts
+++ b/src/features/mate/hooks/useMate.ts
@@ -52,8 +52,8 @@ export function useMate() {
     maxParticipant: number;
     budget: number;
     transport: string;
-    genderPreference?: string;
-    ageGroup?: string;
+    genderPreference: string;
+    ageGroup: string;
     content: string;
   }): Promise<Post | null> => {
     setLoading(true);
@@ -75,12 +75,8 @@ export function useMate() {
         maxParticipant: formData.maxParticipant,
         budget: formData.budget,
         transport: TRANSPORT_MAP[formData.transport] || formData.transport,
-        genderPreference: formData.genderPreference 
-          ? GENDER_PREFERENCE_MAP[formData.genderPreference] || null
-          : null,
-        ageGroup: formData.ageGroup 
-          ? AGE_GROUP_MAP[formData.ageGroup] || null
-          : null,
+        genderPreference: GENDER_PREFERENCE_MAP[formData.genderPreference] ?? "any",
+        ageGroup: AGE_GROUP_MAP[formData.ageGroup] ?? "all",
         content: formData.content,
       };
 

--- a/src/features/mate/pages/Mate.tsx
+++ b/src/features/mate/pages/Mate.tsx
@@ -120,9 +120,9 @@ export default function Mate() {
       currentParticipant: parseInt(formData.get("currentParticipant") as string),
       maxParticipant: parseInt(formData.get("maxParticipant") as string),
       budget,
-      transport: TRANSPORT_MAP[selectedTransport], 
-      genderPreference: selectedGender ? GENDER_PREFERENCE_MAP[selectedGender] : "any",
-      ageGroup: selectedAgeGroup ? AGE_GROUP_MAP[selectedAgeGroup] : "all",
+      transport: selectedTransport, 
+      genderPreference: selectedGender || "무관",
+      ageGroup: selectedAgeGroup ?? "전체",
       content: formData.get("content") as string,
     };
 

--- a/src/features/mate/pages/MateDetail.tsx
+++ b/src/features/mate/pages/MateDetail.tsx
@@ -1,10 +1,10 @@
 import { useState, useEffect, useRef } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import {
-  ArrowLeft, Heart, Calendar, Users, Wallet, MapPin
+  ArrowLeft, Heart, Calendar, Users, Wallet, Eye
 } from "lucide-react";
 import type { Post, ApplicationRequest, ApplicationResponse } from "../hooks/mate.types";
-import { getCurrentUserId, calculateDuration } from "../hooks/mate.constants";
+import { getCurrentUserId, calculateDuration, getAgeGroupLabel, getGenderPreferenceLabel, getTransportLabel } from "../hooks/mate.constants";
 import { useMate } from "../hooks/useMate";
 import "../styles/MateDetail.css";
 
@@ -109,16 +109,17 @@ export default function MateDetail() {
         throw new Error(errorData.message || '신청에 실패했습니다.');
       }
 
-      const applicationResponse: ApplicationResponse = await response.json();
-      console.log('신청 완료:', applicationResponse);
+      setPost(prev => prev ? {
+        ...prev,
+        hasApplied: true, // 신청 완료 상태로 변경
+        currentParticipant: prev.currentParticipant + 1 // 필요시 참여 인원 수도 즉시 반영
+      } : null);
 
       setShowApplyForm(false);
       setApplyMessage("");
       alert("신청이 완료되었습니다!");
       
-      navigate(`/mate/${postId}`, { replace: true });
     } catch (error) {
-      console.error('신청 오류:', error);
       alert(error instanceof Error ? error.message : "신청 중 오류가 발생했습니다.");
     }
   };
@@ -147,147 +148,220 @@ export default function MateDetail() {
   const hasApplied = post.hasApplied || false;
 
   return (
-    <div className="mate-detail max-w-6xl mx-auto px-4 py-8">
-      <div className="flex justify-between items-center mb-6">
-        <button onClick={() => navigate(-1)} className="btn-outline">
-          <ArrowLeft size={18} />
-          뒤로가기
-        </button>
-
-        <button
-          onClick={onLikeClick}
-          className={`btn-outline ${isLiked ? "btn-like" : ""}`}
-        >
-          <Heart size={18} fill={isLiked ? "currentColor" : "none"} />
-          {post.likesCount}
-        </button>
-      </div>
-
-      <div className="global-wrap">
-        <div className="left-col">
-          <div className="route-card">
-            <div className="flex items-center justify-between">
-              <div className="route-point">
-                <p className="route-date">{post.startDate}</p>
-              </div>
-              <div className="route-arrow">✈</div>
-              <div className="route-point">
-                <p className="route-code">{post.destination}</p>
-                <p className="route-date">{post.endDate}</p>
-              </div>
-            </div>
+    <div className="mate-detail">
+      <div className="max-w-4xl mx-auto px-6 py-16">
+        
+        {/* 1. 상단 내비게이션 & 메타 정보 (조회수, 좋아요 가로 배치) */}
+        <div className="flex justify-between items-end header-border">
+          <div>
+            <button 
+              onClick={() => navigate(-1)} 
+              className="flex items-center gap-2 mb-6 font-bold hover:underline group"
+            >
+              <ArrowLeft size={20} strokeWidth={3} className="transition-transform group-hover:-translate-x-1" />
+              <span className="uppercase tracking-tighter text-lg font-black">Back to List</span>
+            </button>
+            <h1 className="text-5xl font-black uppercase tracking-tighter leading-none text-black">
+              {post.destination}
+            </h1>
           </div>
 
-          <div className="info-grid">
-            <div className="info-card">
-              <Calendar size={20} />
-              <p className="info-value">{calculateDuration(post.startDate, post.endDate)}</p>
-              <p className="info-label">여행 기간</p>
+          <div className="flex gap-3 mb-1">
+            {/* 조회수 박스 */}
+            <div className="stat-box">
+              <Eye size={18} strokeWidth={3} className="text-black" />
+              <span>{post.viewsCount}</span>
             </div>
 
-            <div className="info-card">
-              <Wallet size={20} />
-              <p className="info-value">{post.budget.toLocaleString()}원</p>
-              <p className="info-label">예산</p>
-            </div>
-
-            <div className="info-card">
-              <Users size={20} />
-              <p className="info-value">{post.currentParticipant}/{post.maxParticipant}</p>
-              <p className="info-label">참여 인원</p>
-            </div>
-
-            <div className="info-card">
-              <MapPin size={20} />
-              <p className="info-value">{post.viewsCount}</p>
-              <p className="info-label">조회수</p>
-            </div>
-          </div>
-
-          <div className="desc-box">
-            <p className="desc-title">여행 소개</p>
-            <p className="desc-text">{post.content}</p>
-
-            {post.author?.travelStyles && post.author.travelStyles.length > 0 && (
-              <div className="tag-wrap">
-                {post.author.travelStyles.map((tag) => (
-                  <span className="tag" key={tag}>#{tag}</span>
-                ))}
-              </div>
-            )}
+            {/* 좋아요 버튼 (활성화 시 빨간색) */}
+            <button
+              onClick={onLikeClick}
+              className={`stat-box btn-like ${isLiked ? "active" : ""}`}
+            >
+              <Heart 
+                size={18} 
+                strokeWidth={3} 
+                fill={isLiked ? "white" : "none"} 
+              />
+              <span>{post.likesCount}</span>
+            </button>
           </div>
         </div>
 
-        <div className="right-col">
-          <div className="author-card">
-            <p className="author-label">작성자</p>
-
-            <div className="flex gap-3">
-              <div className="author-avatar">
-                {post.author.profileImage || post.author.avatarEmoji || "👤"}
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-12 items-start">
+          
+          {/* 왼쪽 컬럼 */}
+          <div className="lg:col-span-2 space-y-8">
+            
+            {/* 2. 여행 필수 정보 섹션 */}
+            <section className="info-grid">
+              <div className="info-item border-r-4 border-black">
+                <Calendar size={24} strokeWidth={3} className="mb-2 text-black" />
+                <p className="info-label">Duration</p>
+                <p className="text-lg font-black">{calculateDuration(post.startDate, post.endDate)}</p>
+                <p className="text-[10px] font-bold text-gray-400">{post.startDate} ~ {post.endDate}</p>
               </div>
-
-              <div>
-                <p className="author-name">{post.author.nickname}</p>
-                <p className="author-email">{post.author.email}</p>
-                <p className="author-meta">
-                  {post.author.age ? `${post.author.age}세` : ""}
-                  {post.author.age && post.author.gender ? " · " : ""}
-                  {post.author.gender || ""}
-                </p>
+              <div className="info-item border-r-4 border-black">
+                <Users size={24} strokeWidth={3} className="mb-2 text-black" />
+                <p className="info-label">Members</p>
+                <p className="text-lg font-black">{post.currentParticipant}/{post.maxParticipant}</p>
+                <p className="text-[10px] font-bold text-gray-400">PEOPLES</p>
               </div>
-            </div>
-          </div>
+              <div className="info-item">
+                <Wallet size={24} strokeWidth={3} className="mb-2 text-black" />
+                <p className="info-label">Budget</p>
+                <p className="text-lg font-black">{post.budget.toLocaleString()}₩</p>
+                <p className="text-[10px] font-bold text-gray-400">KRW</p>
+              </div>
+            </section>
 
-          <div className="apply-card">
-            {isAuthor ? (
-              <div className="text-center py-4 text-black/60">내가 작성한 게시글입니다</div>
-            ) : !showApplyForm ? (
-              <button
-                disabled={hasApplied || post.currentParticipant >= post.maxParticipant}
-                onClick={() => setShowApplyForm(true)}
-                className={`apply-btn w-full ${
-                  hasApplied || post.currentParticipant >= post.maxParticipant ? "disabled" : ""
-                }`}
-              >
-                {hasApplied
-                  ? "이미 신청함"
-                  : post.currentParticipant >= post.maxParticipant
-                  ? "모집 완료"
-                  : "신청하기"}
-              </button>
-            ) : (
-              <div className="apply-form">
-                <textarea
-                  className="apply-input"
-                  value={applyMessage}
-                  onChange={(e) => setApplyMessage(e.target.value)}
-                  placeholder="신청 메시지를 입력하세요..."
-                />
-
-                <div className="apply-actions">
-                  <button
-                    className="apply-cancel"
-                    onClick={() => {
-                      setShowApplyForm(false);
-                      setApplyMessage("");
-                    }}
-                  >
-                    취소
-                  </button>
-
-                  <button
-                    disabled={!applyMessage.trim()}
-                    className="apply-submit"
-                    onClick={handleApplySubmit}
-                  >
-                    보내기
-                  </button>
+            {/* 3. 메이트 선호도 섹션 */}
+            <section className="preference-card">
+              <div className="flex items-center gap-3 mb-4">
+                <span className="bg-black text-white text-xs font-black px-2 py-1 uppercase italic">
+                  Mate Preference
+                </span>
+                <div className="h-[2px] flex-grow bg-black/10"></div>
+              </div>
+              
+              <div className="grid grid-cols-3 gap-4">
+                <div className="preference-item bg-blue-50">
+                  <span className="text-[10px] font-black text-blue-600 uppercase">Trans</span>
+                  <span className="text-sm font-black">{getTransportLabel(post.transport)}</span>
+                </div>
+                
+                <div className="preference-item bg-pink-50">
+                  <span className="text-[10px] font-black text-pink-600 uppercase">Gender</span>
+                  <span className="text-sm font-black">{getGenderPreferenceLabel(post.genderPreference)}</span>
+                </div>
+                
+                <div className="preference-item bg-green-50">
+                  <span className="text-[10px] font-black text-green-600 uppercase">Age</span>
+                  <span className="text-sm font-black">{getAgeGroupLabel(post.ageGroup)}</span>
                 </div>
               </div>
-            )}
+            </section>
+
+            {/* 4. 여행 소개글 (여기는 시원하게 유지) */}
+            <section className="neo-card min-h-[400px]">
+              <h3 className="text-2xl font-black mb-6 uppercase italic underline decoration-yellow-400 decoration-4 underline-offset-4">
+                Travel Intro
+              </h3>
+              <div className="leading-relaxed whitespace-pre-wrap text-xl font-medium text-black/90">
+                {post.content}
+              </div>
+            </section>
+          </div>
+
+          {/* 오른쪽 컬럼: 사이드바 (작성자 프로필 & 신청하기) */}
+          <div className="space-y-10 lg:sticky lg:top-10">
+            
+            {/* 4. 작성자 상세 프로필 카드 */}
+            <div className="author-card">
+              <p className="inline-block text-[10px] font-black bg-black text-white px-3 py-1 mb-8 uppercase tracking-widest">
+                Host Info
+              </p>
+              
+              <div className="flex items-center gap-5 mb-10 border-black pb-8"
+              style={{borderBottomWidth: "thin", borderBottomColor: "gray"}}>
+                <div className="author-avatar">
+                  {post.author.profileImage ? (
+                    <img 
+                      src={post.author.profileImage} 
+                      alt="profile" 
+                      className="w-full h-full object-cover"
+                    />
+                  ) : (
+                    <span>{post.author.avatarEmoji || "👤"}</span>
+                  )}
+                </div>
+                <div className="overflow-hidden">
+                  <p className="font-black text-3xl uppercase tracking-tighter leading-none mb-2 break-words">
+                    {post.author.nickname}
+                  </p>
+                  <p className="text-xs font-bold border-black inline-block break-all">
+                    {post.author.email}
+                  </p>
+                </div>
+              </div>
+
+              {/* 성별, 나이 정보 */}
+              <div className="grid grid-cols-2 gap-4 mb-8">
+                <div className="meta-tag">
+                  <p className="text-[10px] font-black uppercase text-gray-500 mb-1">Gender</p>
+                  <p className="text-base font-black uppercase">{getGenderPreferenceLabel(post.author.gender.toLowerCase())}</p>
+                </div>
+                <div className="meta-tag">
+                  <p className="text-[10px] font-black uppercase text-gray-500 mb-1">Age</p>
+                  <p className="text-base font-black">{post.author.age}세</p>
+                </div>
+              </div>
+
+              {/* 여행 스타일 태그 */}
+              {post.author?.travelStyles && post.author.travelStyles.length > 0 && (
+                <div>
+                  <p className="text-[10px] font-black uppercase text-gray-500 mb-4">Travel Styles</p>
+                  <div className="flex flex-wrap gap-2">
+                    {post.author.travelStyles.map((tag) => (
+                      <span key={tag} className="travel-style-tag">
+                        #{tag}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
+
+            {/* 5. 신청하기 섹션 */}
+            <div className="apply-card">
+              {isAuthor ? (
+                <div className="text-center py-4 font-black uppercase italic text-xl border-4 border-black bg-white shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]">
+                  My Post
+                </div>
+              ) : !showApplyForm ? (
+                <button
+                  disabled={hasApplied || post.currentParticipant >= post.maxParticipant}
+                  onClick={() => setShowApplyForm(true)}
+                  className="apply-button"
+                >
+                  {hasApplied ? "Applied" : post.currentParticipant >= post.maxParticipant ? "Full" : "Apply Now"}
+                </button>
+              ) : (
+                <div className="space-y-5">
+                  <textarea
+                    className="w-full h-40 p-4 border-4 border-black font-bold resize-none focus:outline-none text-base bg-white placeholder:text-gray-400"
+                    value={applyMessage}
+                    onChange={(e) => setApplyMessage(e.target.value)}
+                    placeholder="신청 메시지를 입력하세요..."
+                  />
+
+                  <div className="grid grid-cols-2 gap-4">
+                    <button
+                      className="py-3 border-4 border-black bg-white font-black uppercase hover:bg-gray-100 transition-all"
+                      onClick={() => {
+                        setShowApplyForm(false);
+                        setApplyMessage("");
+                      }}
+                    >
+                      Cancel
+                    </button>
+
+                    <button
+                      disabled={!applyMessage.trim()}
+                      className="py-3 border-4 border-black bg-black text-white font-black uppercase disabled:opacity-50 transition-all"
+                      onClick={handleApplySubmit}
+                    >
+                      Send
+                    </button>
+                  </div>
+                </div>
+              )}
+            </div>
           </div>
         </div>
+
+        {/* 하단 여백 */}
+        <div className="py-12"></div>
       </div>
     </div>
   );

--- a/src/features/mate/styles/MateDetail.css
+++ b/src/features/mate/styles/MateDetail.css
@@ -1,248 +1,170 @@
-/* --- MateDetail 전용 네임스페이스 --- */
-.mate-detail * {
-  box-sizing: border-box;
-  font-family: var(--font-mono);
+/* --- MateDetail Neo-Brutalism Style --- */
+
+.mate-detail {
+  min-height: 100vh;
+  color: #000;
 }
 
-/* 전체 래퍼 */
-.mate-detail .global-wrap {
-  display: grid;
-  grid-template-columns: 2fr 1fr;
-  gap: 1.5rem;
+/* 상단 헤더 구분선 */
+.mate-detail .header-border {
+  border-bottom: 4px solid #000;
+  padding-bottom: 2rem;
+  margin-bottom: 3rem;
 }
 
-/* 버튼 공통 */
-.mate-detail .btn-outline {
+/* 공통 네오브루탈리즘 카드 스타일 */
+.mate-detail .neo-card {
+  background: #fff;
+  border: 4px solid #000;
+  box-shadow: 8px 8px 0px 0px rgba(0,0,0,1);
+  padding: 2.5rem;
+  transition: all 0.2s;
+}
+
+/* 우측 상단 지표 박스 (조회수, 좋아요) */
+.mate-detail .stat-box {
   display: flex;
   align-items: center;
-  gap: 6px;
-  padding: 10px 14px;
-  border: 2px solid #000;
+  gap: 0.75rem;
+  padding: 0.5rem 1rem;
+  border: 3px solid #000;
   background: #fff;
-  font-weight: 700;
-  cursor: pointer;
-  transition: 0.15s;
-}
-
-.mate-detail .btn-outline:hover {
-  background: #000;
-  color: #fff;
-}
-
-.mate-detail .btn-like {
-  background: #ef4444;
-  border-color: #ef4444;
-  color: #fff;
-}
-
-.mate-detail .btn-like:hover {
-  background: #dc2626;
-  border-color: #dc2626;
-}
-
-/* Left */
-.mate-detail .left-col {
-  display: flex;
-  flex-direction: column;
-  gap: 1.25rem;
-}
-
-/* Route */
-.mate-detail .route-card {
-  background: #000;
-  padding: 1.5rem;
-  border-radius: 16px;
-  color: #fff;
-}
-
-.mate-detail .route-code {
-  font-size: 2rem;
+  box-shadow: 4px 4px 0px 0px rgba(0,0,0,1);
   font-weight: 900;
+  font-size: 1.125rem;
+  min-height: auto;
 }
 
-.mate-detail .route-date {
-  font-size: 0.75rem;
-  opacity: 0.6;
+/* 좋아요 버튼 활성화 상태 (CSS에서 강제 적용) */
+.mate-detail .btn-like.active {
+  background-color: #ff4d4d !important; /* 강렬한 레드 */
+  color: #fff !important;
 }
 
-.mate-detail .route-arrow {
-  font-size: 2rem;
+.mate-detail .btn-like:active {
+  transform: translate(3px, 3px);
+  box-shadow: none;
 }
 
-/* Info Grid */
+/* 정보 그리드 (Duration, Members, Budget) */
 .mate-detail .info-grid {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 0.75rem;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem; /* 간격 축소 */
+  border: 4px solid #000;
+  background: #fff;
+  padding: 1.5rem;
+  box-shadow: 6px 6px 0px 0px rgba(0,0,0,1);
 }
 
-.mate-detail .info-card {
-  background: #fff;
+.mate-detail .preference-card {
+  padding: 0rem 1.5rem;
+}
+
+.mate-detail .preference-item {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  padding: 0.5rem 1rem;
   border: 2px solid #000;
-  border-radius: 12px;
-  padding: 1rem;
+  box-shadow: 3px 3px 0px 0px rgba(0,0,0,1);
+}
+
+.mate-detail .info-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
   text-align: center;
 }
 
-.mate-detail .info-value {
-  font-size: 1.125rem;
-  font-weight: 700;
+.mate-detail .info-item:not(:last-child) {
+  border-right: 4px solid #000;
 }
 
 .mate-detail .info-label {
   font-size: 0.75rem;
+  font-weight: 900;
+  text-transform: uppercase;
   color: #666;
+  margin-top: 0.5rem;
 }
 
-/* Description */
-.mate-detail .desc-box {
-  background: #fff;
-  border: 2px solid #000;
-  border-radius: 12px;
-  padding: 1.25rem;
+.mate-detail .info-value {
+  font-size: 1.25rem;
+  font-weight: 900;
 }
 
-.mate-detail .desc-title {
-  font-size: 0.875rem;
-  font-weight: 700;
-  margin-bottom: 0.75rem;
-}
-
-.mate-detail .desc-text {
-  white-space: pre-line;
-  color: #333;
-  margin-bottom: 1rem;
-}
-
-.mate-detail .tag-wrap {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-}
-
-.mate-detail .tag {
-  padding: 6px 12px;
-  border: 1px solid #000;
-  background: #fff;
-  border-radius: 999px;
-  font-size: 0.75rem;
-}
-
-/* Right */
-.mate-detail .right-col {
-  display: flex;
-  flex-direction: column;
-  gap: 1.25rem;
-}
-
-/* Author */
+/* 작성자 프로필 카드 */
 .mate-detail .author-card {
+  border: 4px solid #000;
   background: #fff;
-  border: 2px solid #000;
-  border-radius: 12px;
-  padding: 1.25rem;
-}
-
-.mate-detail .author-label {
-  font-size: 0.75rem;
-  font-weight: 700;
-  margin-bottom: 1rem;
+  padding: 2rem;
+  box-shadow: 8px 8px 0px 0px rgba(0,0,0,1);
 }
 
 .mate-detail .author-avatar {
-  width: 52px;
-  height: 52px;
-  background: #000;
-  color: #fff;
-  border-radius: 10px;
+  width: 5rem;
+  height: 5rem;
+  border: 4px solid #000;
+  background: #c084fc; /* purple-400 */
   display: flex;
   align-items: center;
   justify-content: center;
+  font-size: 2rem;
+  box-shadow: 4px 4px 0px 0px rgba(0,0,0,1);
 }
 
-/* Apply */
-.mate-detail .apply-card {
-  background: #fff;
+.mate-detail .meta-tag {
   border: 2px solid #000;
-  padding: 1.25rem;
-  border-radius: 12px;
+  padding: 0.75rem;
+  background: #f3f4f6;
+  box-shadow: 3px 3px 0px 0px rgba(0,0,0,1);
+  text-align: center;
 }
 
-.mate-detail .apply-btn {
-  padding: 14px;
+.mate-detail .travel-style-tag {
+  display: inline-block;
+  padding: 0.25rem 0.75rem;
+  border: 2px solid #000;
+  background: #86efac; /* green-300 */
+  font-size: 0.75rem;
   font-weight: 900;
-  color: #fff;
-  background: #000;
-  border: none;
-  border-radius: 8px;
-  cursor: pointer;
-  transition: 0.15s;
+  box-shadow: 2px 2px 0px 0px rgba(0,0,0,1);
+  margin-right: 0.5rem;
+  margin-bottom: 0.5rem;
 }
 
-.mate-detail .apply-btn.disabled {
-  background: #ccc;
-  color: #666;
-  cursor: not-allowed;
+/* 신청하기 카드 */
+.mate-detail .apply-card {
+  border: 4px solid #000;
+  background: #facc15; /* yellow-400 */
+  padding: 2rem;
+  box-shadow: 8px 8px 0px 0px rgba(0,0,0,1);
 }
 
-.mate-detail .apply-form {
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-}
-
-.mate-detail .apply-input {
+.mate-detail .apply-button {
   width: 100%;
-  padding: 10px;
-  border: 2px solid #000;
-  border-radius: 8px;
-  min-height: 100px;
+  padding: 1rem;
+  border: 4px solid #000;
+  background: #fff;
+  font-size: 1.25rem;
+  font-weight: 900;
+  text-transform: uppercase;
+  box-shadow: 5px 5px 0px 0px rgba(0,0,0,1);
+  transition: all 0.1s;
 }
 
-.mate-detail .apply-actions {
-  display: flex;
-  gap: 0.75rem;
+.mate-detail .apply-button:not(:disabled):active {
+  transform: translate(4px, 4px);
+  box-shadow: none;
 }
 
-.mate-detail .apply-cancel {
-  flex: 1;
-  background: #eee;
-  padding: 12px;
-  border-radius: 8px;
-}
-
-.mate-detail .apply-submit {
-  flex: 1;
-  background: #000;
-  color: #fff;
-  padding: 12px;
-  border-radius: 8px;
-}
-
-.mate-detail .apply-submit:disabled {
-  background: #ccc;
-  color: #888;
-}
-
-/* Loading */
-.mate-detail .loading-spinner {
-  width: 36px;
-  height: 36px;
-  border: 4px solid #eee;
-  border-top-color: #000;
-  border-radius: 50%;
-  animation: spin 0.8s linear infinite;
-}
-
-@keyframes spin {
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-/* Responsive */
-@media (max-width: 1024px) {
-  .mate-detail .global-wrap {
-    grid-template-columns: 1fr;
-  }
+.mate-detail .apply-button:disabled {
+  background: #e5e7eb;
+  color: #9ca3af;
+  box-shadow: none;
+  border-color: #9ca3af;
+  cursor: not-allowed;
 }


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #79

---
## 🎨 작업 내용 (What)
- 작성자 프로필 영역 `profileImage` → `<img>` 렌더링, 없으면 `avatarEmoji` → `👤` fallback 처리
- 디테일 페이지의 디자인을 전반적으로 교체함, 네오브루탈리즘 디자인 컨셉 강화 및 전체 페이지 UI 일관성 확보
- `info-grid`, `matePreference` 섹션 패딩 및 아이콘 크기 축소, 네오브루탈리즘 스타일 강화
- Duration 항목 아래 Period(시작일~종료일) 정보 추가
- 좋아요 클릭 시 빨간 배경 + 흰색 하트 즉각 시각 피드백 적용
- 신청 완료 시 `setPost`로 `hasApplied`, `currentParticipant` 즉시 반영 (새로고침 불필요)
- `Mate.tsx`에서 `genderPreference`, `ageGroup` 이중 변환 버그 수정 — 변환은 `useMate.ts` 단일 지점에서만 수행
- `TRANSPORT_REVERSE_MAP`, `GENDER_PREFERENCE_REVERSE_MAP`, `AGE_GROUP_REVERSE_MAP` 키값 소문자 통일
- `getTransportLabel`, `getAgeGroupLabel` 역매핑 유틸 함수 분리

---
## 🧭 작업 목적 (Why)
- 소셜 로그인 유저의 `profileImage`가 URL 텍스트 그대로 노출되는 렌더링 버그 수정
- `Mate.tsx`와 `useMate.ts` 두 곳에서 이중 변환이 발생해 `genderPreference`, `ageGroup`이 항상 기본값(`any`, `all`)으로 저장되는 버그 수정
- 서버 응답 영문 enum값이 한글로 변환되지 않아 교통수단, 성별, 나이대 정보가 그대로 노출되는 문제 수정
- 신청 후 새로고침해야 상태가 반영되던 UX 개선

---
## 🧩 변경 범위
- [x] UI / Layout
- [x] 컴포넌트 구조
- [x] 상태 관리 로직
- [x] API 연동
- [x] 스타일

---
## 🧪 테스트 방법
- [x] 로컬 실행 확인
- [x] 주요 화면 렌더링 확인
  - 소셜 로그인 유저 프로필 이미지 정상 출력 확인
  - 교통수단, 성별, 나이대 한글 정상 표시 확인
  - 포스트 작성 시 `genderPreference`, `ageGroup` 선택값 정상 저장 확인
  - 신청 완료 후 버튼 즉시 "Applied"로 변경 및 인원수 증가 확인
  - 좋아요 클릭 시 즉각 색상 변경 확인
- [x] 에러 콘솔 확인

---
## ⚠️ 참고 사항
- 백엔드 PR(#55)과 함께 배포 필요 — `author.travelStyles`, `profileImage` 응답 필드 추가에 의존
- Tailwind v4 환경에서 일부 gradient 클래스 미적용 이슈로 인라인 스타일 혼용

---
## ✅ 체크리스트
- [ ] main 브랜치 직접 push 하지 않음
- [ ] feature 브랜치에서 작업함
- [ ] 불필요한 console.log 제거
- [ ] PR 단위가 과도하게 크지 않음