### PR TITLE
[FE] feature: 장소 데이터 Spring 연동 및 DayAll 화면 구조 전환

### DIFF
--- a/src/api/place.api.ts
+++ b/src/api/place.api.ts
@@ -1,0 +1,24 @@
+// src/api/place.api.ts
+import { api } from "./api";
+
+// 장소 조회
+export const getPlaces = (tripId: number) =>
+  api.get(`/places?tripId=${tripId}`);
+
+// 장소 저장
+export const createPlace = (body: object) =>
+  api.post("/places", body);
+
+// 장소 수정 (카테고리, 메모)
+export const updatePlace = (
+  placeId: string,
+  body: { category?: string; memo?: string }
+) => api.patch(`/places/${placeId}`, body);
+
+// 장소 삭제
+export const deletePlace = (placeId: string) =>
+  api.delete(`/places/${placeId}`);
+
+// 장소 검색 (네이버 API 프록시)
+export const searchPlaces = (query: string, display = 12) =>
+  api.get("/places/search", { params: { query, display } });

--- a/src/features/workspace/components/schedule/DayAllView.tsx
+++ b/src/features/workspace/components/schedule/DayAllView.tsx
@@ -6,6 +6,7 @@ import AiScheduleModal from "../schedule/modal/AiScheduleModal";
 import type { TimelineNode } from "../schedule/modal/AiScheduleModal";
 import { useWorkspaceCore } from "../../hooks/useWorkspaceCore";
 import { useNaverMap } from "../../hooks/useNaverMap";
+import { usePlaces } from "../../hooks/usePlaces";
 import { CATEGORY_COLOR, CATEGORY_LIST, getCategoryIcon } from "../../hooks/schedule.constants";
 import "../../styles/center.css";
 import "../../styles/modals.css";
@@ -24,6 +25,7 @@ interface Place {
 }
 
 interface DayAllViewProps {
+  tripId: number;
   tripTitle: string;
   startDate: string;
   endDate: string;
@@ -33,6 +35,7 @@ interface DayAllViewProps {
 
 
 const DayAllView: React.FC<DayAllViewProps> = ({
+  tripId,
   tripTitle,
   startDate,
   endDate,
@@ -40,11 +43,11 @@ const DayAllView: React.FC<DayAllViewProps> = ({
 }) => {
   const { selectTab } = useWorkspaceCore();
   const { mapLoaded, mapKey } = useNaverMap();
+  const { places: savedPlaces, addPlace, updatePlace, deletePlace } = usePlaces(tripId);
 
 
 
   // ── 상태 ───────────────────────────────────────────────────
-  const [savedPlaces, setSavedPlaces] = useState<Place[]>([]);
   const [isAddModalOpen, setIsAddModalOpen] = useState(false);
   const [isAiModalOpen, setIsAiModalOpen] = useState(false);
   const [category, setCategory] = useState("all");
@@ -59,30 +62,6 @@ const DayAllView: React.FC<DayAllViewProps> = ({
   const mapInstanceRef = useRef<any>(null);
   const markersRef = useRef<any[]>([]);
   const infoWindowRef = useRef<any>(null);
-
-  // ── localStorage 로드 ──────────────────────────────────────
-  const [isLoaded, setIsLoaded] = useState(false);
-
-  useEffect(() => {
-    const saved = localStorage.getItem("saved_places");
-    if (saved) {
-      try {
-        const parsed = JSON.parse(saved);
-        if (Array.isArray(parsed)) {
-          setSavedPlaces(parsed);
-        }
-      } catch {
-        // 파싱 실패 시 빈 배열 유지
-      }
-    }
-    setIsLoaded(true);
-  }, []);
-
-  // 로드 완료 후에만 저장 — 초기 빈 배열이 localStorage를 덮어쓰는 것을 방지
-  useEffect(() => {
-    if (!isLoaded) return;
-    localStorage.setItem("saved_places", JSON.stringify(savedPlaces));
-  }, [savedPlaces, isLoaded]);
 
   // ── 지도 초기화 ──────────────────────────────────────────
   useEffect(() => {
@@ -206,12 +185,20 @@ const DayAllView: React.FC<DayAllViewProps> = ({
   };
 
   // ── CRUD ───────────────────────────────────────────────────
-  const handleAddPlace = (place: Place) => {
-    if (savedPlaces.some((p) => p.id === place.id)) {
+  const handleAddPlace = async (place: Place) => {
+    if (savedPlaces.some((p) => p.id === place.id || (p.name === place.name && p.lat === place.lat))) {
       showToast("이미 추가된 장소입니다.");
       return;
     }
-    setSavedPlaces([...savedPlaces, place]);
+    await addPlace({
+      name: place.name,
+      category: place.category,
+      address: place.address,
+      description: place.description,
+      memo: place.memo,
+      lat: place.lat,
+      lng: place.lng,
+    });
     showToast(`${place.name} 추가됨`);
   };
 
@@ -219,19 +206,19 @@ const DayAllView: React.FC<DayAllViewProps> = ({
     setConfirmTargetId(placeId);
   };
 
-  const confirmRemove = () => {
+  const confirmRemove = async () => {
     if (!confirmTargetId) return;
-    setSavedPlaces(savedPlaces.filter((p) => p.id !== confirmTargetId));
+    await deletePlace(confirmTargetId);
     setConfirmTargetId(null);
     setExpandedId(null);
   };
 
   const updateCategory = (placeId: string, category: string) => {
-    setSavedPlaces(savedPlaces.map((p) => (p.id === placeId ? { ...p, category } : p)));
+    updatePlace(placeId, { category });
   };
 
   const updateMemo = (placeId: string, memo: string) => {
-    setSavedPlaces(savedPlaces.map((p) => (p.id === placeId ? { ...p, memo } : p)));
+    updatePlace(placeId, { memo });
   };
 
   const handleOpenAiModal = () => {
@@ -542,6 +529,7 @@ const DayAllView: React.FC<DayAllViewProps> = ({
           savedPlaces={savedPlaces}
           startDate={startDate}
           endDate={endDate}
+          tripId={tripId}
         />
       )}
 

--- a/src/features/workspace/components/schedule/modal/AddPlaceModal.tsx
+++ b/src/features/workspace/components/schedule/modal/AddPlaceModal.tsx
@@ -2,6 +2,7 @@
 import React, { useState, useEffect, useRef, useCallback } from "react";
 import "../../../styles/modals.css";
 import { useNaverMap } from "../../../hooks/useNaverMap";
+import { searchPlaces } from "../../../../../api/place.api";
 import { CATEGORY_COLOR, getCategoryIcon } from "../../../hooks/schedule.constants";
 
 interface Place {
@@ -23,7 +24,6 @@ interface AddPlaceModalProps {
   existingPlaces: Place[];
 }
 
-const API_BASE = import.meta.env.VITE_API_BASE_URL ?? "http://localhost:8000";
 
 const CATEGORY_MAP: Record<string, string> = {
   관광지: "관광",
@@ -173,14 +173,7 @@ const AddPlaceModal: React.FC<AddPlaceModalProps> = ({
     setSelectedPlace(null);
 
     try {
-      const res = await fetch(
-        `${API_BASE}/schedule/search?query=${encodeURIComponent(query.trim())}&display=12`
-      );
-      if (!res.ok) {
-        const err = await res.json().catch(() => ({}));
-        throw new Error(err.detail || `서버 오류 (${res.status})`);
-      }
-      const data = await res.json();
+      const { data } = await searchPlaces(query.trim(), 12);
 
       if (!data.success || !data.places?.length) {
         setErrorMsg(`'${query}' 검색 결과가 없습니다.`);

--- a/src/features/workspace/hooks/schedule.constants.ts
+++ b/src/features/workspace/hooks/schedule.constants.ts
@@ -1,15 +1,12 @@
 // src/features/workspace/constants/schedule_constants.ts
-// 카테고리 관련 상수를 한 곳에서 관리합니다.
-// 모든 컴포넌트는 여기서 import하세요.
 
-// ─── 프론트엔드 표시용 카테고리 ──────────────────────────────
 export const CATEGORY_COLOR: Record<string, string> = {
   관광: "#1976d2",
   맛집: "#e53935",
   카페: "#6d4c41",
   쇼핑: "#7b1fa2",
   숙소: "#2e7d32",
-  교통: "#546e7a",   // 공항, 기차역, 버스터미널 등 이동 거점
+  교통: "#546e7a",
 };
 
 export const CATEGORY_LIST = ["관광", "맛집", "카페", "쇼핑", "숙소", "교통"] as const;
@@ -22,12 +19,9 @@ export const getCategoryIcon = (cat: string): string =>
     관광: "🏛️",
     쇼핑: "🛍️",
     숙소: "🏨",
-    교통: "✈️",   // 공항/기차역/버스터미널 대표 아이콘
+    교통: "✈️",
   } as Record<string, string>)[cat] ?? "📍");
 
-// ─── 프론트 → 백엔드 카테고리 변환 ─────────────────────────
-// 프론트: "관광" / 백엔드: "관광지"  (불일치 버그 방지)
-// 프론트: "교통" / 백엔드: "출발지"  (일정 생성 시 출발/도착 기준점으로 처리)
 export const CATEGORY_TO_BACKEND: Record<string, string> = {
   관광: "관광지",
   맛집: "맛집",
@@ -37,7 +31,6 @@ export const CATEGORY_TO_BACKEND: Record<string, string> = {
   교통: "출발지",
 };
 
-// ─── 백엔드 → 프론트 카테고리 변환 ─────────────────────────
 export const CATEGORY_FROM_BACKEND: Record<string, string> = {
   관광지: "관광",
   맛집: "맛집",
@@ -47,25 +40,16 @@ export const CATEGORY_FROM_BACKEND: Record<string, string> = {
   출발지: "교통",
 };
 
-// ─── 이동 수단 변환 ──────────────────────────────────────────
 export const TRANSPORT_TO_BACKEND: Record<string, string> = {
   walk: "도보",
   public: "대중교통",
   car: "택시",
 };
 
-// ─── 페이스(pace) 변환 ───────────────────────────────────────
 export const PACE_TO_BACKEND: Record<string, string> = {
   efficiency: "tight",
   balanced: "normal",
   relaxed: "relaxed",
 };
 
-// ─── localStorage 스키마 버전 ────────────────────────────────
-export const STORAGE_SCHEMA_VERSION = 2;
-export const STORAGE_KEYS = {
-  TIMELINE: "tripmoa_timeline_data",
-  DATE_LOGS: "tripmoa_date_logs",
-  SAVED_PLACES: "saved_places",
-  SCHEMA_VERSION: "tripmoa_schema_version",
-} as const;
+// STORAGE_KEYS, STORAGE_SCHEMA_VERSION 제거 — localStorage 완전 제거됨

--- a/src/features/workspace/hooks/usePlaces.ts
+++ b/src/features/workspace/hooks/usePlaces.ts
@@ -1,0 +1,94 @@
+// src/features/workspace/hooks/usePlaces.ts
+import { useEffect, useState, useCallback } from "react";
+import { getPlaces, createPlace, updatePlace, deletePlace } from "../../../api/place.api";
+
+export interface Place {
+  id: string;
+  name: string;
+  category: string;
+  address: string;
+  description?: string;
+  memo?: string;
+  imageUrl?: string;
+  rating?: number;
+  lat?: number;
+  lng?: number;
+}
+
+export const usePlaces = (tripId: number | null) => {
+  const [places, setPlaces] = useState<Place[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchPlaces = useCallback(async () => {
+    if (!tripId) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const { data } = await getPlaces(tripId);
+      setPlaces(data.map((p: any) => ({
+        id: String(p.id),
+        name: p.name,
+        category: p.category,
+        address: p.address ?? "",
+        description: p.description ?? "",
+        memo: p.memo ?? "",
+        lat: p.lat,
+        lng: p.lng,
+      })));
+    } catch (e: any) {
+      setError(e.message);
+    } finally {
+      setLoading(false);
+    }
+  }, [tripId]);
+
+  useEffect(() => { fetchPlaces(); }, [fetchPlaces]);
+
+  const addPlace = useCallback(async (place: Omit<Place, "id">) => {
+    if (!tripId) return;
+    try {
+      const { data } = await createPlace({ tripId, ...place });
+      setPlaces((prev) => [...prev, {
+        id: String(data.id),
+        name: data.name,
+        category: data.category,
+        address: data.address ?? "",
+        description: data.description ?? "",
+        memo: data.memo ?? "",
+        lat: data.lat,
+        lng: data.lng,
+      }]);
+    } catch (e: any) {
+      setError(e.message);
+    }
+  }, [tripId]);
+
+  const updatePlaceItem = useCallback(async (placeId: string, patch: { category?: string; memo?: string }) => {
+    try {
+      const { data } = await updatePlace(placeId, patch);
+      setPlaces((prev) => prev.map((p) =>
+        p.id === placeId ? { ...p, category: data.category, memo: data.memo } : p
+      ));
+    } catch (e: any) {
+      setError(e.message);
+    }
+  }, []);
+
+  const deletePlaceItem = useCallback(async (placeId: string) => {
+    try {
+      await deletePlace(placeId);
+      setPlaces((prev) => prev.filter((p) => p.id !== placeId));
+    } catch (e: any) {
+      setError(e.message);
+    }
+  }, []);
+
+  return {
+    places, loading, error,
+    addPlace,
+    updatePlace: updatePlaceItem,
+    deletePlace: deletePlaceItem,
+    refetch: fetchPlaces,
+  };
+};


### PR DESCRIPTION
## 🔗 관련 이슈
* Parent: #22
* Close: #115 

---

## 🎨 작업 내용 (What)

* 장소 데이터를 local 상태 → Spring API 기반으로 전환
* 장소 검색 및 추가 기능 서버 연동
* DayAll 화면에서 서버 데이터 기반 장소 리스트 및 지도 렌더링 구현
* 장소 중복 추가 방지 및 카테고리 필터 기능 추가

---

## 🧭 작업 목적 (Why)

기존에는 프론트에서만 장소 데이터를 관리하여 데이터 정합성 문제가 발생할 수 있었음
이를 서버 기반으로 전환하여 일정 생성에 필요한 데이터를 일관된 구조로 관리하고, 이후 기능 확장 가능하도록 개선

---

## 🧩 변경 범위

* [x] UI / Layout
* [x] 컴포넌트 구조
* [x] 상태 관리 로직
* [x] API 연동
* [ ] 스타일

---

## 🧪 테스트 방법

* [x] 로컬 실행 확인
* [x] 주요 화면 렌더링 확인 (DayAll)
* [x] 장소 검색 및 추가 동작 확인
* [x] 지도 마커 및 정보창 정상 동작 확인
* [x] 에러 콘솔 확인

---

## ⚠️ 참고 사항

* 장소 데이터는 `/places` API 기준으로 동작하도록 변경됨
* 기존 localStorage 기반 데이터는 사용하지 않음
* API 응답 구조 변경 시 영향 범위 있음

---

## ✅ 체크리스트

* [x] main 브랜치 직접 push 하지 않음
* [x] feature 브랜치에서 작업함
* [x] 불필요한 console.log 제거
* [x] PR 단위가 과도하게 크지 않음
