### PR TITLE
[FE] refactor: 인증 구조 개선 및 토큰 처리 로직 안정화

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,35 +12,38 @@ import Login from "./features/user/pages/Login";
 import UserSettings from "./features/user/pages/UserSetting";
 import OAuthSuccess from "./features/user/pages/OAuthSuccess";
 import ProtectedRoute from "./features/user/pages/ProtectedRoute";
+import { AuthProvider } from "./features/user/pages/AuthContext";
 
 export default function App() {
   return (
-    <Routes>
-      {/* 레이아웃 없는 페이지 */}
-      <Route path="/login" element={<Login />} />
-      <Route path="/oauth2/redirect" element={<OAuthSuccess />} />
-
-      {/* 보호된 라우트: 설정 페이지 */}
-      <Route element={<ProtectedRoute />}>
-        <Route path="/setting" element={<UserSettings />} />
-      </Route>
-
-      {/* 레이아웃 있는 페이지 */}
-      <Route element={<Layout />}>
-        <Route path="/" element={<Home />} />
-        <Route path="/mate" element={<Mate />} />
-        <Route path="/mate/:postId" element={<MateDetail />} />
-        <Route path="/travelstory" element={<TravelStory />} />
+    <AuthProvider>
+      <Routes>
+        {/* 레이아웃 없는 페이지 */}
+        <Route path="/login" element={<Login />} />
+        <Route path="/oauth2/redirect" element={<OAuthSuccess />} />
 
         {/* 보호된 라우트: 설정 페이지 */}
         <Route element={<ProtectedRoute />}>
-          <Route path="/mytrips" element={<MyTrips />} />
-          <Route path="/workspace" element={<Workspace />} />
-          <Route path="/workspace/:tripId" element={<Workspace />} />
+          <Route path="/setting" element={<UserSettings />} />
         </Route>
 
-        <Route path="*" element={<Navigate to="/" replace />} />
-      </Route>
-    </Routes>
+        {/* 레이아웃 있는 페이지 */}
+        <Route element={<Layout />}>
+          <Route path="/" element={<Home />} />
+          <Route path="/mate" element={<Mate />} />
+          <Route path="/mate/:postId" element={<MateDetail />} />
+          <Route path="/travelstory" element={<TravelStory />} />
+
+          {/* 보호된 라우트: 설정 페이지 */}
+          <Route element={<ProtectedRoute />}>
+            <Route path="/mytrips" element={<MyTrips />} />
+            <Route path="/workspace" element={<Workspace />} />
+            <Route path="/workspace/:tripId" element={<Workspace />} />
+          </Route>
+
+          <Route path="*" element={<Navigate to="/" replace />} />
+        </Route>
+      </Routes>
+    </AuthProvider>
   );
 }

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -9,10 +9,46 @@ type RetryableConfig = {
   url?: string;
 };
 
-// Axios 인스턴스 생성
+export type AuthLogoutReason =
+  | "manual"
+  | "withdraw"
+  | "refresh-expired"
+  | "remote-tab";
+
+// refreshToken 쿠키 자동 전송
 export const api = axios.create({
   baseURL: "/api",
+  withCredentials: true,
 });
+
+// accessToken 메모리 관리
+let accessTokenMemory: string | null = null;
+
+export const getAccessToken = () => accessTokenMemory;
+
+export const setAccessToken = (token: string) => {
+  accessTokenMemory = token;
+};
+export const clearAccessToken = () => {
+  accessTokenMemory = null;
+};
+
+// 인증 관련 클라이언트 상태 초기화
+export const clearAuthState = () => {
+  clearAccessToken();
+};
+
+// 인증 상태 변경 이벤트 발행
+export const notifyAuthLogout = (reason: AuthLogoutReason = "manual") => {
+  window.dispatchEvent(
+    new CustomEvent("auth:logout", {
+      detail: { reason },
+    }),
+  );
+};
+
+// 공유 Promise : 동시에 여러 401 발생 -> refresh 중복 방지
+let refreshPromise: Promise<RefreshTokenResponse> | null = null;
 
 /**
  * 요청 인터셉터
@@ -20,7 +56,7 @@ export const api = axios.create({
  */
 api.interceptors.request.use(
   (config) => {
-    const token = localStorage.getItem("accessToken");
+    const token = getAccessToken();
 
     if (token) {
       config.headers = config.headers ?? {};
@@ -33,9 +69,57 @@ api.interceptors.request.use(
 );
 
 /**
+ * refresh 요청은 반드시 여기서만 수행
+ * - 토큰 저장/정리까지만 담당
+ * - 전역 로그아웃 이벤트는 여기서 발행하지 않음
+ */
+const refreshTokens = async (): Promise<RefreshTokenResponse> => {
+  if (!refreshPromise) {
+    refreshPromise = axios
+      .post<RefreshTokenResponse>(
+        "/api/auth/refresh",
+        {},
+        { withCredentials: true },
+      )
+      .then((res) => {
+        const { accessToken, authenticated } = res.data;
+
+        if (!accessToken || authenticated === false) {
+          clearAuthState();
+          throw new Error("Unauthenticated");
+        }
+
+        setAccessToken(accessToken);
+        return res.data;
+      })
+      .catch((error) => {
+        clearAuthState();
+        throw error;
+      })
+      .finally(() => {
+        refreshPromise = null;
+      });
+  }
+
+  return refreshPromise;
+};
+
+/**
+ * 앱 시작 시 명시적으로 1회 인증 복구가 필요할 때 사용할 함수
+ * bootstrap 경로에서는 실패해도 이벤트 발행하지 않음
+ */
+export const tryRefreshAuth = async (): Promise<boolean> => {
+  try {
+    await refreshTokens();
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+/**
  * 응답 인터셉터
  * 인증 만료 시 토큰 재발급 후 재시도
- * 자동 로그아웃 & 기타 에러 처리
  */
 api.interceptors.response.use(
   (response) => response,
@@ -50,56 +134,25 @@ api.interceptors.response.use(
 
     const isRefreshRequest = originalRequest.url?.includes("/auth/refresh");
 
-    // 401 에러: 토큰 만료 시 재발급 시도
     if (status === 401 && !originalRequest._retry && !isRefreshRequest) {
       originalRequest._retry = true;
 
       try {
-        const refreshToken = localStorage.getItem("refreshToken");
-
-        if (!refreshToken) {
-          throw new Error("refreshToken 없음");
-        }
-
-        // 리프레시 토큰으로 새 토큰 발급 요청 (주의: api 인스턴스가 아닌 axios를 직접 사용하여 무한 루프 방지)
-        const res = await axios.post<RefreshTokenResponse>(
-          "/api/auth/refresh",
-          { refreshToken },
-        );
-
-        const { accessToken, refreshToken: newRefreshToken } = res.data;
-
-        // 새 토큰들 저장
-        localStorage.setItem("accessToken", accessToken);
-        localStorage.setItem("refreshToken", newRefreshToken);
+        const { accessToken } = await refreshTokens();
 
         const headers = (originalRequest.headers ?? {}) as Record<
           string,
           string
         >;
-
-        // 실패했던 기존 요청의 헤더를 새 토큰으로 교체 후 재시도
         headers.Authorization = `Bearer ${accessToken}`;
         originalRequest.headers = headers;
 
         return api(originalRequest);
       } catch (refreshError) {
-        // 리프레시 토큰도 만료되었거나 오류 발생 시 로그아웃
-        localStorage.removeItem("accessToken");
-        localStorage.removeItem("refreshToken");
-        localStorage.removeItem("userId");
-        // localStorage.clear();
-
-        window.location.href = "/login";
+        clearAuthState();
+        notifyAuthLogout("refresh-expired");
         return Promise.reject(refreshError);
       }
-    }
-
-    // 기타 에러 처리
-    if (status === 403) {
-      alert("접근 권한이 없습니다.");
-    } else if (status && status >= 500) {
-      alert("서버 오류가 발생했습니다.");
     }
 
     return Promise.reject(error);

--- a/src/api/auth.api.ts
+++ b/src/api/auth.api.ts
@@ -40,8 +40,8 @@ const broadcastLogoutToOtherTabs = (reason: "manual" | "withdraw") => {
 export const logout = async () => {
   try {
     await api.post<void>("/logout");
-  } catch (error) {
-    console.error("서버 로그아웃 처리 실패:", error);
+  } catch {
+    // 서버 로그아웃 실패해도 클라이언트 상태는 초기화
   } finally {
     clearAuthState();
     broadcastLogoutToOtherTabs("manual");
@@ -51,13 +51,8 @@ export const logout = async () => {
 
 // 회원 탈퇴
 export const withdraw = async () => {
-  try {
-    await api.delete("/users/me");
-    clearAuthState();
-    broadcastLogoutToOtherTabs("withdraw");
-    notifyAuthLogout("withdraw");
-  } catch (error) {
-    console.error("회원 탈퇴 실패:", error);
-    throw error;
-  }
+  await api.delete("/users/me");
+  clearAuthState();
+  broadcastLogoutToOtherTabs("withdraw");
+  notifyAuthLogout("withdraw");
 };

--- a/src/api/auth.api.ts
+++ b/src/api/auth.api.ts
@@ -1,12 +1,14 @@
 // src/api/auth.api.ts
 
-import { api } from "./api";
+import { api, clearAuthState, notifyAuthLogout } from "./api";
 import type {
   CheckEmailRequest,
   CheckEmailResponse,
   UserResponse,
   UserUpdateRequestDto,
 } from "../types/auth.types";
+
+const LOGOUT_SYNC_KEY = "logout-event";
 
 // 로그인된 사용자 정보 조회
 export const getMyInfo = () => {
@@ -23,6 +25,17 @@ export const updateMyInfo = (data: UserUpdateRequestDto) => {
   return api.patch<void>("/users/me", data);
 };
 
+// 로그아웃 상태를 다른 탭에도 동기화
+const broadcastLogoutToOtherTabs = (reason: "manual" | "withdraw") => {
+  localStorage.setItem(
+    LOGOUT_SYNC_KEY,
+    JSON.stringify({
+      reason,
+      timestamp: Date.now(),
+    }),
+  );
+};
+
 // 로그아웃
 export const logout = async () => {
   try {
@@ -30,21 +43,21 @@ export const logout = async () => {
   } catch (error) {
     console.error("서버 로그아웃 처리 실패:", error);
   } finally {
-    localStorage.removeItem("accessToken");
-    localStorage.removeItem("refreshToken");
-    localStorage.removeItem("userId");
-    // localStorage.clear();
+    clearAuthState();
+    broadcastLogoutToOtherTabs("manual");
+    notifyAuthLogout("manual");
   }
 };
 
 // 회원 탈퇴
 export const withdraw = async () => {
-  const response = await api.delete<void>("/users/me");
-
-  localStorage.removeItem("accessToken");
-  localStorage.removeItem("refreshToken");
-  localStorage.removeItem("userId");
-  // localStorage.clear();
-
-  return response;
+  try {
+    await api.delete("/users/me");
+    clearAuthState();
+    broadcastLogoutToOtherTabs("withdraw");
+    notifyAuthLogout("withdraw");
+  } catch (error) {
+    console.error("회원 탈퇴 실패:", error);
+    throw error;
+  }
 };

--- a/src/features/user/components/LoginForm.tsx
+++ b/src/features/user/components/LoginForm.tsx
@@ -1,5 +1,8 @@
+// src/features/user/components/LoginForm.tsx
+
 import React, { useState, useEffect } from "react";
 import styles from "../styles/LoginForm.module.css";
+import { API_BASE_URL } from "../../../shared/config/env";
 
 export const LoginForm: React.FC = () => {
   // 상태 선언 (초기값 null)
@@ -29,8 +32,7 @@ export const LoginForm: React.FC = () => {
             <button
               type="button"
               onClick={() => {
-                window.location.href =
-                  "http://localhost:8080/oauth2/authorization/google";
+                window.location.href = `${API_BASE_URL}/oauth2/authorization/google`;
               }}
               className={styles.socialButton}
             >
@@ -66,8 +68,7 @@ export const LoginForm: React.FC = () => {
             <button
               type="button"
               onClick={() => {
-                window.location.href =
-                  "http://localhost:8080/oauth2/authorization/kakao";
+                window.location.href = `${API_BASE_URL}/oauth2/authorization/kakao`;
               }}
               className={`${styles.socialButton} ${styles.kakao}`}
             >
@@ -88,8 +89,7 @@ export const LoginForm: React.FC = () => {
             <button
               type="button"
               onClick={() => {
-                window.location.href =
-                  "http://localhost:8080/oauth2/authorization/naver";
+                window.location.href = `${API_BASE_URL}/oauth2/authorization/naver`;
               }}
               className={`${styles.socialButton} ${styles.naver}`}
             >

--- a/src/features/user/hooks/useUserSetting.ts
+++ b/src/features/user/hooks/useUserSetting.ts
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { generateRandomAvatar } from "../components/User.constant";
 import { MBTI_TYPES } from "../components/User.constant";
 import { getMyInfo, updateMyInfo, withdraw } from "../../../api/auth.api";
+import { useAuth } from "../pages/AuthContext";
 
 export interface UserProfile {
   // 기본 필드
@@ -45,16 +46,16 @@ export interface UserProfile {
 export function useUserProfile() {
   const navigate = useNavigate();
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const { isAuthenticated, authReady, clearAuth } = useAuth();
 
   const [profile, setProfile] = useState<UserProfile | null>(null);
   const [hasChanges, setHasChanges] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
 
-  // 로컬 저장소에서 로그인 여부 확인
-  const isLoggedIn = !!localStorage.getItem("accessToken");
-
   useEffect(() => {
-    if (!isLoggedIn) {
+    if (!authReady) return;
+
+    if (!isAuthenticated) {
       setProfile(null);
       return;
     }
@@ -69,10 +70,10 @@ export function useUserProfile() {
         setProfile(data);
       })
       .catch(() => {
-        localStorage.removeItem("accessToken");
-        navigate("/login");
+        clearAuth();
+        navigate("/login", { replace: true });
       });
-  }, [isLoggedIn]);
+  }, [authReady, isAuthenticated, navigate, clearAuth]);
 
   // 나이 계산
   const calculateAge = (birthDate: string): number => {

--- a/src/features/user/pages/AuthContext.tsx
+++ b/src/features/user/pages/AuthContext.tsx
@@ -1,0 +1,192 @@
+// src/features/user/pages/AuthContext.tsx
+
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+  useCallback,
+} from "react";
+import { getMyInfo } from "../../../api/auth.api";
+import {
+  clearAuthState,
+  tryRefreshAuth,
+  type AuthLogoutReason,
+  notifyAuthLogout,
+} from "../../../api/api";
+
+type AuthContextType = {
+  isAuthenticated: boolean;
+  authReady: boolean;
+  userId: number | null;
+  logoutMessage: string | null;
+  setAuthenticated: (value: boolean) => void;
+  setUserId: (id: number | null) => void;
+  refreshAuth: () => Promise<boolean>;
+  clearAuth: () => void;
+  clearLogoutMessage: () => void;
+};
+
+type AuthLogoutEventDetail = {
+  reason?: AuthLogoutReason;
+};
+
+const LOGOUT_SYNC_KEY = "logout-event";
+
+const AuthContext = createContext<AuthContextType | null>(null);
+
+export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const [authReady, setAuthReady] = useState(false);
+  const [userId, setUserId] = useState<number | null>(null);
+  const [logoutMessage, setLogoutMessage] = useState<string | null>(null);
+  const didBootstrap = useRef(false);
+
+  /**
+   * 클라이언트 인증 상태 초기화 후 비로그인 상태 전환
+   */
+  const clearAuth = useCallback(() => {
+    clearAuthState();
+    setIsAuthenticated(false);
+    setUserId(null);
+  }, []);
+
+  const clearLogoutMessage = useCallback(() => {
+    setLogoutMessage(null);
+  }, []);
+
+  /**
+   * refreshToken 쿠키 기준으로 인증 상태 복구
+   */
+  const refreshAuth = useCallback(async (): Promise<boolean> => {
+    const refreshed = await tryRefreshAuth();
+
+    if (!refreshed) {
+      clearAuth();
+      return false;
+    }
+
+    try {
+      const response = await getMyInfo();
+      setUserId(response.data.id);
+      setIsAuthenticated(true);
+      return true;
+    } catch {
+      clearAuth();
+      return false;
+    }
+  }, [clearAuth]);
+
+  /**
+   * 앱 최초 진입 시 1회 인증 부트스트랩
+   */
+  useEffect(() => {
+    if (didBootstrap.current) return;
+    didBootstrap.current = true;
+
+    const runBootstrap = async () => {
+      await refreshAuth();
+      setAuthReady(true);
+    };
+
+    runBootstrap();
+  }, [refreshAuth]);
+
+  /**
+   * auth:logout 이벤트 수신
+   * - 현재 탭의 인증 상태 초기화
+   * - 로그아웃 사유에 따라 사용자 안내 메시지 분기
+   */
+  useEffect(() => {
+    const handleLogout = (event: Event) => {
+      const customEvent = event as CustomEvent<AuthLogoutEventDetail>;
+      const reason = customEvent.detail?.reason;
+
+      clearAuth();
+
+      if (reason === "refresh-expired") {
+        setLogoutMessage("세션이 만료되어 다시 로그인해주세요.");
+        return;
+      }
+
+      if (reason === "remote-tab") {
+        setLogoutMessage(
+          "다른 탭에서 로그아웃되어 현재 탭도 로그아웃되었습니다.",
+        );
+        return;
+      }
+
+      if (reason === "withdraw") {
+        setLogoutMessage("회원 탈퇴가 완료되었습니다.");
+        return;
+      }
+
+      setLogoutMessage(null);
+    };
+
+    window.addEventListener("auth:logout", handleLogout);
+
+    return () => {
+      window.removeEventListener("auth:logout", handleLogout);
+    };
+  }, [clearAuth]);
+
+  /**
+   * 다른 탭에서 발생한 로그아웃을 감지하여 현재 탭도 동기화
+   * storage 이벤트는 값을 쓴 탭이 아닌 "다른 탭"에서만 발생한다.
+   */
+  useEffect(() => {
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key !== LOGOUT_SYNC_KEY || !event.newValue) return;
+
+      try {
+        const parsed = JSON.parse(event.newValue) as {
+          reason?: "manual" | "withdraw";
+          timestamp?: number;
+        };
+
+        if (parsed.reason === "withdraw") {
+          notifyAuthLogout("withdraw");
+          return;
+        }
+
+        notifyAuthLogout("remote-tab");
+      } catch {
+        notifyAuthLogout("remote-tab");
+      }
+    };
+
+    window.addEventListener("storage", handleStorage);
+
+    return () => {
+      window.removeEventListener("storage", handleStorage);
+    };
+  }, []);
+
+  return (
+    <AuthContext.Provider
+      value={{
+        isAuthenticated,
+        authReady,
+        userId,
+        logoutMessage,
+        setUserId,
+        setAuthenticated: setIsAuthenticated,
+        refreshAuth,
+        clearAuth,
+        clearLogoutMessage,
+      }}
+    >
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export const useAuth = () => {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error("useAuth must be used within AuthProvider");
+  }
+  return context;
+};

--- a/src/features/user/pages/Login.tsx
+++ b/src/features/user/pages/Login.tsx
@@ -1,9 +1,19 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { TicketLayout } from "../components/common/TicketLayout";
 import { TicketInfo } from "../components/common/TicketInfo";
 import { LoginForm } from "../components/LoginForm";
+import { useAuth } from "../../../features/user/pages/AuthContext";
 
 const Login: React.FC = () => {
+  const { logoutMessage, clearLogoutMessage } = useAuth();
+
+  useEffect(() => {
+    if (!logoutMessage) return;
+
+    alert(logoutMessage);
+    clearLogoutMessage();
+  }, [logoutMessage, clearLogoutMessage]);
+
   return (
     <TicketLayout
       leftContent={
@@ -15,7 +25,7 @@ const Login: React.FC = () => {
           tagline="Social login only"
         />
       }
-      rightContent={<LoginForm socialOnly />}
+      rightContent={<LoginForm />}
     />
   );
 };

--- a/src/features/user/pages/OAuthSuccess.tsx
+++ b/src/features/user/pages/OAuthSuccess.tsx
@@ -1,52 +1,46 @@
+// src/features/user/pages/OAuthSuccess.tsx
+
 import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
-import { getMyInfo } from "../../../api/auth.api";
+import { useAuth } from "./AuthContext";
 
 /**
- * OAuthSuccess 컴포넌트
- * 소셜 로그인 성공 후 URL에 담긴 JWT 토큰 저장
- * 실제 로그인 상태를 확인한 뒤 홈으로 이동하는 페이지
+ * OAuthSuccess 컴포넌트.
+ * 소셜 로그인 성공 후 refreshToken 쿠키를 기준으로 accessToken을 재발급받고 사용자 인증 상태 복구
+ * 인증 성공 시 홈으로 이동, 실패 시 로그인 페이지로 이동
  */
 export default function OAuthSuccess() {
   const navigate = useNavigate();
+  const { refreshAuth } = useAuth();
 
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
-    const token = params.get("token");
-    const refreshToken = params.get("refreshToken");
     const provider = params.get("provider");
-
-    // 액세스 토큰과 리프레시 토큰이 모두 있는지 확인
-    if (!token || !refreshToken) {
-      alert("로그인 정보가 부족합니다. 다시 로그인 해주세요.");
-      navigate("/login", { replace: true });
-      return;
-    }
-
-    // 토큰 모두 저장
-    localStorage.setItem("accessToken", token);
-    localStorage.setItem("refreshToken", refreshToken);
 
     // 최근 로그인 정보 저장
     if (provider) {
       localStorage.setItem("lastLoginProvider", provider.toLowerCase());
     }
 
-    getMyInfo()
-      .then((response) => {
-        localStorage.setItem("userId", response.data.id.toString());
-        navigate("/", { replace: true });
-      })
-      .catch(() => {
-        alert("로그인 처리 중 오류가 발생했습니다.");
+    // 주소창 잔여 쿼리 제거
+    window.history.replaceState({}, document.title, "/oauth2/redirect");
 
-        // 실패 시 모든 토큰 삭제하여 세션 초기화
-        localStorage.removeItem("accessToken");
-        localStorage.removeItem("refreshToken");
-        localStorage.removeItem("userId");
-        navigate("/login", { replace: true });
+    const run = async () => {
+      const success = await refreshAuth();
+
+      if (success) {
+        navigate("/", { replace: true });
+        return;
+      }
+
+      navigate("/login", {
+        replace: true,
+        state: { message: "로그인 처리 중 오류가 발생했습니다." },
       });
-  }, [navigate]);
+    };
+
+    run();
+  }, [navigate, refreshAuth]);
 
   return <p>로그인 처리 중입니다...</p>;
 }

--- a/src/features/user/pages/ProtectedRoute.tsx
+++ b/src/features/user/pages/ProtectedRoute.tsx
@@ -1,14 +1,75 @@
-import { Navigate, Outlet } from "react-router-dom";
+// src/features/user/pages/ProtectedRoute.tsx
 
-// 보호된 라우트를 위한 컴포넌트
+import { Navigate, Outlet, useLocation } from "react-router-dom";
+import { useAuth } from "./AuthContext";
+
+// 인증이 필요한 라우트를 보호하는 컴포넌트
 const ProtectedRoute = () => {
-  // 로컬 스토리지 액세스 토큰 확인
-  const isLoggedIn = !!localStorage.getItem("accessToken");
+  const { isAuthenticated, authReady } = useAuth();
+  const location = useLocation();
 
-  if (!isLoggedIn) {
-    alert("로그인 이후 이용 가능합니다.");
-    // 로그인 페이지로 강제 이동
-    return <Navigate to="/login" replace />;
+  if (!authReady) {
+    return (
+      <>
+        <style>{`
+          @keyframes spin {
+            to { transform: rotate(360deg); }
+          }
+          @keyframes blink {
+            0%, 100% { opacity: 1; }
+            50% { opacity: 0.3; }
+          }
+        `}</style>
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "center",
+            height: "60vh",
+            gap: "1.2rem",
+            fontFamily: "monospace",
+          }}
+        >
+          {/* 스피너 */}
+          <div
+            style={{
+              width: "36px",
+              height: "36px",
+              border: "2px solid rgba(255,255,255,0.1)",
+              borderTop: "2px solid currentColor",
+              borderRadius: "50%",
+              animation: "spin 0.75s linear infinite",
+            }}
+          />
+          {/* 상태 텍스트 */}
+          <span
+            style={{
+              fontSize: "0.75rem",
+              letterSpacing: "0.25em",
+              textTransform: "uppercase",
+              opacity: 0.5,
+              animation: "blink 1.4s ease-in-out infinite",
+            }}
+          >
+            AUTHENTICATING...
+          </span>
+        </div>
+      </>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return (
+      <Navigate
+        to="/login"
+        replace
+        state={{
+          from: location.pathname,
+          message: "로그인 이후 이용 가능합니다.",
+        }}
+      />
+    );
   }
 
   // 로그인 상태면 원래 가려던 페이지를 보여줌

--- a/src/features/user/pages/UserSetting.tsx
+++ b/src/features/user/pages/UserSetting.tsx
@@ -13,6 +13,7 @@ import { useUserProfile } from "../hooks/useUserSetting";
 import type { UserProfile } from "../hooks/useUserSetting";
 import { TRAVEL_STYLES, MODAL_MESSAGES } from "../components/User.constant";
 import styles from "../styles/UserSetting.module.css";
+import { API_BASE_URL } from "../../../shared/config/env";
 
 export default function UserSettings() {
   const navigate = useNavigate();
@@ -114,11 +115,18 @@ export default function UserSettings() {
 
   // 계정 탈퇴 핸들러
   const handleDeleteAccount = async () => {
-    const success = await deleteAccount(); // 비동기 호출 대기
+    try {
+      await deleteAccount();
 
-    if (success) {
       alert(MODAL_MESSAGES.DELETE.SUCCESS);
       setShowDeleteModal(false);
+      navigate("/login", { replace: true });
+    } catch (error: any) {
+      const message =
+        error?.response?.data?.message ||
+        "회원 탈퇴에 실패했습니다. 잠시 후 다시 시도해주세요.";
+
+      alert(message);
     }
   };
 

--- a/src/shared/components/Header.tsx
+++ b/src/shared/components/Header.tsx
@@ -1,42 +1,95 @@
-import { useNavigate } from "react-router-dom";
-import { useUserProfile } from "../../features/user/hooks/useUserSetting";
-import { logout } from "../../api/auth.api";
+// src/shared/components/Header.tsx
 
-export default function Header() {
+import { useNavigate } from "react-router-dom";
+import { logout } from "../../api/auth.api";
+import { useAuth } from "../../features/user/pages/AuthContext";
+import { useUserProfile } from "../../features/user/hooks/useUserSetting";
+
+function HeaderProfileMenu() {
   const navigate = useNavigate();
   const { profile } = useUserProfile();
 
-  // 로그인 상태 확인
-  const isLoggedIn = !!localStorage.getItem("accessToken");
+  const fallbackProfile = {
+    avatarEmoji: "😊",
+    avatarColor: "#FFE5E5",
+    profileImage: null,
+  };
+
+  const displayProfile = profile ?? fallbackProfile;
+
+  const handleLogout = async () => {
+    await logout();
+    navigate("/", { replace: true });
+  };
+
+  const handleSettingsClick = () => {
+    navigate("/setting");
+  };
+
+  return (
+    <>
+      <button className="nav-item btn-profile" type="button">
+        <div
+          className="profile-circle"
+          style={{
+            background: displayProfile.profileImage
+              ? "transparent"
+              : displayProfile.avatarColor,
+            overflow: "hidden",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+        >
+          {displayProfile.profileImage ? (
+            <img
+              src={displayProfile.profileImage}
+              alt="Profile"
+              style={{
+                width: "100%",
+                height: "100%",
+                objectFit: "cover",
+              }}
+            />
+          ) : (
+            <span style={{ fontSize: "1.2rem" }}>
+              {displayProfile.avatarEmoji}
+            </span>
+          )}
+        </div>
+      </button>
+
+      <div className="dropdown-menu dropdown-right">
+        <button onClick={handleSettingsClick} className="dropdown-item-btn">
+          {">>"} SETTINGS
+        </button>
+        <button onClick={handleLogout} className="dropdown-item-btn">
+          {">>"} LOGOUT
+        </button>
+      </div>
+    </>
+  );
+}
+
+export default function Header() {
+  const navigate = useNavigate();
+  const { isAuthenticated, authReady } = useAuth();
 
   const handleLogoClick = () => navigate("/");
 
-  // MY PLAN 클릭 핸들러
   const handlePlanClick = () => {
-    if (!isLoggedIn) {
-      // 비로그인 시 알림창을 띄우고 로그인 페이지로 이동
-      alert("로그인 이후 이용 가능합니다.");
-      navigate("/login");
-    } else {
-      // 로그인 상태면 마이트립 페이지로 이동
-      navigate("/mytrips");
+    if (!isAuthenticated) {
+      navigate("/login", {
+        state: { message: "로그인 이후 이용 가능합니다.", from: "/mytrips" },
+      });
+      return;
     }
+
+    navigate("/mytrips");
   };
 
-  // 로그인 핸들러
   const handleLogin = () => {
     navigate("/login");
-  };
-
-  // 로그아웃 핸들러
-  const handleLogout = async () => {
-    await logout();
-    window.location.href = "/";
-  };
-
-  // 설정 버튼 클릭 핸들러
-  const handleSettingsClick = () => {
-    navigate("/setting");
   };
 
   return (
@@ -47,7 +100,6 @@ export default function Header() {
 
       <nav>
         <ul>
-          {/* MY PLAN */}
           <li className="nav-group">
             <button
               className="nav-item"
@@ -58,7 +110,6 @@ export default function Header() {
             </button>
           </li>
 
-          {/* COMMUNITY */}
           <li className="nav-group">
             <button className="nav-item" type="button">
               COMMUNITY ▼
@@ -69,62 +120,15 @@ export default function Header() {
             </div>
           </li>
 
-          {/* LOGIN / PROFILE */}
           <li className="nav-group">
-            {!isLoggedIn ? (
+            {!authReady ? (
+              <div style={{ width: "80px", height: "40px" }} />
+            ) : !isAuthenticated ? (
               <button className="btn-login" type="button" onClick={handleLogin}>
                 LOGIN
               </button>
             ) : (
-              isLoggedIn &&
-              profile && (
-                <>
-                  <button className="nav-item btn-profile" type="button">
-                    <div
-                      className="profile-circle"
-                      style={{
-                        background: profile.profileImage
-                          ? "transparent"
-                          : profile.avatarColor,
-                        overflow: "hidden",
-                        display: "flex",
-                        alignItems: "center",
-                        justifyContent: "center",
-                      }}
-                    >
-                      {profile.profileImage ? (
-                        <img
-                          src={profile.profileImage}
-                          alt="Profile"
-                          style={{
-                            width: "100%",
-                            height: "100%",
-                            objectFit: "cover",
-                          }}
-                        />
-                      ) : (
-                        <span style={{ fontSize: "1.2rem" }}>
-                          {profile.avatarEmoji}
-                        </span>
-                      )}
-                    </div>
-                  </button>
-                  <div className="dropdown-menu dropdown-right">
-                    <button
-                      onClick={handleSettingsClick}
-                      className="dropdown-item-btn"
-                    >
-                      {">>"} SETTINGS
-                    </button>
-                    <button
-                      onClick={handleLogout}
-                      className="dropdown-item-btn"
-                    >
-                      {">>"} LOGOUT
-                    </button>
-                  </div>
-                </>
-              )
+              <HeaderProfileMenu />
             )}
           </li>
         </ul>

--- a/src/shared/config/env.ts
+++ b/src/shared/config/env.ts
@@ -1,0 +1,3 @@
+// src/shared/config/env.ts
+
+export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "";

--- a/src/types/auth.types.ts
+++ b/src/types/auth.types.ts
@@ -8,6 +8,11 @@ export type Gender = "MALE" | "FEMALE" | "OTHER" | null;
 
 export type ProfileType = "CUSTOM" | "AVATAR";
 
+export type RefreshTokenResponse = {
+  accessToken?: string;
+  authenticated?: boolean;
+};
+
 // ===================
 // Request DTO
 // ===================
@@ -33,11 +38,6 @@ export interface UserUpdateRequestDto {
 // ===================
 // Response DTO
 // ===================
-
-export interface RefreshTokenResponse {
-  accessToken: string;
-  refreshToken: string;
-}
 
 export interface CheckEmailResponse {
   exists: boolean;


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #103

---

## 🎨 작업 내용 (What)

- 인증 구조 전면 개선 (access / refresh 토큰 관리 방식 변경)
- accessToken → 메모리 저장 방식으로 변경
- refreshToken → HttpOnly 쿠키 기반으로 변경
- AuthContext 중심으로 인증 상태 관리 구조 통합
- App 최초 진입 시 refresh 1회로 인증 상태 복원 처리
- axios interceptor에서 401 발생 시 자동 refresh 처리
- ProtectedRoute에서 localStorage 기반 인증 확인 제거 → auth 상태 기반으로 변경
- 로그인 / OAuth 성공 후 인증 처리 흐름 정리 (중복 호출 방지)
- 서버 오류 발생 시 강제 로그아웃되지 않도록 수정
- 불필요한 console.log 제거

---

## 🧭 작업 목적 (Why)

기존 인증 구조에서 다음과 같은 문제가 발생하고 있었음:

1. accessToken 만료 시 refreshToken이 존재해도 로그아웃 처리되는 문제
2. localStorage 기반 인증 확인으로 인해 인증 상태 불일치 발생
3. 로그인/OAuth 과정에서 토큰 저장 로직이 중복 실행되는 문제
4. 서버 오류 시 사용자 의도와 다르게 로그아웃되는 UX 문제

이를 해결하기 위해:

- 토큰 저장 방식을 분리 (메모리 + HttpOnly 쿠키)
- 인증 상태를 AuthContext로 단일화
- refresh 흐름을 중앙에서 제어하도록 구조 개선

---

## 🧩 변경 범위

- [ ] UI / Layout
- [x] 컴포넌트 구조
- [x] 상태 관리 로직
- [x] API 연동
- [ ] 스타일

---

## 🧪 테스트 방법

- [x] 로컬 실행 확인
- [x] accessToken 만료 후 자동 refresh 동작 확인
- [x] refreshToken만 존재할 때 로그인 유지 확인
- [x] 로그인 / OAuth 로그인 정상 동작 확인
- [x] 로그아웃 시 상태 초기화 및 탭 간 동기화 확인
- [x] 서버 오류 발생 시 로그아웃되지 않는지 확인
- [x] 에러 콘솔 확인 (불필요한 로그 제거)

---

## ⚠️ 참고 사항

### ⚠️ 다른 프론트 코드 영향 있음

- localStorage에서 accessToken을 직접 사용하는 로직이 있다면 제거 필요
- 인증 여부를 직접 토큰으로 판단하지 말고 `AuthContext` 상태 사용 필요
- API 호출 시 토큰을 직접 헤더에 넣는 로직이 있다면 interceptor 구조로 변경 필요

### ⚠️ 백엔드 연동 전제

- refreshToken은 HttpOnly 쿠키로 내려와야 정상 동작
- `/auth/refresh` API 정상 동작 필요
- 로그아웃 시 쿠키 삭제 처리 필요

---

## ✅ 체크리스트

- [x] main 브랜치 직접 push 하지 않음
- [x] feature 브랜치에서 작업함
- [x] 불필요한 console.log 제거
- [x] PR 단위가 과도하게 크지 않음