### PR TITLE
[FE] feature: 여행 생성 시 제목/인원/기간 workspace 반영

### DIFF
--- a/src/features/workspace/components/layout/WorkspaceCenter.tsx
+++ b/src/features/workspace/components/layout/WorkspaceCenter.tsx
@@ -1,6 +1,6 @@
 // src/features/workspace/components/layout/WorkspaceCenter.tsx
 
-import React, { useState, useEffect } from "react";
+import React, { useState, useMemo } from "react";
 
 import "../../styles/center.css";
 import "../../styles/layout.css";
@@ -27,18 +27,21 @@ import type { UseNoticesStore } from "../../hooks/useNotices";
 
 interface Props {
   noticeStore: UseNoticesStore;
-  rightOpen: boolean;
-  setRightOpen: (v: boolean) => void;
 }
 
-const WorkspaceCenter: React.FC<Props> = ({
-  noticeStore,
-  rightOpen,
-  setRightOpen,
-}) => {
-  const { activeView, currentDay } = useWorkspaceCore();
+const WorkspaceCenter: React.FC<Props> = ({ noticeStore }) => {
+  const { activeView, currentDay, trip, updateTripData } = useWorkspaceCore();
 
-  const { nodes, addNode, updateNode } = useTimeline(currentDay);
+  const { nodes, addNode, updateNode, deleteNode, reorderNodes, moveNodeToDay, loadFromExternal } = useTimeline(currentDay);
+
+  const dayKeys: string[] = useMemo(() => {
+    try {
+      const saved = localStorage.getItem("tripmoa_timeline_data");
+      return saved ? Object.keys(JSON.parse(saved)) : [];
+    } catch {
+      return [];
+    }
+  }, [nodes]);
 
   const {
     notices,
@@ -66,21 +69,6 @@ const WorkspaceCenter: React.FC<Props> = ({
 
   const voucherStore = useVouchers();
   const [isVoucherModalOpen, setIsVoucherModalOpen] = useState(false);
-
-  const [trip, setTrip] = useState({
-    title: "OSAKA X-MAS 🎄",
-    startDate: "2025-12-24",
-    endDate: "2025-12-25",
-  });
-
-  useEffect(() => {
-    const saved = localStorage.getItem("tripData");
-    if (saved) setTrip(JSON.parse(saved));
-  }, []);
-
-  useEffect(() => {
-    localStorage.setItem("tripData", JSON.stringify(trip));
-  }, [trip]);
 
   return (
     <div className="ws-main">
@@ -144,6 +132,8 @@ const WorkspaceCenter: React.FC<Props> = ({
               tripTitle={trip.title}
               startDate={trip.startDate}
               endDate={trip.endDate}
+              //추가
+              onScheduleGenerated={loadFromExternal}
             />
           ) : (
             <DayDetailView
@@ -152,10 +142,12 @@ const WorkspaceCenter: React.FC<Props> = ({
               startDate={trip.startDate}
               endDate={trip.endDate}
               nodes={nodes}
+              dayKeys={dayKeys}
               addNode={addNode}
               updateNode={updateNode}
-              rightOpen={rightOpen}
-              setRightOpen={setRightOpen}
+              deleteNode={deleteNode}
+              reorderNodes={reorderNodes}
+              moveNodeToDay={moveNodeToDay}
             />
           )}
         </div>
@@ -230,7 +222,7 @@ const WorkspaceCenter: React.FC<Props> = ({
           init={trip}
           onClose={closeEdit}
           onSave={(data) => {
-            setTrip(data);
+            void updateTripData(data);
             closeEdit();
           }}
         />

--- a/src/features/workspace/components/layout/WorkspaceSidebar.tsx
+++ b/src/features/workspace/components/layout/WorkspaceSidebar.tsx
@@ -19,7 +19,27 @@ const WorkspaceSidebar: React.FC = () => {
     renameNoticeGroup,
     deleteNoticeGroup,
     isNoticeGroupsLoading,
+    trip,
+    tripMembers,
   } = useWorkspaceCore();
+
+  const formatDateRange = (start: string, end: string) => {
+    if (!start || !end) return "-";
+    const s = new Date(start);
+    const e = new Date(end);
+    const sm = String(s.getMonth() + 1).padStart(2, "0");
+    const sd = String(s.getDate()).padStart(2, "0");
+    const em = String(e.getMonth() + 1).padStart(2, "0");
+    const ed = String(e.getDate()).padStart(2, "0");
+    return `${s.getFullYear()}.${sm}.${sd} - ${em}.${ed}`;
+  };
+
+  const calcNightsDays = (start: string, end: string) => {
+    if (!start || !end) return "-";
+    const diff = Math.round((new Date(end).getTime() - new Date(start).getTime()) / 86400000);
+    if (diff <= 0) return "당일치기";
+    return `${diff}박 ${diff + 1}일`;
+  };
 
   return (
     <div className="ws-panel">
@@ -173,17 +193,23 @@ const WorkspaceSidebar: React.FC = () => {
       <div className="ws-info-area">
         <div className="info-group">
           <div className="info-label">TRIP DURATION</div>
-          <div className="info-val">2025.12.24 - 12.25</div>
-          <div className="info-sub">1박 2일</div>
+          <div className="info-val">{formatDateRange(trip.startDate, trip.endDate)}</div>
+          <div className="info-sub">{calcNightsDays(trip.startDate, trip.endDate)}</div>
         </div>
 
         <div className="info-group">
-          <div className="info-label">MEMBERS (4)</div>
+          <div className="info-label">MEMBERS ({tripMembers.length})</div>
           <div className="member-row">
-            <div className="mem-icon owner">ME</div>
-            <div className="mem-icon">J</div>
-            <div className="mem-icon">K</div>
-            <div className="mem-icon">M</div>
+            {tripMembers.map((m) => (
+              <div
+                key={m.memberId}
+                className="mem-icon"
+                style={m.avatarColor ? { background: m.avatarColor } : undefined}
+                title={m.nickname}
+              >
+                {m.avatarEmoji || m.nickname.charAt(0).toUpperCase()}
+              </div>
+            ))}
           </div>
         </div>
 


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #93

---

## 🎨 작업 내용 (What)
- TripCreateModal에서 입력한 여행 정보(제목, 시작일, 종료일, 인원)를 Workspace 상태에 반영하도록 구현
- useWorkspaceCore를 통해 trip 데이터 전역 상태 관리 구조 연결
- WorkspaceCenter 상단 영역에 여행 제목 표시 로직 반영
- WorkspaceSidebar에 여행 기간 및 인원 정보 표시 로직 연동
- localStorage 기반 데이터 유지 처리

---

## 🧭 작업 목적 (Why)
기존에는 여행 생성 후 Workspace 진입 시  
입력한 여행 정보가 즉시 반영되지 않아 사용자 흐름이 단절되는 문제가 있었음

여행 생성 → Workspace 진입 시  
기본 정보(제목/인원/기간)가 즉시 표시되도록 하여  
사용자가 생성 결과를 직관적으로 확인할 수 있도록 개선

---

## 🧩 변경 범위
- [x] UI / Layout
- [x] 컴포넌트 구조
- [x] 상태 관리 로직
- [ ] API 연동
- [ ] 스타일

---

## 🧪 테스트 방법
- [x] 로컬 실행 확인
- [x] 여행 생성 시 입력한 제목이 Workspace 상단에 정상 표시되는지 확인
- [x] 시작일 / 종료일이 Sidebar에 정상 반영되는지 확인
- [x] 인원 정보가 Sidebar에 정상 표시되는지 확인
- [x] 페이지 이동 후에도 데이터 유지되는지 확인 (localStorage)
- [x] 콘솔 에러 없는지 확인

---

## ⚠️ 참고 사항
- trip 데이터는 useWorkspaceCore를 통해 관리
- localStorage에 저장된 trip 데이터를 Workspace 초기 렌더 시 로드
- WorkspaceCenter 및 Sidebar에서 동일 상태를 참조하도록 구성
- TripCreateModal에서 생성된 데이터를 Workspace 상태로 전달하는 흐름 연결

---

## ✅ 체크리스트
- [x] main 브랜치 직접 push 하지 않음
- [x] feature 브랜치에서 작업함
- [x] 불필요한 console.log 제거
- [x] 기능 단위 PR 유지