### PR TITLE
[FE] feature: DayDetail 타임라인 UI 및 일정 편집 기능 구현

### DIFF
--- a/src/features/workspace/components/schedule/DayDetailView.tsx
+++ b/src/features/workspace/components/schedule/DayDetailView.tsx
@@ -1,7 +1,9 @@
 //src\features\workspace\components\schedule\DayDetailView.tsx
 
-import React, { useMemo, useState } from "react";
+import React, { useMemo, useState, useEffect, useRef } from "react";
 import PlaceDetailModal from "../schedule/modal/PlaceDetailModal";
+import { useNaverMap } from "../../hooks/useNaverMap";
+import { CATEGORY_COLOR, getCategoryIcon } from "../../hooks/schedule.constants";
 
 interface PlaceInfo {
   name: string;
@@ -21,177 +23,531 @@ interface TimelineNode {
   placeInfo?: PlaceInfo;
 }
 
+interface SavedPlace {
+  id: string;
+  name: string;
+  category: string;
+  address: string;
+  rating?: number;
+  lat?: number;
+  lng?: number;
+}
+
 interface DayDetailViewProps {
   dayTitle: string;
   tripTitle: string;
   startDate: string;
   endDate: string;
   nodes: TimelineNode[];
+  dayKeys?: string[];
+  storageError?: string | null;
   addNode: () => void;
   updateNode: (idx: number, field: string, value: string) => void;
-  rightOpen?: boolean;
-  setRightOpen?: (open: boolean) => void;
+  deleteNode: (idx: number) => void;
+  reorderNodes: (fromIdx: number, toIdx: number) => void;
+  moveNodeToDay: (idx: number, targetDay: string) => void;
 }
 
 const DayDetailView: React.FC<DayDetailViewProps> = ({
   dayTitle,
   tripTitle,
   startDate,
-  endDate,
   nodes,
+  dayKeys = [],
+  storageError = null,
   addNode,
   updateNode,
-  rightOpen,
-  setRightOpen,
+  deleteNode,
+  reorderNodes,
+  moveNodeToDay,
 }) => {
   const [selectedPlace, setSelectedPlace] = useState<PlaceInfo | null>(null);
+  const [mapSelectedPlace, setMapSelectedPlace] = useState<SavedPlace | null>(null);
 
-  // DAY 1, DAY 2 등에서 숫자 추출하여 해당 날짜 계산
+  const { mapLoaded, mapKey } = useNaverMap();
+
+  const mapRef = useRef<HTMLDivElement>(null);
+  const mapInstanceRef = useRef<any>(null);
+  const markersRef = useRef<any[]>([]);
+  const infoWindowRef = useRef<any>(null);
+
+  // saved_places에서 lat/lng 참조 — storage 변경도 감지
+  const [savedPlaces, setSavedPlaces] = useState<SavedPlace[]>([]);
+
+  useEffect(() => {
+    const load = () => {
+      const saved = localStorage.getItem("saved_places");
+      if (saved) {
+        try {
+          const parsed = JSON.parse(saved);
+          if (Array.isArray(parsed)) setSavedPlaces(parsed);
+        } catch { /* 파싱 실패 무시 */ }
+      }
+    };
+    load();
+    window.addEventListener("storage", load);
+    return () => window.removeEventListener("storage", load);
+  }, []);
+
+  const dragFromIdx = React.useRef<number | null>(null);
+  const [dragOverIdx, setDragOverIdx] = useState<number | null>(null);
+  const [isEditing, setIsEditing] = useState(false);
+  const [lockTooltipIdx, setLockTooltipIdx] = useState<number | null>(null);
+
+  // 현재 날짜 계산
   const currentDate = useMemo(() => {
     const dayMatch = dayTitle.match(/DAY\s*(\d+)/i);
     if (!dayMatch) return startDate;
-    
     const dayNumber = parseInt(dayMatch[1], 10);
     const start = new Date(startDate);
-    
-    // dayNumber - 1일을 더함 (DAY 1 = 첫날, DAY 2 = 둘째날)
     start.setDate(start.getDate() + (dayNumber - 1));
-    
-    return start.toISOString().split('T')[0];
+    return start.toISOString().split("T")[0];
   }, [dayTitle, startDate]);
 
-  // 노드 클릭 핸들러
+  // 노드에서 좌표를 가진 장소만 추출 (saved_places 매칭)
+  const mapPlaces = useMemo(() => {
+    return nodes
+      .filter((n) => n.placeInfo?.name)
+      .map((n, idx) => {
+        const matched = savedPlaces.find(
+          (sp) => sp.name === n.placeInfo!.name
+        );
+        return matched
+          ? { ...matched, _idx: idx, _time: n.time }
+          : null;
+      })
+      .filter((p): p is SavedPlace & { _idx: number; _time: string } => p !== null && p.lat != null && p.lng != null);
+  }, [nodes, savedPlaces]);
+
+  // 지도 초기화 및 마커 그리기
+  useEffect(() => {
+    if (!mapLoaded || !mapRef.current) return;
+
+    if (!mapInstanceRef.current) {
+      const initialCenter = mapPlaces.length > 0
+        ? new window.naver.maps.LatLng(mapPlaces[0].lat!, mapPlaces[0].lng!)
+        : new window.naver.maps.LatLng(37.5665, 126.978);
+
+      const map = new window.naver.maps.Map(mapRef.current, {
+        center: initialCenter,
+        zoom: 12,
+        mapTypeControl: false,
+        scaleControl: false,
+        logoControl: false,
+        mapDataControl: false,
+      });
+
+      infoWindowRef.current = new window.naver.maps.InfoWindow({
+        anchorSkew: true,
+        backgroundColor: "#fff",
+        borderColor: "#000",
+        borderWidth: 2,
+        pixelOffset: new window.naver.maps.Point(0, -10),
+      });
+
+      mapInstanceRef.current = map;
+    }
+
+    drawMarkers(mapPlaces);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mapLoaded, mapPlaces]);
+
+  const clearMarkers = () => {
+    markersRef.current.forEach((m) => m.setMap(null));
+    markersRef.current = [];
+    infoWindowRef.current?.close();
+  };
+
+  const drawMarkers = (places: (SavedPlace & { _idx: number; _time: string })[]) => {
+    if (!mapInstanceRef.current || !window.naver) return;
+    clearMarkers();
+
+    if (!places.length) return;
+
+    const bounds = new window.naver.maps.LatLngBounds();
+
+    places.forEach((place, i) => {
+      const pos = new window.naver.maps.LatLng(place.lat!, place.lng!);
+      const color = CATEGORY_COLOR[place.category] || "#333";
+
+      const marker = new window.naver.maps.Marker({
+        position: pos,
+        map: mapInstanceRef.current,
+        icon: {
+          content: `
+            <div style="
+              background:${color};color:#fff;
+              border:2px solid #fff;border-radius:50% 50% 50% 0;
+              transform:rotate(-45deg);width:30px;height:30px;
+              display:flex;align-items:center;justify-content:center;
+              box-shadow:0 2px 6px rgba(0,0,0,0.35);cursor:pointer;
+              font-size:11px;font-weight:bold;">
+              <span style="transform:rotate(45deg)">${i + 1}</span>
+            </div>`,
+          anchor: new window.naver.maps.Point(15, 30),
+        },
+        zIndex: 100,
+      });
+
+      window.naver.maps.Event.addListener(marker, "click", () => {
+        infoWindowRef.current.setContent(`
+          <div style="padding:12px 16px;min-width:180px;max-width:240px;font-family:inherit">
+            <div style="display:flex;align-items:center;gap:6px;margin-bottom:6px">
+              <span style="background:${color};color:#fff;padding:2px 7px;border-radius:3px;font-size:11px;font-weight:bold">
+                ${getCategoryIcon(place.category)} ${place.category}
+              </span>
+              ${place.rating ? `<span style="font-size:12px;color:#ff9800;font-weight:bold">⭐ ${place.rating}</span>` : ""}
+            </div>
+            <div style="font-size:11px;color:#888;margin-bottom:2px">${place._time}</div>
+            <div style="font-weight:bold;font-size:14px;margin-bottom:4px">${place.name}</div>
+            <div style="font-size:11px;color:#666">${place.address || ""}</div>
+          </div>
+        `);
+        infoWindowRef.current.open(mapInstanceRef.current, marker);
+        setMapSelectedPlace(place);
+      });
+
+      bounds.extend(pos);
+      markersRef.current.push(marker);
+    });
+
+    if (places.length === 1) {
+      mapInstanceRef.current.setCenter(new window.naver.maps.LatLng(places[0].lat!, places[0].lng!));
+      mapInstanceRef.current.setZoom(15);
+    } else {
+      mapInstanceRef.current.fitBounds(bounds, { top: 60, right: 40, bottom: 80, left: 40 });
+    }
+  };
+
   const handleNodeClick = (node: TimelineNode) => {
     if (node.placeInfo) {
-      setSelectedPlace({
-        ...node.placeInfo,
-        time: node.time,
-      });
+      setSelectedPlace({ ...node.placeInfo, time: node.time });
     }
   };
 
   return (
-    <div>
-      {/* 헤더 영역 */}
-      <div style={{ 
-        display: "flex", 
-        justifyContent: "space-between", 
-        alignItems: "center",
-        marginBottom: "10px" 
-      }}>
-        <h2 style={{ fontSize: "24px", fontWeight: 800, margin: 0 }}>
-          {dayTitle}
-        </h2>
+    <>
+      <div style={{ display: "flex", flexDirection: "column", height: "calc(100vh - 120px)", minHeight: 0 }}>
 
-        {/* 오른쪽 사이드바 토글 버튼 */}
-        {setRightOpen && (
-          <button
-            onClick={() => setRightOpen(!rightOpen)}
-            style={{
-              padding: "8px 16px",
-              background: rightOpen ? "#000" : "#fff",
-              color: rightOpen ? "#fff" : "#000",
-              border: "2px solid #000",
-              borderRadius: "6px",
-              fontWeight: "bold",
-              fontSize: "13px",
-              cursor: "pointer",
-              transition: "all 0.2s",
-            }}
-            onMouseEnter={(e) => {
-              if (!rightOpen) {
-                e.currentTarget.style.background = "#f0f0f0";
-              }
-            }}
-            onMouseLeave={(e) => {
-              if (!rightOpen) {
-                e.currentTarget.style.background = "#fff";
-              }
-            }}
-          >
-            {/* {rightOpen ? "🗂️ 사이드바 닫기" : "🗂️ 사이드바 열기"} */}
-            {rightOpen ? "🗺️ 지도 · 체크리스트 닫기" : "🗺️ 지도 · 체크리스트 열기"}
-
-          </button>
+        {/* ── 저장 오류 배너 ── */}
+        {storageError && (
+          <div style={{
+            flexShrink: 0,
+            marginBottom: "12px",
+            padding: "10px 16px",
+            background: "#ffebee",
+            border: "2px solid #e53935",
+            borderRadius: "6px",
+            fontSize: "13px",
+            color: "#c62828",
+            display: "flex",
+            alignItems: "center",
+            gap: "8px",
+          }}>
+            ⚠️ {storageError}
+          </div>
         )}
-      </div>
 
-      <p
-        style={{
-          color: "#666",
-          marginBottom: "30px",
-          fontFamily: "var(--font-mono)",
-        }}
-      >
-        {currentDate}
-      </p>
-
-      <div className="timeline">
-        {nodes.map((n, idx) => (
-          <div className="tl-item" key={idx}>
-            <div className="tl-dot"></div>
-
-            <div className="tl-time">
-              {n.time}
-            </div>
-
-            <div 
-              className="tl-box"
-              onClick={() => handleNodeClick(n)}
+        {/* ── 헤더 ── */}
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "16px", flexShrink: 0 }}>
+          <div>
+            <h2 style={{ fontSize: "24px", fontWeight: 800, margin: 0 }}>{dayTitle}</h2>
+            <p style={{ color: "#999", marginTop: "4px", fontFamily: "var(--font-mono)", fontSize: "12px" }}>
+              {currentDate}
+            </p>
+          </div>
+          <div style={{ display: "flex", gap: "10px" }}>
+            {isEditing && (
+              <button
+                onClick={addNode}
+                style={{ padding: "10px 20px", background: "#fff", color: "#000", border: "2px solid #000", fontWeight: "bold", fontSize: "14px", cursor: "pointer", borderRadius: "4px" }}
+              >
+                + 노드 추가
+              </button>
+            )}
+            <button
+              onClick={() => setIsEditing((v) => !v)}
               style={{
-                cursor: "pointer",
-                transition: "all 0.2s",
-              }}
-              onMouseEnter={(e) => {
-                e.currentTarget.style.transform = "translateX(5px)";
-                e.currentTarget.style.boxShadow = "4px 4px 0px rgba(0, 0, 0, 0.1)";
-              }}
-              onMouseLeave={(e) => {
-                e.currentTarget.style.transform = "translateX(0)";
-                e.currentTarget.style.boxShadow = "none";
+                padding: "10px 20px",
+                background: isEditing ? "#000" : "#fff",
+                color: isEditing ? "#fff" : "#000",
+                border: "2px solid #000",
+                fontWeight: "bold", fontSize: "14px", cursor: "pointer", borderRadius: "4px",
               }}
             >
-              <div style={{ fontWeight: "bold", fontSize: "16px" }}>
-                {n.title}
-              </div>
+              {isEditing ? "✓ 완료" : "✏️ 일정 수정하기"}
+            </button>
+          </div>
+        </div>
 
-              <div
-                style={{
-                  fontSize: "13px",
-                  color: "#555",
-                  marginTop: "5px",
-                }}
-              >
-                {n.desc}
-              </div>
+        {/* ── 바디: 타임라인 + 지도 ── */}
+        <div style={{ display: "flex", gap: "16px", flex: 1, minHeight: 0, overflow: "hidden" }}>
+
+          {/* ── 왼쪽: 타임라인 노드 ── */}
+          <div style={{ width: isEditing ? "640px" : "440px", flexShrink: 0, display: "flex", flexDirection: "column", minHeight: 0, transition: "width 0.25s ease" }}>
+            <div style={{ flex: 1, overflowY: "auto", display: "flex", flexDirection: "column", gap: "0" }}>
+              {nodes.length === 0 ? (
+                <div style={{ textAlign: "center", padding: "60px 20px", color: "#bbb" }}>
+                  <p style={{ fontSize: "28px", marginBottom: "8px" }}>📅</p>
+                  <p style={{ fontSize: "13px" }}>아직 추가된 노드가 없습니다</p>
+                </div>
+              ) : (
+                nodes.map((n, idx) => {
+                  const color = CATEGORY_COLOR[n.placeInfo?.category ?? ""] || "#d0d0d0";
+                  const hasCategory = !!n.placeInfo?.category;
+                  const icon = hasCategory ? getCategoryIcon(n.placeInfo!.category!) : null;
+                  const isFixed = n.placeInfo?.category === "출발지" || n.placeInfo?.category === "숙소";
+
+                  return (
+                    <div key={idx} style={{ display: "flex", alignItems: "stretch", minWidth: 0, overflow: "hidden" }}>
+                      {/* 시간 */}
+                      <div style={{
+                        width: "54px",
+                        flexShrink: 0,
+                        paddingTop: "15px",
+                        textAlign: "right",
+                        paddingRight: "12px",
+                        fontSize: "11px",
+                        fontFamily: "var(--font-mono)",
+                        color: "#aaa",
+                        lineHeight: 1,
+                      }}>
+                        {n.time}
+                      </div>
+
+                      {/* 타임라인 축 */}
+                      <div style={{
+                        display: "flex",
+                        flexDirection: "column",
+                        alignItems: "center",
+                        width: "20px",
+                        flexShrink: 0,
+                      }}>
+                        <div style={{
+                          width: "12px",
+                          height: "12px",
+                          borderRadius: "50%",
+                          background: hasCategory ? color : "#ddd",
+                          border: `2px solid ${hasCategory ? color : "#ccc"}`,
+                          marginTop: "14px",
+                          flexShrink: 0,
+                          zIndex: 1,
+                          boxShadow: hasCategory ? `0 0 0 3px ${color}22` : "none",
+                        }} />
+                        {idx < nodes.length - 1 && (
+                          <div style={{
+                            width: "2px",
+                            flex: 1,
+                            minHeight: "24px",
+                            background: "linear-gradient(to bottom, #e0e0e0, #efefef)",
+                            marginTop: "4px",
+                          }} />
+                        )}
+                      </div>
+
+                      {/* 카드 */}
+                      <div
+                        className="tl-box"
+                        draggable={isEditing && !isFixed}
+                        onDragStart={() => { if (isEditing && !isFixed) dragFromIdx.current = idx; }}
+                        onDragOver={(e) => { if (isEditing && !isFixed) { e.preventDefault(); setDragOverIdx(idx); } }}
+                        onDragLeave={() => setDragOverIdx(null)}
+                        onDrop={() => {
+                          if (dragFromIdx.current !== null && dragFromIdx.current !== idx) {
+                            reorderNodes(dragFromIdx.current, idx);
+                          }
+                          dragFromIdx.current = null;
+                          setDragOverIdx(null);
+                        }}
+                        onDragEnd={() => { dragFromIdx.current = null; setDragOverIdx(null); }}
+                        style={{
+                          flex: 1,
+                          minWidth: 0,
+                          marginLeft: "12px",
+                          marginBottom: "12px",
+                          padding: "13px 16px",
+                          display: "flex",
+                          alignItems: "center",
+                          gap: "12px",
+                          cursor: (isEditing && !isFixed) ? "grab" : "default",
+                          background: (dragOverIdx === idx && !isFixed) ? "#f0f0f0" : "#fff",
+                          borderTop: (dragOverIdx === idx && !isFixed) ? "2px dashed #000" : "1px solid #eee",
+                          borderRight: (dragOverIdx === idx && !isFixed) ? "2px dashed #000" : "1px solid #eee",
+                          borderBottom: (dragOverIdx === idx && !isFixed) ? "2px dashed #000" : "1px solid #eee",
+                          borderLeft: `4px solid ${hasCategory ? color : "#e0e0e0"}`,
+                          borderRadius: "0 6px 6px 0",
+                          transition: "background 0.1s, border 0.1s",
+                          userSelect: "none",
+                        }}
+                      >
+                        {/* 드래그 핸들 — 편집 모드 + 고정 아닐 때만 */}
+                        {isEditing && !isFixed && (
+                          <span style={{ fontSize: "14px", color: "#ccc", flexShrink: 0, cursor: "grab" }}>⠿</span>
+                        )}
+                        {/* 고정 노드 표시 */}
+                        {isEditing && isFixed && (
+                          <span
+                            style={{ position: "relative", fontSize: "11px", color: "#bbb", flexShrink: 0, cursor: "help" }}
+                            onMouseEnter={() => setLockTooltipIdx(idx)}
+                            onMouseLeave={() => setLockTooltipIdx(null)}
+                          >
+                            🔒
+                            {lockTooltipIdx === idx && (
+                              <span style={{
+                                position: "absolute", bottom: "calc(100% + 6px)", left: "50%",
+                                transform: "translateX(-50%)",
+                                background: "#333", color: "#fff",
+                                padding: "5px 10px", borderRadius: "4px",
+                                fontSize: "11px", whiteSpace: "nowrap",
+                                pointerEvents: "none", zIndex: 100,
+                              }}>
+                                {n.placeInfo?.category === "숙소" ? "숙소" : "출발지"}는 순서 변경이 불가합니다
+                              </span>
+                            )}
+                          </span>
+                        )}
+
+                        {icon && (
+                          <span style={{ fontSize: "18px", flexShrink: 0, lineHeight: 1 }}>{icon}</span>
+                        )}
+
+                        {/* 클릭 시 상세 모달 */}
+                        <div
+                          style={{ flex: 1, minWidth: 0, cursor: (!isEditing && n.placeInfo) ? "pointer" : "default" }}
+                          onClick={() => { if (!isEditing) handleNodeClick(n); }}
+                        >
+                          <div style={{ display: "flex", alignItems: "center", gap: "8px", marginBottom: "3px" }}>
+                            <h3 style={{ fontSize: "14px", fontWeight: "700", margin: 0, overflow: "hidden", textOverflow: isEditing ? "unset" : "ellipsis", whiteSpace: isEditing ? "normal" : "nowrap", color: "#111" }}>
+                              {n.title}
+                            </h3>
+                            {n.placeInfo?.rating && (
+                              <span style={{ fontSize: "11px", color: "#ff9800", flexShrink: 0 }}>⭐ {n.placeInfo.rating}</span>
+                            )}
+                          </div>
+                          <p style={{ fontSize: "12px", color: "#aaa", margin: 0, overflow: "hidden", textOverflow: isEditing ? "unset" : "ellipsis", whiteSpace: isEditing ? "normal" : "nowrap", lineHeight: 1.5 }}>
+                            {n.desc}
+                          </p>
+                        </div>
+
+                        {n.placeInfo?.category && (
+                          <span style={{ fontSize: "11px", fontWeight: "600", flexShrink: 0, color, padding: "3px 10px", border: `1.5px solid ${color}`, borderRadius: "20px", background: `${color}10` }}>
+                            {n.placeInfo.category}
+                          </span>
+                        )}
+
+                        {/* 날짜 이동 + 삭제 — 편집 모드 + 고정 아닐 때만 */}
+                        {isEditing && !isFixed && (
+                          <>
+                            {dayKeys.filter((d) => d !== dayTitle).length > 0 && (
+                              <select
+                                value=""
+                                onChange={(e) => {
+                                  if (e.target.value) moveNodeToDay(idx, e.target.value);
+                                }}
+                                onClick={(e) => e.stopPropagation()}
+                                style={{ padding: "3px 6px", border: "1.5px solid #ddd", borderRadius: "4px", fontSize: "11px", color: "#888", cursor: "pointer", background: "#fff", flexShrink: 0 }}
+                              >
+                                <option value="">이동 ▸</option>
+                                {dayKeys.filter((d) => d !== dayTitle).map((d) => (
+                                  <option key={d} value={d}>{d}</option>
+                                ))}
+                              </select>
+                            )}
+                            <button
+                              onClick={(e) => { e.stopPropagation(); deleteNode(idx); }}
+                              style={{ padding: "3px 8px", background: "#fff", color: "#ccc", border: "1.5px solid #eee", borderRadius: "4px", fontSize: "12px", cursor: "pointer", flexShrink: 0, lineHeight: 1 }}
+                              onMouseEnter={(e) => { e.currentTarget.style.color = "#e53935"; e.currentTarget.style.borderColor = "#e53935"; }}
+                              onMouseLeave={(e) => { e.currentTarget.style.color = "#ccc"; e.currentTarget.style.borderColor = "#eee"; }}
+                            >
+                              ✕
+                            </button>
+                          </>
+                        )}
+                      </div>
+                    </div>
+                  );
+                })
+              )}
             </div>
           </div>
-        ))}
 
-        <button
-          style={{
-            width: "100%",
-            border: "2px dashed #ccc",
-            padding: "15px",
-            fontWeight: "bold",
-            color: "#999",
-            cursor: "pointer",
-            background: "transparent",
-          }}
-          onClick={addNode}
-        >
-          + ADD NODE
-        </button>
+          {/* ── 오른쪽: 지도 ── */}
+          <div style={{
+            flex: 1,
+            position: "relative",
+            border: "2px solid #000",
+            borderRadius: "8px",
+            overflow: "hidden",
+            minHeight: 0,
+          }}>
+            <div ref={mapRef} style={{ width: "100%", height: "100%" }} />
+
+            {!mapLoaded && (
+              <div style={{ position: "absolute", inset: 0, display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", background: "#f5f5f5", color: "#999" }}>
+                <p style={{ fontSize: "28px", marginBottom: "8px" }}>🗺️</p>
+                <p style={{ fontSize: "13px" }}>{mapKey ? "지도 로딩 중..." : "지도 키가 설정되지 않았습니다"}</p>
+              </div>
+            )}
+
+            {mapLoaded && mapPlaces.length === 0 && (
+              <div style={{ position: "absolute", inset: 0, display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", background: "rgba(255,255,255,0.9)", color: "#bbb" }}>
+                <p style={{ fontSize: "32px", marginBottom: "10px" }}>🗺️</p>
+                <p style={{ fontSize: "13px" }}>표시할 장소가 없습니다</p>
+              </div>
+            )}
+
+            {/* 좌표 없는 장소 안내 */}
+            {mapLoaded && mapPlaces.length > 0 && mapPlaces.length < nodes.filter(n => n.placeInfo?.name).length && (
+              <div style={{ position: "absolute", top: "12px", left: "50%", transform: "translateX(-50%)", background: "rgba(0,0,0,0.65)", color: "#fff", padding: "5px 14px", borderRadius: "14px", fontSize: "11px", pointerEvents: "none", whiteSpace: "nowrap" }}>
+                📍 {mapPlaces.length}/{nodes.filter(n => n.placeInfo?.name).length}개 표시 중 (좌표 없는 장소 제외)
+              </div>
+            )}
+
+            {mapSelectedPlace && (
+              <div style={{ position: "absolute", bottom: 0, left: 0, right: 0, background: "#fff", borderTop: "2px solid #000", padding: "12px 20px", display: "flex", alignItems: "center", gap: "12px" }}>
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ display: "flex", alignItems: "center", gap: "8px", marginBottom: "3px" }}>
+                    <span style={{ fontSize: "13px", fontWeight: "bold", color: CATEGORY_COLOR[mapSelectedPlace.category] || "#333" }}>
+                      {getCategoryIcon(mapSelectedPlace.category)} {mapSelectedPlace.category}
+                    </span>
+                    <span style={{ fontWeight: "bold", fontSize: "14px" }}>{mapSelectedPlace.name}</span>
+                  </div>
+                  <p style={{ fontSize: "12px", color: "#888", margin: 0 }}>📍 {mapSelectedPlace.address}</p>
+                </div>
+                <button
+                  onClick={() => setMapSelectedPlace(null)}
+                  style={{ padding: "6px 14px", background: "#fff", color: "#000", border: "2px solid #000", borderRadius: "5px", fontWeight: "bold", fontSize: "12px", cursor: "pointer", flexShrink: 0 }}
+                >
+                  닫기
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
       </div>
 
-      {/* 장소 상세 정보 모달 */}
+      {/* 장소 상세 모달 */}
       {selectedPlace && (
         <PlaceDetailModal
           placeInfo={selectedPlace}
           onClose={() => setSelectedPlace(null)}
+          onViewOnMap={() => {
+            // 지도 마커와 연동: 같은 이름의 장소를 mapSelectedPlace로 설정
+            const matched = mapPlaces.find((p) => p.name === selectedPlace.name);
+            if (matched) {
+              setMapSelectedPlace(matched);
+              if (mapInstanceRef.current && matched.lat != null && matched.lng != null) {
+                mapInstanceRef.current.setCenter(
+                  new window.naver.maps.LatLng(matched.lat, matched.lng)
+                );
+                mapInstanceRef.current.setZoom(16);
+              }
+            }
+            setSelectedPlace(null);
+          }}
         />
       )}
-    </div>
+    </>
   );
 };
 

--- a/src/features/workspace/hooks/useTimeline.ts
+++ b/src/features/workspace/hooks/useTimeline.ts
@@ -1,17 +1,102 @@
-//src\features\workspace\hooks\useTimeline.ts
+// src/features/workspace/hooks/useTimeline.ts
+import { useEffect, useState, useCallback } from "react";
+import { STORAGE_KEYS, STORAGE_SCHEMA_VERSION } from "../hooks/schedule.constants";
 
-import { useEffect, useState } from "react";
+interface PlaceInfo {
+  name: string;
+  address?: string;
+  category?: string;
+  description?: string;
+  memo?: string;
+  imageUrl?: string;
+  rating?: number;
+}
 
-interface TimelineNode {
+export interface TimelineNode {
   time: string;
   title: string;
   desc: string;
+  placeInfo?: PlaceInfo;
 }
 
-const STORAGE_KEY = "tripmoa_timeline_data";
+// ─── localStorage 안전 헬퍼 ──────────────────────────────────
+
+function safeGetStorage(key: string): string | null {
+  try {
+    return localStorage.getItem(key);
+  } catch (e) {
+    console.warn(`[useTimeline] localStorage.getItem("${key}") 실패:`, e);
+    return null;
+  }
+}
+
+function safeSetStorage(key: string, value: string): boolean {
+  try {
+    localStorage.setItem(key, value);
+    return true;
+  } catch (e) {
+    // QuotaExceededError 등
+    console.error(`[useTimeline] localStorage.setItem("${key}") 실패:`, e);
+    return false;
+  }
+}
+
+function safeParseJSON<T>(raw: string | null, fallback: T): T {
+  if (!raw) return fallback;
+  try {
+    return JSON.parse(raw) as T;
+  } catch (e) {
+    console.warn("[useTimeline] JSON 파싱 실패:", e);
+    return fallback;
+  }
+}
+
+// ─── 스키마 마이그레이션 ─────────────────────────────────────
+// 버전이 다를 경우 기존 데이터를 안전하게 초기화하고 버전을 갱신합니다.
+
+function runMigrationIfNeeded(): void {
+  const savedVersion = safeParseJSON<number>(
+    safeGetStorage(STORAGE_KEYS.SCHEMA_VERSION),
+    0
+  );
+
+  if (savedVersion < STORAGE_SCHEMA_VERSION) {
+    console.info(
+      `[useTimeline] 스키마 마이그레이션: v${savedVersion} → v${STORAGE_SCHEMA_VERSION}`
+    );
+    // v1 이하: 타임라인/날짜 데이터 구조 변경 가능성 — 기존 데이터 초기화
+    if (savedVersion < 2) {
+      // 기존 타임라인 데이터는 유지하되 구조가 맞는지 검증
+      const raw = safeGetStorage(STORAGE_KEYS.TIMELINE);
+      const data = safeParseJSON<Record<string, unknown>>(raw, {});
+      const isValid =
+        typeof data === "object" &&
+        !Array.isArray(data) &&
+        Object.values(data).every((v) => Array.isArray(v));
+
+      if (!isValid) {
+        console.warn("[useTimeline] 기존 타임라인 데이터 구조 불일치 — 초기화");
+        safeSetStorage(STORAGE_KEYS.TIMELINE, "{}");
+        safeSetStorage(STORAGE_KEYS.DATE_LOGS, "[]");
+      }
+    }
+    safeSetStorage(
+      STORAGE_KEYS.SCHEMA_VERSION,
+      JSON.stringify(STORAGE_SCHEMA_VERSION)
+    );
+  }
+}
+
+// ─── 훅 본체 ────────────────────────────────────────────────
 
 export const useTimeline = (currentDay: string) => {
   const [nodes, setNodes] = useState<TimelineNode[]>([]);
+  const [storageError, setStorageError] = useState<string | null>(null);
+
+  // 앱 첫 마운트 시 마이그레이션 실행
+  useEffect(() => {
+    runMigrationIfNeeded();
+  }, []);
 
   /* =========================
      1️⃣ DAY 변경 시 저장된 일정 불러오기
@@ -22,19 +107,9 @@ export const useTimeline = (currentDay: string) => {
       return;
     }
 
-    const saved = localStorage.getItem(STORAGE_KEY);
-    if (!saved) {
-      setNodes([]);
-      return;
-    }
-
-    try {
-      const parsed = JSON.parse(saved);
-      setNodes(parsed[currentDay] || []);
-    } catch (e) {
-      console.error("timeline load error", e);
-      setNodes([]);
-    }
+    const raw = safeGetStorage(STORAGE_KEYS.TIMELINE);
+    const data = safeParseJSON<Record<string, TimelineNode[]>>(raw, {});
+    setNodes(data[currentDay] ?? []);
   }, [currentDay]);
 
   /* =========================
@@ -43,35 +118,125 @@ export const useTimeline = (currentDay: string) => {
   useEffect(() => {
     if (!currentDay || currentDay === "DAY ALL") return;
 
-    const saved = localStorage.getItem(STORAGE_KEY);
-    const data = saved ? JSON.parse(saved) : {};
-
+    const raw = safeGetStorage(STORAGE_KEYS.TIMELINE);
+    const data = safeParseJSON<Record<string, TimelineNode[]>>(raw, {});
     data[currentDay] = nodes;
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+
+    const ok = safeSetStorage(STORAGE_KEYS.TIMELINE, JSON.stringify(data));
+    if (!ok) {
+      setStorageError(
+        "저장 공간이 부족합니다. 일정이 저장되지 않을 수 있습니다."
+      );
+    } else {
+      setStorageError(null);
+    }
   }, [nodes, currentDay]);
 
   /* =========================
      3️⃣ 노드 추가
   ========================= */
-  const addNode = () => {
-    setNodes((prev) => [
-      ...prev,
-      { time: "00:00", title: "NEW", desc: "" },
-    ]);
-  };
+  const addNode = useCallback(() => {
+    setNodes((prev) => [...prev, { time: "00:00", title: "NEW", desc: "" }]);
+  }, []);
 
   /* =========================
      4️⃣ 노드 수정
   ========================= */
-  const updateNode = (idx: number, field: string, value: string) => {
-    setNodes((prev) =>
-      prev.map((n, i) => (i === idx ? { ...n, [field]: value } : n))
-    );
-  };
+  const updateNode = useCallback(
+    (idx: number, field: string, value: string) => {
+      setNodes((prev) =>
+        prev.map((n, i) => (i === idx ? { ...n, [field]: value } : n))
+      );
+    },
+    []
+  );
+
+  /* =========================
+     5️⃣ 노드 삭제
+  ========================= */
+  const deleteNode = useCallback((idx: number) => {
+    setNodes((prev) => prev.filter((_, i) => i !== idx));
+  }, []);
+
+  /* =========================
+     6️⃣ 노드 순서 변경 (드래그앤드롭 결과 반영)
+  ========================= */
+  const reorderNodes = useCallback((fromIdx: number, toIdx: number) => {
+    setNodes((prev) => {
+      const next = [...prev];
+      const [moved] = next.splice(fromIdx, 1);
+      next.splice(toIdx, 0, moved);
+      return next;
+    });
+  }, []);
+
+  /* =========================
+     7️⃣ 노드를 다른 날로 이동
+  ========================= */
+  const moveNodeToDay = useCallback(
+    (idx: number, targetDay: string) => {
+      const node = nodes[idx];
+      if (!node) return;
+
+      const nextNodes = nodes.filter((_, i) => i !== idx);
+      setNodes(nextNodes);
+
+      const raw = safeGetStorage(STORAGE_KEYS.TIMELINE);
+      const data = safeParseJSON<Record<string, TimelineNode[]>>(raw, {});
+      data[currentDay] = nextNodes;
+      data[targetDay] = [...(data[targetDay] ?? []), node];
+
+      const ok = safeSetStorage(STORAGE_KEYS.TIMELINE, JSON.stringify(data));
+      if (!ok) {
+        setStorageError(
+          "저장 공간이 부족합니다. 일정 이동이 저장되지 않을 수 있습니다."
+        );
+      }
+    },
+    [nodes, currentDay]
+  );
+
+  /* =========================
+     8️⃣ 외부 데이터로 타임라인 교체 (AI 생성 결과 반영)
+        페이지 새로고침 없이 상태 직접 업데이트
+  ========================= */
+  const loadFromExternal = useCallback(
+    (allDaysData: Record<string, TimelineNode[]>) => {
+      const raw = safeGetStorage(STORAGE_KEYS.TIMELINE);
+      const existing = safeParseJSON<Record<string, TimelineNode[]>>(raw, {});
+      const merged = { ...existing, ...allDaysData };
+
+      const ok = safeSetStorage(
+        STORAGE_KEYS.TIMELINE,
+        JSON.stringify(merged)
+      );
+      if (!ok) {
+        setStorageError(
+          "저장 공간이 부족합니다. 일정이 저장되지 않을 수 있습니다."
+        );
+        return;
+      }
+      setStorageError(null);
+
+      if (
+        currentDay &&
+        currentDay !== "DAY ALL" &&
+        allDaysData[currentDay]
+      ) {
+        setNodes(allDaysData[currentDay]);
+      }
+    },
+    [currentDay]
+  );
 
   return {
     nodes,
+    storageError,   // 컴포넌트에서 에러 배너 표시용
     addNode,
     updateNode,
+    deleteNode,
+    reorderNodes,
+    moveNodeToDay,
+    loadFromExternal,
   };
 };

--- a/src/features/workspace/pages/Workspace.tsx
+++ b/src/features/workspace/pages/Workspace.tsx
@@ -1,6 +1,6 @@
 // src\features\workspace\pages\Workspace.tsx
 
-import { useState, useEffect } from "react";
+import { useEffect } from "react";
 import "../styles/layout.css";
 import {
   WorkspaceCoreProvider,
@@ -10,21 +10,17 @@ import {
 import WorkspaceLayout from "../components/layout/WorkspaceLayout";
 import WorkspaceSidebar from "../components/layout/WorkspaceSidebar";
 import WorkspaceCenter from "../components/layout/WorkspaceCenter";
-import WorkspaceRight from "../components/layout/WorkspaceRight";
 import { useNotices } from "../hooks/useNotices";
 
 /* =========================
    Provider 내부 실제 UI
 ========================= */
 const WorkspaceContent: React.FC = () => {
-  const { activeView, currentDay } = useWorkspaceCore();
-  const [rightOpen, setRightOpen] = useState(true);
+  const { activeView } = useWorkspaceCore();
 
-  // 2열로 써야 하는 화면
-  // timeline은 DAY ALL일 때만 2열, DAY 1/DAY 2 등은 rightOpen 상태에 따라
+  // timeline 포함 모든 뷰가 2열 (오른쪽 사이드바 미사용)
   const isTwoColumn =
-    !rightOpen ||
-    (activeView === "timeline" && currentDay === "DAY ALL") || // ✅ DAY ALL만 무조건 2열
+    activeView === "timeline" ||
     activeView === "expenses" ||
     activeView === "voucher" ||
     activeView === "notice";
@@ -36,7 +32,7 @@ const WorkspaceContent: React.FC = () => {
       <WorkspaceLayout>
         <WorkspaceSidebar />
 
-        {/* 🔥 핵심: 2열 화면일 때 center가 오른쪽 칸까지 먹음 */}
+        {/* 핵심: 2열 화면일 때 center가 오른쪽 칸까지 먹음 */}
         <div
           style={
             isTwoColumn
@@ -44,15 +40,10 @@ const WorkspaceContent: React.FC = () => {
               : undefined
           }
         >
-          <WorkspaceCenter
-            noticeStore={noticeStore}
-            rightOpen={rightOpen}
-            setRightOpen={setRightOpen}
-          />
+          <WorkspaceCenter noticeStore={noticeStore} />
         </div>
 
-        {/* 3열 화면에서만 Right 렌더 */}
-        {!isTwoColumn && rightOpen && <WorkspaceRight />}
+        {/* WorkspaceRight 미사용 */}
       </WorkspaceLayout>
     </>
   );


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #96 

---

## 🎨 작업 내용 (What)
- DayDetail 화면 타임라인 UI 구현
- 일정 노드(시간/장소) 렌더링 및 편집 기능 구현
- 일정 추가 / 수정 / 삭제 기능 구현
- 드래그 앤 드롭 기반 일정 순서 변경 기능 구현
- Day 간 일정 이동 기능 구현
- 장소 정보 기반 지도 마커 렌더링 및 클릭 인터랙션 구현
- localStorage 기반 일정 데이터 저장 및 동기화 처리

---

## 🧭 작업 목적 (Why)
DayAll에서 수집된 장소 데이터를 기반으로  
사용자가 실제 일정(Time-based)을 구성하고 편집할 수 있는 인터페이스를 제공하기 위함

단순 데이터 조회가 아닌  
일정 생성 → 수정 → 재배치까지 가능한 실사용 중심 기능 구현

---

## 🧩 변경 범위
- [x] UI / Layout
- [x] 컴포넌트 구조
- [x] 상태 관리 로직
- [ ] API 연동
- [x] 스타일

---

## 🧪 테스트 방법
- [x] 로컬 실행 확인
- [x] 타임라인 일정 정상 렌더링 확인
- [x] 일정 추가 / 수정 / 삭제 기능 정상 동작 확인
- [x] 드래그 앤 드롭 순서 변경 정상 동작 확인
- [x] Day 간 일정 이동 기능 확인
- [x] 지도 마커가 일정과 일치하게 표시되는지 확인
- [x] localStorage 저장 및 새로고침 후 데이터 유지 확인
- [x] 콘솔 에러 없는지 확인

---

## ⚠️ 참고 사항
- 일정 데이터는 useTimeline 훅을 통해 localStorage와 동기화 처리
- 장소 정보는 DayAll에서 관리된 데이터를 기반으로 매칭하여 사용
- 지도 마커는 일정 노드 기준으로 렌더링
- drag & drop 동작 시 상태 업데이트 순서에 주의 필요

---

## ✅ 체크리스트
- [x] main 브랜치 직접 push 하지 않음
- [x] feature 브랜치에서 작업함
- [x] 불필요한 console.log 제거
- [x] 기능 단위 PR 유지