### PR TITLE
[FE] feature: 비회원 mate, chat 접근 제한 UI 및 로그인 유도 모달 구현

### DIFF
--- a/src/features/chat/hooks/useChat.ts
+++ b/src/features/chat/hooks/useChat.ts
@@ -255,6 +255,8 @@ export function useChat(): UseChatReturn {
   // ─────────────────────────────────────────
 
   useEffect(() => {
+    const token = localStorage.getItem("accessToken");
+    if (!token) return;
     refreshRooms();
   }, [refreshRooms]);
 

--- a/src/features/mate/components/LoginPromptModal.tsx
+++ b/src/features/mate/components/LoginPromptModal.tsx
@@ -1,0 +1,43 @@
+import "../styles/MateModals.css";
+
+interface LoginPromptModalProps {
+  onClose: () => void;
+  onLogin: () => void;
+}
+
+export function LoginPromptModal({ onClose, onLogin }: LoginPromptModalProps) {
+  return (
+    <div className="modal-overlay active" onMouseDown={(e) => { if (e.target === e.currentTarget) onClose(); }}>
+      <div className="modal-window detail-window" onMouseDown={(e) => e.stopPropagation()}>
+        <div className="modal-header">
+          <span className="mh-title">&gt;&gt; LOGIN REQUIRED</span>
+        </div>
+
+        <div className="modal-body" style={{ textAlign: "center", padding: "48px 32px" }}>
+          <p className="text-xl font-black uppercase tracking-tight mb-2">
+            Members Only
+          </p>
+          <p className="text-sm text-black/50 font-bold mb-8">
+            이 기능은 로그인 후 이용할 수 있습니다
+          </p>
+
+          <div className="flex gap-4 justify-center">
+            <button
+              onClick={onClose}
+              className="px-6 py-3 border-3 border-black bg-white font-black uppercase text-sm hover:bg-[#eee] transition-all"
+              style={{ border: "3px solid #000" }}
+            >
+              둘러보기
+            </button>
+            <button
+              onClick={onLogin}
+              className="px-6 py-3 font-black uppercase text-sm transition-all button bgBlackHoverable"
+            >
+              로그인하기
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/mate/components/MateHeader.tsx
+++ b/src/features/mate/components/MateHeader.tsx
@@ -1,4 +1,5 @@
 import { PenSquare, Inbox, User, MessageSquare } from "lucide-react";
+import { useAuthGuard } from "../hooks/useAuthGuard";
 import "../styles/MateHeader.css";
 
 interface MateHeaderProps {
@@ -15,11 +16,12 @@ export function MateHeader({
   onWriteClick, 
   onMySentClick, 
   onReceivedClick, 
-  onChatListClick,
   mySentCount, 
   receivedPendingCount,
-  unreadChatCount = 0, 
 }: MateHeaderProps){
+
+  const { withLoginCheck } = useAuthGuard();
+
   return (
     <div className="header">
       <div className="flex items-center justify-between flex-wrap gap-4">
@@ -30,7 +32,7 @@ export function MateHeader({
         <div className="flex gap-3">
           <button 
             className="flex items-center gap-2 bg-white text-black px-5 py-2.5 transition-colors font-bold text-sm uppercase tracking-wide button"
-            onClick={onWriteClick}
+            onClick={() => withLoginCheck(onWriteClick)}
           >
             <PenSquare className="w-4 h-4" />
             WRITE
@@ -38,7 +40,7 @@ export function MateHeader({
 
           <button 
             className="flex items-center gap-2 bg-white text-black px-5 py-2.5 transition-colors font-bold text-sm uppercase tracking-wide relative button"
-            onClick={onMySentClick}
+            onClick={() => withLoginCheck(onMySentClick)}
           >
             <Inbox className="w-4 h-4" />
             MY SENT
@@ -51,7 +53,7 @@ export function MateHeader({
 
           <button 
             className="flex items-center gap-2 px-5 py-2.5 transition-colors font-bold text-sm uppercase tracking-wide relative button buttonDark"
-            onClick={onReceivedClick}
+            onClick={() => withLoginCheck(onReceivedClick)}
           >
             <User className="w-4 h-4" />
             RECEIVED

--- a/src/features/mate/components/MateHeader.tsx
+++ b/src/features/mate/components/MateHeader.tsx
@@ -1,5 +1,6 @@
-import { PenSquare, Inbox, User, MessageSquare } from "lucide-react";
+import { PenSquare, Inbox, User } from "lucide-react";
 import { useAuthGuard } from "../hooks/useAuthGuard";
+import { LoginPromptModal } from "./LoginPromptModal";
 import "../styles/MateHeader.css";
 
 interface MateHeaderProps {
@@ -20,9 +21,10 @@ export function MateHeader({
   receivedPendingCount,
 }: MateHeaderProps){
 
-  const { withLoginCheck } = useAuthGuard();
+  const { withLoginCheck, showLoginModal, closeLoginModal, goToLogin } = useAuthGuard();
 
   return (
+    <>
     <div className="header">
       <div className="flex items-center justify-between flex-wrap gap-4">
         <h1 className="text-[32px] font-black font-mono uppercase tracking-wide leading-tight">
@@ -66,5 +68,10 @@ export function MateHeader({
         </div>
       </div>
     </div>
+
+    {showLoginModal && (
+      <LoginPromptModal onClose={closeLoginModal} onLogin={goToLogin} />
+    )}
+    </>
   );
 }

--- a/src/features/mate/components/MatePostCard.tsx
+++ b/src/features/mate/components/MatePostCard.tsx
@@ -36,6 +36,7 @@ export function MatePostCard({
 }: MatePostCardProps){
   const currentUserId = getCurrentUserId();
   const isAuthor = post.author.id === currentUserId;
+  const token = localStorage.getItem("accessToken");
 
   // 날짜 포맷팅 (YYYY-MM-DD -> MM-DD)
   const formatDate = (dateString: string) => {
@@ -64,8 +65,6 @@ export function MatePostCard({
       >
         <div className="flex items-center justify-between mb-4">
           <div className="flex items-center gap-4">
-            {/* <div className="text-2xl text-black/60 mx-2">✈</div> */}
-
             <div className="text-left">
               <div className="text-xs text-black/50 uppercase font-bold mb-1">To</div>
               <div className="text-2xl font-bold text-black">{post.destination}</div>
@@ -196,6 +195,13 @@ export function MatePostCard({
               </div>
             </>
           )          
+          : !token ? (
+            <>
+              <div className="text-xs font-bold text-black/40 text-center">
+                회원 전용<br />서비스 입니다
+              </div>
+            </>
+          )
           : isAuthor ? (
             <>
               <button

--- a/src/features/mate/hooks/useAuthGuard.ts
+++ b/src/features/mate/hooks/useAuthGuard.ts
@@ -1,19 +1,26 @@
-// hooks/useAuthGuard.ts
+import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useCurrentUser } from "../../chat/hooks/useCurrentUser";
 
 export function useAuthGuard() {
   const { id } = useCurrentUser();
   const navigate = useNavigate();
+  const [showLoginModal, setShowLoginModal] = useState(false);
 
   const withLoginCheck = (callback: () => void) => {
     if (!id) {
-      alert("로그인이 필요합니다.");
-      navigate("/login");
+      setShowLoginModal(true);
       return;
     }
     callback();
   };
 
-  return { withLoginCheck };
+  const closeLoginModal = () => setShowLoginModal(false);
+
+  const goToLogin = () => {
+    setShowLoginModal(false);
+    navigate("/login");
+  };
+
+  return { withLoginCheck, showLoginModal, closeLoginModal, goToLogin };
 }

--- a/src/features/mate/hooks/useAuthGuard.ts
+++ b/src/features/mate/hooks/useAuthGuard.ts
@@ -1,0 +1,19 @@
+// hooks/useAuthGuard.ts
+import { useNavigate } from "react-router-dom";
+import { useCurrentUser } from "../../chat/hooks/useCurrentUser";
+
+export function useAuthGuard() {
+  const { id } = useCurrentUser();
+  const navigate = useNavigate();
+
+  const withLoginCheck = (callback: () => void) => {
+    if (!id) {
+      alert("로그인이 필요합니다.");
+      navigate("/login");
+      return;
+    }
+    callback();
+  };
+
+  return { withLoginCheck };
+}

--- a/src/features/mate/hooks/useMate.ts
+++ b/src/features/mate/hooks/useMate.ts
@@ -22,12 +22,16 @@ export function useMate() {
     setLoading(true);
     setError(null);
     try {
+      const headers: Record<string, string> = {
+        "Content-Type": "application/json",
+      };
+      if (token) {
+        headers["Authorization"] = `Bearer ${token}`;
+      }
+
       const response = await fetch(`${API_BASE_URL}/mate/`, {
         method: "GET",
-        headers: {
-          "Content-Type": "application/json",
-          "Authorization": `Bearer ${token}`
-        },
+        headers,
       });
 
       if (!response.ok) {
@@ -109,12 +113,16 @@ export function useMate() {
     setError(null);
 
     try {
+      const headers: Record<string, string> = {
+        "Content-Type": "application/json",
+      };
+      if (token) {
+        headers["Authorization"] = `Bearer ${token}`;
+      }
+
       const response = await fetch(`${API_BASE_URL}/mate/${postId}`, {
         method: "GET",
-        headers: {
-          "Content-Type": "application/json",
-          "Authorization": `Bearer ${token}`
-        },
+        headers,
       });
 
       if (!response.ok) {
@@ -329,6 +337,7 @@ export function useMate() {
 
   const fetchPassedPosts = useCallback(async () => {
     try {
+      if(!token) return;
       const response = await fetch(`${API_BASE_URL}/mate/posts/passed`, {
         method: "GET",
         headers: {
@@ -346,13 +355,18 @@ export function useMate() {
 
   const fetchExpiredPosts = useCallback(async () => {
     try {
+      const headers: Record<string, string> = {
+        "Content-Type": "application/json",
+      };
+      if (token) {
+        headers["Authorization"] = `Bearer ${token}`;
+      }
+
       const response = await fetch(`${API_BASE_URL}/mate/posts/expired`, {
         method: "GET",
-        headers: {
-          "Content-Type": "application/json",
-          "Authorization": `Bearer ${token}`,
-        },
+        headers,
       });
+
       if (!response.ok) throw new Error("EXPIRED 목록을 불러오는데 실패했습니다.");
       const data: Post[] = await response.json();
       setExpiredPosts(data);

--- a/src/features/mate/pages/Mate.tsx
+++ b/src/features/mate/pages/Mate.tsx
@@ -230,6 +230,7 @@ export default function Mate() {
     [toggleLike]
   );
 
+  const token = localStorage.getItem("accessToken");
 
   return (
     <section className="page-section">
@@ -457,6 +458,7 @@ export default function Mate() {
         />
       )}
 
+      {token && (
       <ChatFAB 
         onClick={() => {
           refreshRooms();
@@ -464,8 +466,8 @@ export default function Mate() {
           fetchReceivedApplications();
           setShowChatModal(true);
         }}
-        unreadCount={0}
       />
+      )}
 
       {showChatModal && (
         <ChatSlideModal

--- a/src/features/mate/pages/MateDetail.tsx
+++ b/src/features/mate/pages/MateDetail.tsx
@@ -24,7 +24,7 @@ export default function MateDetail() {
   const hasLoadedRef = useRef(false);
 
   const currentUserId = getCurrentUserId();
-  const isAuthor = post?.author.id === currentUserId;
+  const isAuthor = post?.author?.id === currentUserId;
   const token = localStorage.getItem("accessToken");
 
   const { withLoginCheck } = useAuthGuard();

--- a/src/features/mate/pages/MateDetail.tsx
+++ b/src/features/mate/pages/MateDetail.tsx
@@ -7,6 +7,7 @@ import type { Post, ApplicationRequest } from "../hooks/mate.types";
 import { getCurrentUserId, calculateDuration, getAgeGroupLabel, getGenderPreferenceLabel, getTransportLabel } from "../hooks/mate.constants";
 import { useMate } from "../hooks/useMate";
 import { isPostExpired } from "../hooks/mate.util";
+import { useAuthGuard } from "../hooks/useAuthGuard";
 import "../styles/MateDetail.css";
 
 export default function MateDetail() {
@@ -25,6 +26,8 @@ export default function MateDetail() {
   const currentUserId = getCurrentUserId();
   const isAuthor = post?.author.id === currentUserId;
   const token = localStorage.getItem("accessToken");
+
+  const { withLoginCheck } = useAuthGuard();
 
   useEffect(() => {
     const loadPost = async () => {
@@ -331,7 +334,7 @@ export default function MateDetail() {
               ) : !showApplyForm ? (
                 <button
                   disabled={hasApplied || post.currentParticipant >= post.maxParticipant}
-                  onClick={() => setShowApplyForm(true)}
+                  onClick={() => withLoginCheck(() => setShowApplyForm(true))}
                   className="apply-button"
                 >
                   {hasApplied ? "Applied" : post.currentParticipant >= post.maxParticipant ? "Full" : "Apply Now"}

--- a/src/features/mate/pages/MateDetail.tsx
+++ b/src/features/mate/pages/MateDetail.tsx
@@ -1,8 +1,7 @@
 import { useState, useEffect, useRef } from "react";
 import { useParams, useNavigate } from "react-router-dom";
-import {
-  ArrowLeft, Heart, Calendar, Users, Wallet, Eye
-} from "lucide-react";
+import { ArrowLeft, Heart, Calendar, Users, Wallet, Eye } from "lucide-react";
+import { LoginPromptModal } from "../components/LoginPromptModal";
 import type { Post, ApplicationRequest } from "../hooks/mate.types";
 import { getCurrentUserId, calculateDuration, getAgeGroupLabel, getGenderPreferenceLabel, getTransportLabel } from "../hooks/mate.constants";
 import { useMate } from "../hooks/useMate";
@@ -27,7 +26,7 @@ export default function MateDetail() {
   const isAuthor = post?.author?.id === currentUserId;
   const token = localStorage.getItem("accessToken");
 
-  const { withLoginCheck } = useAuthGuard();
+  const { withLoginCheck, showLoginModal, closeLoginModal, goToLogin } = useAuthGuard();
 
   useEffect(() => {
     const loadPost = async () => {
@@ -153,6 +152,7 @@ export default function MateDetail() {
   const isExpire = isPostExpired(post);
 
   return (
+    <>
     <div className="mate-detail">
       <div className="max-w-4xl mx-auto px-6 py-16">
         
@@ -180,7 +180,7 @@ export default function MateDetail() {
 
             {/* 좋아요 버튼 (활성화 시 빨간색) */}
             <button
-              onClick={onLikeClick}
+              onClick={() => withLoginCheck(() => onLikeClick)}
               className={`stat-box btn-like ${isLiked ? "active" : ""}`}
             >
               <Heart 
@@ -377,5 +377,10 @@ export default function MateDetail() {
         <div className="py-12"></div>
       </div>
     </div>
+
+    {showLoginModal && (
+      <LoginPromptModal onClose={closeLoginModal} onLogin={goToLogin} />
+    )}
+    </>
   );
 }


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #89

---

## 🎨 작업 내용 (What)
- `useAuthGuard` 훅 생성 (로그인 체크 + 모달 상태 관리)
- `LoginPromptModal` 컴포넌트 생성 (Members Only 안내, 둘러보기/로그인하기 선택)
- `MateHeader` 글쓰기/MY SENT/RECEIVED 버튼에 `withLoginCheck` + 모달 적용
- `MateDetail` Apply Now 버튼에 `withLoginCheck` + 모달 적용
- `MatePostCard` 비로그인 hover 시 "회원 전용 서비스입니다" 안내, 좋아요/PASS 버튼 숨김
- `useMate.ts` 공개 API(fetchPosts, fetchPostDetail, fetchExpiredPosts) 토큰 조건부 헤더 처리, 
인증 필수 API(fetchPassedPosts) 비로그인 시 호출 스킵
- `useChat.ts` 비로그인 시 채팅방 목록 호출 스킵
- 비로그인 시 채팅 FAB 버튼 숨김

---

## 🧭 작업 목적 (Why)
비회원이 페이지 진입 시 401 에러가 콘솔에 다수 발생하고, 인증 필요 버튼 클릭 시 아무 피드백 없이 실패하는 문제 해결. 
기존 `alert` + 페이지 이동 방식 대신 모달로 변경하여, 현재 페이지를 벗어나지 않으면서 로그인을 유도하여 사용자 경험 개선

---

## 🧩 변경 범위
- [x] UI / Layout
- [x] 컴포넌트 구조
- [x] 상태 관리 로직
- [x] API 연동
- [ ] 스타일

---

## 🧪 테스트 방법
- [x] 로컬 실행 확인
- [x] 주요 화면 렌더링 확인
  - 비회원 상태에서 게시글 목록/상세 정상 표시
  - 글쓰기/신청/MY SENT/RECEIVED 클릭 시 LoginPromptModal 표시
  - 모달 "둘러보기" → 현재 페이지 유지, "로그인하기" → 로그인 페이지 이동
  - 비로그인 시 카드 hover → "회원 전용 서비스입니다" 안내
  - 비로그인 시 채팅 FAB 미노출
- [x] 에러 콘솔 확인 (401 에러 없음)

---

## ⚠️ 참고 사항
- `useAuthGuard`는 mate 전용이 아닌 공통 훅으로, 향후 다른 도메인에서도 재사용 가능
- `JwtAuthenticationFilter`에서 잘못된 토큰 시 401 + return 하는 기존 로직은 유지하되, 프론트에서 토큰 없을 때 Authorization 헤더를 보내지 않는 방식으로 우회
- `useCurrentUser` 훅이 현재 리액트 상태 기반이 아닌 localStorage 직접 읽기 방식이라, 추후 Context 전환 시 `useAuthGuard`도 자동으로 개선됨

---

## ✅ 체크리스트
- [x] main 브랜치 직접 push 하지 않음
- [x] feature 브랜치에서 작업함
- [x] 불필요한 console.log 제거
- [x] PR 단위가 과도하게 크지 않음