### PR TITLE
[FE] refactor: 채팅 identity를 email에서 userId로 전환 및 useCurrentUser 제거

### DIFF
--- a/src/features/chat/components/ChatModal.tsx
+++ b/src/features/chat/components/ChatModal.tsx
@@ -1,9 +1,9 @@
 // components/mate/ChatModal.tsx
 import { useState, useEffect, useRef } from "react";
-import { X, MessageSquare, Users, Send, Search } from "lucide-react";
+import { X, MessageSquare, Send, Search } from "lucide-react";
 import type { OneOnOneChat } from "../hooks/chat.types";
 import type { Post } from "../../mate/hooks/mate.types";
-import { useCurrentUser } from "../hooks/useCurrentUser";
+import { useAuth } from "../../user/pages/AuthContext";
 
 interface ChatModalProps {
   isOpen: boolean;
@@ -24,11 +24,11 @@ export function ChatModal({
   allPosts,
   onSendOneOnOneMessage,
 }: ChatModalProps){
-  const { email: currentUserEmail } = useCurrentUser();
   const [selectedChat, setSelectedChat] = useState<SelectedChat>(null);
   const [messageInput, setMessageInput] = useState("");
   const [searchQuery, setSearchQuery] = useState("");
   const messagesEndRef = useRef<HTMLDivElement>(null);
+  const { userId } = useAuth();
 
   // 모달이 닫힐 때 선택된 채팅 초기화
   useEffect(() => {
@@ -104,7 +104,7 @@ export function ChatModal({
   const filteredOneOnOneChats = oneOnOneChats.filter(chat => {
     if (!searchQuery) return true;
     const post = getPostInfo(chat.postId);
-    const isMyChat = chat.applicantId === currentUserEmail;
+    const isMyChat = chat.applicantId === userId;
     const otherUserName = isMyChat ? post?.author.nickname : "Unknown";
     return post?.destination.toLowerCase().includes(searchQuery.toLowerCase()) ||
            otherUserName?.toLowerCase().includes(searchQuery.toLowerCase());
@@ -161,8 +161,8 @@ export function ChatModal({
                 <div className="space-y-4 max-w-5xl mx-auto">
                   {filteredOneOnOneChats.map((chat) => {
                     const post = getPostInfo(chat.postId);
-                    const isMyChat = chat.applicantId === currentUserEmail;
-                    const otherUser = chat.postAuthorId === currentUserEmail
+                    const isMyChat = chat.applicantId === userId;
+                    const otherUser = chat.postAuthorId === userId
                      ? chat.applicant
                      : chat.postAuthor;
                     const lastMessage = chat.messages[chat.messages.length - 1];
@@ -203,7 +203,7 @@ export function ChatModal({
             <div className="bg-white border-b-2 border-black p-5 flex items-center justify-between">
               <div className="flex items-center gap-4">
                 {(() => {
-                  const otherUser = selectedChat.chat.postAuthorId === currentUserEmail
+                  const otherUser = selectedChat.chat.postAuthorId === userId
                     ? selectedChat.chat.applicant
                     : selectedChat.chat.postAuthor;
                   return (
@@ -231,7 +231,7 @@ export function ChatModal({
             {/* 메시지 영역 */}
             <div className="flex-1 overflow-y-auto p-6 space-y-4 bg-blue-50">
               {(selectedChat.type === "one-on-one" ? selectedChat.chat.messages : selectedChat.chat.messages).map((msg) => {
-                const isMyMessage = msg.senderId === currentUserEmail;
+                const isMyMessage = msg.senderId === userId;
 
                 return (
                   <div key={msg.id} className={`flex ${isMyMessage ? "justify-end" : "justify-start"}`}>

--- a/src/features/chat/components/ChatSlideModal.tsx
+++ b/src/features/chat/components/ChatSlideModal.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useRef } from "react";
 import { X, MessageSquare, Send, Plus, LogOut, MapPin, Calendar, User } from "lucide-react";
 import type { OneOnOneChat } from "../hooks/chat.types";
 import type { Post, ApplicationResponse } from "../../mate/hooks/mate.types";
-import { useCurrentUser } from "../hooks/useCurrentUser";
+import { useAuth } from "../../user/pages/AuthContext";
 import { markRoomAsRead } from "../../../api/chat.api";
 import "../styles/ChatSlide.css";
 
@@ -53,7 +53,7 @@ export function ChatSlideModal({
   const [isClosing, setIsClosing] = useState(false);
   const [activeTab, setActiveTab] = useState<TabType>("active");
   const messagesEndRef = useRef<HTMLDivElement>(null);
-  const { email: currentUserEmail, id: currentUserId } = useCurrentUser();
+  const { userId } = useAuth();
   const [readMessageCounts, setReadMessageCounts] = useState<Record<string, number>>({});
 
   // 모달 닫을 때 애니메이션
@@ -101,7 +101,7 @@ export function ChatSlideModal({
 
   const getPostInfo = (chat: OneOnOneChat): ChatPostInfo => {
     // 채팅 객체에 이미 모든 정보가 있으므로 바로 반환
-    const isIamAuthor = chat.postAuthorId === currentUserEmail;
+    const isIamAuthor = chat.postAuthorId === userId;
     
     return {
       id: chat.postId,
@@ -114,7 +114,7 @@ export function ChatSlideModal({
 
   const getOtherUser = (chat: OneOnOneChat) => {
     // 상대방 정보 가져오기
-    const isIamAuthor = chat.postAuthorId === currentUserEmail;
+    const isIamAuthor = chat.postAuthorId === userId;
     return isIamAuthor ? chat.applicant : chat.postAuthor;
   };
 
@@ -156,7 +156,7 @@ export function ChatSlideModal({
     // 내가 신청한 목록
     // myApplications.filter(app => app.status === 'APPROVED').forEach(app => {
     //   const hasChat = oneOnOneChats.some(
-    //     chat => chat.postId === String(app.matePostId) && chat.applicantId === currentUserEmail
+    //     chat => chat.postId === String(app.matePostId) && chat.applicantId === userId
     //   );
     //   if (!hasChat) {
     //     available.push({
@@ -552,10 +552,10 @@ export function ChatSlideModal({
                     );
                   }
                   
-                  const myEmail = selectedChat.chat.postAuthor.id === currentUserId
-                    ? selectedChat.chat.postAuthor.email
-                    : selectedChat.chat.applicant.email;
-                  const isMyMessage = msg.senderId === myEmail;
+                  const myId = selectedChat.chat.postAuthor.id === userId
+                    ? selectedChat.chat.postAuthor.id
+                    : selectedChat.chat.applicant.id;
+                  const isMyMessage = msg.senderId === myId;
 
                   return (
                     <div key={msg.id} style={{ display: "flex", justifyContent: isMyMessage ? "flex-end" : "flex-start" }}>

--- a/src/features/chat/components/OneononeChatModal.tsx
+++ b/src/features/chat/components/OneononeChatModal.tsx
@@ -5,7 +5,7 @@ import type { Post } from "../../mate/hooks/mate.types";
 import type { ChatMessage } from "../hooks/chat.types";  // 경로 수정
 import ChatBubble from "./ChatBubble";
 import ChatInput from "./ChatInput";    
-// import { CURRENT_USER } from "../../hooks/mate.constants";
+import { useAuth } from "../../user/pages/AuthContext";
 
 interface OneOnOneChatModalProps {
   post: Post;
@@ -21,6 +21,7 @@ export default function OneOnOneChatModal({
   onClose,
 }: OneOnOneChatModalProps) {
   const messagesEndRef = useRef<HTMLDivElement>(null);
+  const { userId } = useAuth();
 
   // 메시지 추가될 때마다 스크롤 하단으로
   useEffect(() => {
@@ -70,7 +71,7 @@ export default function OneOnOneChatModal({
                 <ChatBubble
                   key={msg.id}
                   message={msg}
-                  isMyMessage={msg.senderId === CURRENT_USER.email}
+                  isMyMessage={msg.senderId === userId}
                 />
               ))}
               <div ref={messagesEndRef} />

--- a/src/features/chat/hooks/chat.types.ts
+++ b/src/features/chat/hooks/chat.types.ts
@@ -7,7 +7,7 @@
 /** 채팅 메시지 (백엔드 ChatMessageResponse 매칭) */
 export interface ChatMessage {
   id: string;
-  senderId: string;       // Member.email
+  senderId: number;       // Member.Id
   senderName: string;
   senderAvatar: string;   // profileImage
   content: string;
@@ -29,8 +29,8 @@ export interface ChatMemberInfo {
 export interface OneOnOneChat {
   id: string;
   postId: string;
-  postAuthorId: string;     // author email
-  applicantId: string;      // applicant email
+  postAuthorId: number;     // author id
+  applicantId: number;      // applicant id
   destination: string;
   startDate: string;
   endDate: string;

--- a/src/features/chat/hooks/useCurrentUser.ts
+++ b/src/features/chat/hooks/useCurrentUser.ts
@@ -1,8 +1,0 @@
-// hooks/useCurrentUser.ts
-
-export function useCurrentUser() {
-    return {
-        email: localStorage.getItem("userEmail") ?? "",
-        id: Number(localStorage.getItem("userId") ?? 0)
-    };
-}

--- a/src/features/mate/components/MatePostCard.tsx
+++ b/src/features/mate/components/MatePostCard.tsx
@@ -8,7 +8,6 @@ import {
   AGE_GROUP_REVERSE_MAP
 } from "../hooks/mate.constants";
 import "../styles/MatePostCard.css";
-import { getAccessToken } from "../../../api/api";
 import { useAuth } from "../../user/pages/AuthContext";
 
 interface MatePostCardProps {
@@ -36,8 +35,8 @@ export function MatePostCard({
   onRestore,
   onDelete,
 }: MatePostCardProps){
-  const currentUserId = getCurrentUserId();
-  const isAuthor = post.author.id === currentUserId;
+  const { userId } = useAuth();
+  const isAuthor = post.author.id === userId;
   const { isAuthenticated } = useAuth();
 
   // 날짜 포맷팅 (YYYY-MM-DD -> MM-DD)

--- a/src/features/mate/pages/Mate.tsx
+++ b/src/features/mate/pages/Mate.tsx
@@ -3,13 +3,13 @@ import { useNavigate } from "react-router-dom";
 import { ArrowUpDown, User, ChevronDown } from "lucide-react";
 
 import { useMate } from "../hooks/useMate";
+import { useAuth } from "../../user/pages/AuthContext";
 import { useChat } from "../../chat/hooks/useChat";
 import { ChatFAB } from "../../chat/components/ChatFAB";
 import { ChatSlideModal } from "../../chat/components/ChatSlideModal";
 import { useMateFilters } from "../hooks/useMateFilters";
 import { usePagination } from "../hooks/usePagination";
 import { SORT_OPTIONS, getSortLabel, POSTS_PER_PAGE } from "../hooks/mate.constants";
-import { useCurrentUser } from "../../chat/hooks/useCurrentUser";
 
 import {
   MateHeader,
@@ -30,6 +30,7 @@ import { getAccessToken } from "../../../api/api";
 
 export default function Mate() {
   const navigate = useNavigate();
+  const { userId } = useAuth();
 
   const [writeError, setWriteError] = useState<string | null>(null);
   const [showWriteModal, setShowWriteModal] = useState(false);
@@ -79,9 +80,6 @@ export default function Mate() {
     handleResetAll,
   } = useMateFilters(posts);
 
-  const currentUser = useCurrentUser();
-  const currentUserId = currentUser?.id;
-
   const passedIdSet = useMemo(
     () => new Set(passedPosts.map(p => p.id)),
     [passedPosts]
@@ -96,7 +94,7 @@ export default function Mate() {
       case 'liked':
         return filteredPosts.filter(p => p.liked);
       case 'my':
-        return posts.filter(p => p.author.id === currentUserId);
+        return posts.filter(p => p.author.id === userId);
       case 'all':
       default:
         return filteredPosts.filter(p =>
@@ -110,7 +108,7 @@ export default function Mate() {
     passed: passedPosts.length,
     expired: expiredPosts.length,
     liked: posts.filter(p => p.liked).length,
-    my: posts.filter(p => p.author.id === currentUserId).length,
+    my: posts.filter(p => p.author.id === userId).length,
   };
 
   const { currentPage, setCurrentPage, totalPages, visiblePosts } = usePagination(

--- a/src/features/mate/pages/MateDetail.tsx
+++ b/src/features/mate/pages/MateDetail.tsx
@@ -3,8 +3,9 @@ import { useParams, useNavigate } from "react-router-dom";
 import { ArrowLeft, Heart, Calendar, Users, Wallet, Eye } from "lucide-react";
 import { LoginPromptModal } from "../components/LoginPromptModal";
 import type { Post, ApplicationRequest } from "../hooks/mate.types";
-import { getCurrentUserId, calculateDuration, getAgeGroupLabel, getGenderPreferenceLabel, getTransportLabel } from "../hooks/mate.constants";
+import { calculateDuration, getAgeGroupLabel, getGenderPreferenceLabel, getTransportLabel } from "../hooks/mate.constants";
 import { useMate } from "../hooks/useMate";
+import { useAuth } from "../../user/pages/AuthContext";
 import { isPostExpired } from "../hooks/mate.util";
 import { useAuthGuard } from "../hooks/useAuthGuard";
 import { ProfileIncompleteModal } from "../components/ProfileIncompleteModal";
@@ -24,8 +25,8 @@ export default function MateDetail() {
 
   const hasLoadedRef = useRef(false);
 
-  const currentUserId = getCurrentUserId();
-  const isAuthor = post?.author?.id === currentUserId;
+  const { userId } = useAuth();
+  const isAuthor = post?.author?.id === userId;
   const token = getAccessToken();
 
   const {
@@ -74,7 +75,7 @@ export default function MateDetail() {
 
     setPost(prev => prev ? {
       ...prev,
-      isLiked: !prev.liked,
+      liked: !prev.liked,
       likesCount: prev.liked ? prev.likesCount - 1 : prev.likesCount + 1
     } : null);
 
@@ -83,13 +84,13 @@ export default function MateDetail() {
     if (result) {
       setPost(prev => prev ? {
         ...prev,
-        isLiked: result.liked,
+        liked: result.liked,
         likesCount: result.count
       } : null);
     } else {
       setPost(prev => prev ? {
         ...prev,
-        isLiked: prevLiked,
+        liked: prevLiked,
         likesCount: prevCount
       } : null);
     }
@@ -185,7 +186,7 @@ export default function MateDetail() {
 
             {/* 좋아요 버튼 (활성화 시 빨간색) */}
             <button
-              onClick={() => withLoginCheck(() => onLikeClick)}
+              onClick={(e) => withLoginCheck(() => onLikeClick(e))}
               className={`stat-box btn-like ${isLiked ? "active" : ""}`}
             >
               <Heart 


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #109 
---
## 🎨 작업 내용 (What)
- ChatModal, ChatSlideModal, OneononeChatModal 내 email 비교를 userId 비교로 교체
- `isMyMessage`, `isIamAuthor` 등 판별 로직을 `postAuthor.id` / `applicant.id` 기반으로 변경
- `useCurrentUser` 훅 삭제 및 `useAuth`로 교체 (Mate.tsx 포함)
- `localStorage.getItem("userEmail")` / `setItem("userEmail")` 참조 전수 제거
- MateDetail 좋아요 optimistic update에서 `isLiked` → `liked` 필드명 통일
- `withLoginCheck` 콜백 내 `onLikeClick` 미호출 버그 수정
---
## 🧭 작업 목적 (Why)
- BE DTO가 senderId를 email → userId로 변경함에 따라 FE identity 비교 로직 대응
- 채팅 메시지가 항상 왼쪽에 표시되는 버그 해결 (email vs userId 타입 불일치가 근본 원인)
- `useCurrentUser` + `localStorage.userEmail` 이중 관리를 `useAuth` 단일 소스로 통합
- liked/isLiked 필드명 불일치로 인한 좋아요 하트 색상 미반영 버그 수정
---
## 🧩 변경 범위
- [ ] UI / Layout
- [x] 컴포넌트 구조
- [x] 상태 관리 로직
- [x] API 연동
- [ ] 스타일
---
## 🧪 테스트 방법
- [x] 로컬 실행 확인
- [x] 주요 화면 렌더링 확인
- [x] 에러 콘솔 확인
- 채팅방 진입 → 내 메시지 오른쪽, 상대 메시지 왼쪽 정렬 확인
- 좋아요 클릭 → 하트 빨간색 토글 즉시 반영 확인
- `grep -rn "useCurrentUser" src/` 결과 0건 확인
---
## ⚠️ 참고 사항
- BE PR(ChatMessageResponse/ChatRoomResponse DTO 변경)과 함께 머지해야 정상 동작합니다
- `useAuth().userId`가 `number` 타입인지 확인 필요 — DTO의 `senderId`(Long)와 `===` 비교 시 타입 불일치 가능성 있음
---
## ✅ 체크리스트
- [x] main 브랜치 직접 push 하지 않음
- [x] feature 브랜치에서 작업함
- [x] 불필요한 console.log 제거
- [x] PR 단위가 과도하게 크지 않음