### PR TITLE
[FE] feature: mate 글쓰기/신청 시 프로필 완성 여부 검증

### DIFF
--- a/src/features/mate/components/MateHeader.tsx
+++ b/src/features/mate/components/MateHeader.tsx
@@ -1,6 +1,7 @@
 import { PenSquare, Inbox, User } from "lucide-react";
 import { useAuthGuard } from "../hooks/useAuthGuard";
 import { LoginPromptModal } from "./LoginPromptModal";
+import { ProfileIncompleteModal } from "./ProfileIncompleteModal";
 import "../styles/MateHeader.css";
 
 interface MateHeaderProps {
@@ -21,7 +22,10 @@ export function MateHeader({
   receivedPendingCount,
 }: MateHeaderProps){
 
-  const { withLoginCheck, showLoginModal, closeLoginModal, goToLogin } = useAuthGuard();
+  const {
+    withLoginCheck, showLoginModal, closeLoginModal, goToLogin,
+    withProfileCheck, showProfileModal, closeProfileModal, goToProfileEdit,
+  } = useAuthGuard();
 
   return (
     <>
@@ -34,7 +38,7 @@ export function MateHeader({
         <div className="flex gap-3">
           <button 
             className="flex items-center gap-2 bg-white text-black px-5 py-2.5 transition-colors font-bold text-sm uppercase tracking-wide button"
-            onClick={() => withLoginCheck(onWriteClick)}
+            onClick={() => withProfileCheck(onWriteClick)}
           >
             <PenSquare className="w-4 h-4" />
             WRITE
@@ -68,6 +72,13 @@ export function MateHeader({
         </div>
       </div>
     </div>
+
+    {showProfileModal && (
+      <ProfileIncompleteModal
+        onClose={closeProfileModal}
+        onGoToEdit={goToProfileEdit}
+      />
+    )}
 
     {showLoginModal && (
       <LoginPromptModal onClose={closeLoginModal} onLogin={goToLogin} />

--- a/src/features/mate/components/ProfileIncompleteModal.tsx
+++ b/src/features/mate/components/ProfileIncompleteModal.tsx
@@ -1,0 +1,44 @@
+// components/ProfileIncompleteModal.tsx
+import "../styles/MateModals.css";
+
+interface ProfileIncompleteModalProps {
+  onClose: () => void;
+  onGoToEdit: () => void;
+}
+
+export function ProfileIncompleteModal({ onClose, onGoToEdit }: ProfileIncompleteModalProps) {
+  return (
+    <div className="modal-overlay active" onMouseDown={(e) => { if (e.target === e.currentTarget) onClose(); }}>
+      <div className="modal-window detail-window" onMouseDown={(e) => e.stopPropagation()}>
+        <div className="modal-header">
+          <span className="mh-title">&gt;&gt; PROFILE INCOMPLETE</span>
+        </div>
+
+        <div className="modal-body" style={{ textAlign: "center", padding: "48px 32px" }}>
+          <p className="text-xl font-black uppercase tracking-tight mb-2">
+            Complete Your Profile
+          </p>
+          <p className="text-sm text-black/50 font-bold mb-8">
+            나이와 성별을 먼저 설정해주세요
+          </p>
+
+          <div className="flex gap-4 justify-center">
+            <button
+              onClick={onClose}
+              className="px-6 py-3 border-3 border-black bg-white font-black uppercase text-sm hover:bg-[#eee] transition-all"
+              style={{ border: "3px solid #000" }}
+            >
+              닫기
+            </button>
+            <button
+              onClick={onGoToEdit}
+              className="px-6 py-3 font-black uppercase text-sm transition-all button bgBlackHoverable"
+            >
+              프로필 설정하기
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/mate/hooks/useAuthGuard.ts
+++ b/src/features/mate/hooks/useAuthGuard.ts
@@ -1,11 +1,14 @@
+// hooks/useAuthGuard.ts
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useCurrentUser } from "../../chat/hooks/useCurrentUser";
+import { getMyInfo } from "../../../api/auth.api";
 
 export function useAuthGuard() {
   const { id } = useCurrentUser();
   const navigate = useNavigate();
   const [showLoginModal, setShowLoginModal] = useState(false);
+  const [showProfileModal, setShowProfileModal] = useState(false);
 
   const withLoginCheck = (callback: () => void) => {
     if (!id) {
@@ -15,12 +18,39 @@ export function useAuthGuard() {
     callback();
   };
 
+  const withProfileCheck = async (callback: () => void) => {
+    if (!id) {
+        setShowLoginModal(true);
+        return;
+    }
+
+    try {
+        const res = await getMyInfo();
+        const { gender, birthDate } = res.data;
+
+        if (!gender || !birthDate) {
+        setShowProfileModal(true);
+        return;
+        }
+        callback();
+    } catch {
+    }
+    };
+
   const closeLoginModal = () => setShowLoginModal(false);
+  const closeProfileModal = () => setShowProfileModal(false);
 
   const goToLogin = () => {
     setShowLoginModal(false);
     navigate("/login");
   };
 
-  return { withLoginCheck, showLoginModal, closeLoginModal, goToLogin };
+  const goToProfileEdit = () => {
+    setShowProfileModal(false);
+    navigate("/setting");
+  };
+
+  return { withLoginCheck, showLoginModal, closeLoginModal, goToLogin,
+    withProfileCheck, showProfileModal, closeProfileModal, goToProfileEdit
+   };
 }

--- a/src/features/mate/pages/MateDetail.tsx
+++ b/src/features/mate/pages/MateDetail.tsx
@@ -7,6 +7,7 @@ import { getCurrentUserId, calculateDuration, getAgeGroupLabel, getGenderPrefere
 import { useMate } from "../hooks/useMate";
 import { isPostExpired } from "../hooks/mate.util";
 import { useAuthGuard } from "../hooks/useAuthGuard";
+import { ProfileIncompleteModal } from "../components/ProfileIncompleteModal";
 import "../styles/MateDetail.css";
 
 export default function MateDetail() {
@@ -26,7 +27,10 @@ export default function MateDetail() {
   const isAuthor = post?.author?.id === currentUserId;
   const token = localStorage.getItem("accessToken");
 
-  const { withLoginCheck, showLoginModal, closeLoginModal, goToLogin } = useAuthGuard();
+  const {
+    withLoginCheck, showLoginModal, closeLoginModal, goToLogin,
+    withProfileCheck, showProfileModal, closeProfileModal, goToProfileEdit,
+  } = useAuthGuard();
 
   useEffect(() => {
     const loadPost = async () => {
@@ -334,7 +338,7 @@ export default function MateDetail() {
               ) : !showApplyForm ? (
                 <button
                   disabled={hasApplied || post.currentParticipant >= post.maxParticipant}
-                  onClick={() => withLoginCheck(() => setShowApplyForm(true))}
+                  onClick={() => withProfileCheck(() => setShowApplyForm(true))}
                   className="apply-button"
                 >
                   {hasApplied ? "Applied" : post.currentParticipant >= post.maxParticipant ? "Full" : "Apply Now"}
@@ -378,6 +382,13 @@ export default function MateDetail() {
       </div>
     </div>
 
+    {showProfileModal && (
+      <ProfileIncompleteModal
+        onClose={closeProfileModal}
+        onGoToEdit={goToProfileEdit}
+      />
+    )}
+    
     {showLoginModal && (
       <LoginPromptModal onClose={closeLoginModal} onLogin={goToLogin} />
     )}


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #91
---
## 🎨 작업 내용 (What)
- useAuthGuard에 withProfileCheck 추가 (GET /users/me 호출하여 gender, birthDate 확인)
- ProfileIncompleteModal 컴포넌트 생성
- MateHeader WRITE 버튼에 withProfileCheck 적용
- MateDetail Apply Now 버튼에 withProfileCheck 적용

---
## 🧭 작업 목적 (Why)

프로필(성별, 생년월일) 미설정 상태에서 글 작성이나 신청이 진행되면 상대방이 매칭 판단에 필요한 정보를 확인할 수 없음 
검증 안 된 사용자를 사전에 차단하고 마이페이지 편집으로 유도하여 데이터 품질을 보장

---
## 🧩 변경 범위
- [x] UI / Layout
- [x] 컴포넌트 구조
- [x] 상태 관리 로직
- [x] API 연동
- [ ] 스타일
---
## 🧪 테스트 방법
- [x] 로컬 실행 확인
- [x] 주요 화면 렌더링 확인
- [x] 에러 콘솔 확인
- 시나리오:
  - 프로필 미설정 → WRITE 클릭 → ProfileIncompleteModal 표시
  - 프로필 미설정 → Apply Now 클릭 → ProfileIncompleteModal 표시
  - 모달에서 "프로필 설정하기" → /mypage/edit 이동
  - 프로필 설정 완료 후 → 정상 진행
  - 비로그인 → LoginPromptModal 우선 표시
---
## ⚠️ 참고 사항
- withProfileCheck는 내부에서 withLoginCheck를 포함하므로, 로그인 체크 → 프로필 체크 순서로 동작
- ProfileIncompleteModal은 LoginPromptModal과 동일 구조 (추후 ConfirmModal로 통합 예정)
- MateHeader에서 미사용 import (useState, useNavigate) 정리
---
## ✅ 체크리스트
- [x] main 브랜치 직접 push 하지 않음
- [x] feature 브랜치에서 작업함
- [x] 불필요한 console.log 제거
- [x] PR 단위가 과도하게 크지 않음