### PR TITLE
[FE] feature: 만료 게시글 신청 내역 삭제 버튼 추가

### DIFF
--- a/src/features/mate/components/MateReceiveModal.tsx
+++ b/src/features/mate/components/MateReceiveModal.tsx
@@ -1,8 +1,8 @@
-import { Send, Check, XCircle, ArrowLeft, MessageSquare } from "lucide-react";
+import { Send, Check, XCircle, ArrowLeft, MessageSquare, Trash2 } from "lucide-react";
 import { useState } from "react";
 import "../styles/MateModals.css";
 import type { ApplicationResponse, SelectedApplicant } from "../hooks/mate.types";
-import { getApplicantAvatar } from "../hooks/mate.util.ts";
+import { getApplicantAvatar, isPostExpired } from "../hooks/mate.util.ts";
 
 interface ReceivedModalProps {
   applications: ApplicationResponse[];
@@ -10,6 +10,7 @@ interface ReceivedModalProps {
   onApprove: (id: string, postId: number, applicantId: number, e?: React.MouseEvent<HTMLButtonElement>) => void;
   onReject: (id: string, e?: React.MouseEvent<HTMLButtonElement>) => void;
   onClose: () => void;
+  onDeleteReceived?: (applyId: string) => void;
 }
 
 function AvatarDisplay({ profileImage, avatarEmoji, className }: {
@@ -31,6 +32,7 @@ export function MateReceivedModal({
   onApprove, 
   onReject,
   onClose,
+  onDeleteReceived,
 }: ReceivedModalProps){
   const [selectedApplicant, setSelectedApplicant] = useState<SelectedApplicant | null>(null);
 
@@ -189,6 +191,29 @@ export function MateReceivedModal({
                             <MessageSquare className="w-3 h-3" /> 채팅 가능
                           </span>
                         )}
+                        {isPostExpired(data) && onDeleteReceived && (
+                            <button
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                if (window.confirm("이 신청을 삭제하시겠습니까?")) {
+                                  onDeleteReceived(String(data.id));
+                                }
+                              }}
+                              title="신청 삭제"
+                              style={{
+                                padding: "6px",
+                                background: "transparent",
+                                border: "none",
+                                cursor: "pointer",
+                                color: "#9ca3af",
+                                transition: "color 0.15s",
+                              }}
+                              onMouseEnter={(e) => (e.currentTarget.style.color = "#dc2626")}
+                              onMouseLeave={(e) => (e.currentTarget.style.color = "#9ca3af")}
+                            >
+                              <Trash2 size={16} />
+                            </button>
+                          )}
                       </div>
                     </div>
 

--- a/src/features/mate/components/MateSentModal.tsx
+++ b/src/features/mate/components/MateSentModal.tsx
@@ -1,17 +1,20 @@
-import { Send } from "lucide-react";
+import { Send, Trash2 } from "lucide-react";
 import "../styles/MateModals.css";
 import type { MyApplication } from "../hooks/mate.types";
+import { isPostExpired } from "../hooks/mate.util";
 
 interface MateSentModalProps {
   applications: MyApplication[];
   getApplicantStatus: (id: string) => "approved" | "rejected" | "pending";
   onClose: () => void;
+  onDeleteSent?: (applyId: string) => void;
 }
 
 export function MateSentModal({ 
   applications, 
   getApplicantStatus, 
   onClose,
+  onDeleteSent,
 }: MateSentModalProps){
   return (
     <div className="modal-overlay active" onMouseDown={(e) => { if (e.target === e.currentTarget) onClose(); }}>
@@ -52,9 +55,34 @@ export function MateSentModal({
                             {app.startDate} — {app.endDate}
                           </p>
                         </div>
-                        <div className={`flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-gray-50 border border-gray-100 ${statusStyles.color}`}>
-                          <span className={`w-2 h-2 rounded-full ${statusStyles.dot}`} />
-                          <span className="text-xs font-bold uppercase tracking-wider">{statusStyles.label}</span>
+                        <div className="flex items-center gap-2">
+                          <div className={`flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-gray-50 border border-gray-100 ${statusStyles.color}`}>
+                            <span className={`w-2 h-2 rounded-full ${statusStyles.dot}`} />
+                            <span className="text-xs font-bold uppercase tracking-wider">{statusStyles.label}</span>
+                          </div>
+                          {isPostExpired(app) && onDeleteSent && (
+                            <button
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                if (window.confirm("이 신청을 삭제하시겠습니까?")) {
+                                  onDeleteSent(String(app.id));
+                                }
+                              }}
+                              title="신청 삭제"
+                              style={{
+                                padding: "6px",
+                                background: "transparent",
+                                border: "none",
+                                cursor: "pointer",
+                                color: "#9ca3af",
+                                transition: "color 0.15s",
+                              }}
+                              onMouseEnter={(e) => (e.currentTarget.style.color = "#dc2626")}
+                              onMouseLeave={(e) => (e.currentTarget.style.color = "#9ca3af")}
+                            >
+                              <Trash2 size={16} />
+                            </button>
+                          )}
                         </div>
                       </div>
 

--- a/src/features/mate/hooks/useMate.ts
+++ b/src/features/mate/hooks/useMate.ts
@@ -269,6 +269,26 @@ export function useMate() {
     }
   }, [token, fetchSentApplications]);
 
+// 5. 받은 신청서 삭제하기
+  const deleteReceivedApplication = useCallback(async (applyId: string): Promise<boolean> => {
+
+    try {
+      const response = await fetch(`${API_BASE_URL}/mate/applications/${applyId}/received`, {
+        method: "DELETE",
+        headers: { "Authorization": `Bearer ${token}`}
+      });
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.message || "신청서 삭제에 실패했습니다.");
+      }
+      await fetchReceivedApplications();
+      return true;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "신청서 삭제에 실패했습니다.");
+      return false;
+    }
+  }, [token, fetchReceivedApplications]);
+
   const passPost = useCallback(async (postId: number) => {
     const target = posts.find(p => p.id === postId);
     if (target) setPassedPosts(prev => [target, ...prev.filter(p => p.id !== postId)]);
@@ -365,6 +385,7 @@ export function useMate() {
       const app = receivedApplications.find(a => String(a.id) === String(id));
       return app?.status || "pending"; 
     },
-    deleteSentApplication
+    deleteSentApplication,
+    deleteReceivedApplication,
   };
 }

--- a/src/features/mate/hooks/useMate.ts
+++ b/src/features/mate/hooks/useMate.ts
@@ -240,14 +240,34 @@ export function useMate() {
   const fetchSentApplications = useCallback(async () => {
     try {
       const response = await fetch(`${API_BASE_URL}/mate/applications/sent`, {
-        headers: { "Authorization": `Bearer ${localStorage.getItem("accessToken")}`}
+        headers: { "Authorization": `Bearer ${token}`}
       });
       if(!response.ok) throw new Error("데이터 로딩 실패");
       const data = await response.json();
       setApplications(data);
     } catch (err) {
     }
-  }, []);
+  }, [token]);
+
+  // 4. 보낸 신청서 삭제하기(만료된 게시글)
+  const deleteSentApplication = useCallback(async (applyId: string): Promise<boolean> => {
+
+    try {
+      const response = await fetch(`${API_BASE_URL}/mate/applications/${applyId}/sent`, {
+        method: "DELETE",
+        headers: { "Authorization": `Bearer ${token}`}
+      });
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.message || "신청서 삭제에 실패했습니다.");
+      }
+      await fetchSentApplications();
+      return true;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "신청서 삭제에 실패했습니다.");
+      return false;
+    }
+  }, [token, fetchSentApplications]);
 
   const passPost = useCallback(async (postId: number) => {
     const target = posts.find(p => p.id === postId);
@@ -344,6 +364,7 @@ export function useMate() {
     getApplicantStatus: (id: string) => {
       const app = receivedApplications.find(a => String(a.id) === String(id));
       return app?.status || "pending"; 
-    }
+    },
+    deleteSentApplication
   };
 }

--- a/src/features/mate/pages/Mate.tsx
+++ b/src/features/mate/pages/Mate.tsx
@@ -56,6 +56,7 @@ export default function Mate() {
     fetchPassedPosts, fetchExpiredPosts,
     passPost, unpassPost,
     passedPosts, expiredPosts,
+    deleteSentApplication
    } = useMate();
 
   const {
@@ -437,6 +438,7 @@ export default function Mate() {
           return app?.status || "pending";
          }}
          onClose={() => setShowSentModal(false)}
+         onDeleteSent={(applyId) => deleteSentApplication(applyId)}
         />
       )}
 

--- a/src/features/mate/pages/Mate.tsx
+++ b/src/features/mate/pages/Mate.tsx
@@ -56,7 +56,8 @@ export default function Mate() {
     fetchPassedPosts, fetchExpiredPosts,
     passPost, unpassPost,
     passedPosts, expiredPosts,
-    deleteSentApplication
+    deleteSentApplication,
+    deleteReceivedApplication,
    } = useMate();
 
   const {
@@ -452,6 +453,7 @@ export default function Mate() {
           onApprove={(id, postId, applicantId) => handleApplicationStatus(id, 'approve')}
           onReject={(id) => handleApplicationStatus(id, 'reject')}
           onClose={() => setShowReceivedModal(false)}
+          onDeleteReceived={(applyId) => deleteReceivedApplication(applyId)}
         />
       )}
 


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #87

---
## 🎨 작업 내용 (What)
- `useMate` 훅에 `deleteSentApplication()`, `deleteReceivedApplication()` 추가
- `MateSentModal`에 만료된 신청 삭제 아이콘(Trash2) 추가
- `MateReceivedModal`에 만료된 신청 삭제 아이콘(Trash2) 추가
- `Mate.tsx`에서 삭제 핸들러 prop 전달
- 삭제 시 confirm 다이얼로그 → 성공 시 목록 자동 갱신

---
## 🧭 작업 목적 (Why)
만료된 게시글의 신청 내역이 Sent/Received 모달에 계속 쌓여 관리가 어려움.
사용자가 불필요한 신청을 직접 정리할 수 있도록 삭제 UI 제공.

---
## 🧩 변경 범위
- [x] UI / Layout
- [ ] 컴포넌트 구조
- [x] 상태 관리 로직
- [x] API 연동
- [x] 스타일

---
## 🧪 테스트 방법
- [x] 로컬 실행 확인
- [x] 주요 화면 렌더링 확인
- [x] 에러 콘솔 확인

### 확인 사항
- 만료된 신청 카드 → 우측 상단에 휴지통 아이콘 노출
- 만료되지 않은 신청 카드 → 아이콘 미노출
- 아이콘 호버 시 회색 → 빨간색 전환
- 삭제 클릭 → confirm → 목록에서 즉시 제거

---
## ⚠️ 참고 사항
- BE PR(삭제 API)이 먼저 머지되어야 정상 동작
- `isPostExpired()` 유틸 함수 재사용 (KST 기준 만료 판별)
- `lucide-react`의 `Trash2` 아이콘 사용

---
## ✅ 체크리스트
- [ ] main 브랜치 직접 push 하지 않음
- [ ] feature 브랜치에서 작업함
- [ ] 불필요한 console.log 제거
- [ ] PR 단위가 과도하게 크지 않음