### PR TITLE
[FE] feature: AI 일정 생성 및 Timeline 상태를 Spring 기반으로 전환

### DIFF
--- a/src/api/schedule.api.ts
+++ b/src/api/schedule.api.ts
@@ -1,0 +1,36 @@
+// src/api/schedule.api.ts
+import { api } from "./api";
+
+// 일정 조회
+export const getSchedules = (tripId: number) =>
+  api.get(`/schedules?tripId=${tripId}`);
+
+// AI 일정 생성
+export const generateSchedule = (body: object) =>
+  api.post("/schedules/ai", body);
+
+// 노드 추가
+export const createScheduleItem = (body: {
+  scheduleId: number;
+  time: string;
+  title: string;
+  description: string;
+}) => api.post("/schedule-items", body);
+
+// 노드 수정
+export const updateScheduleItem = (
+  itemId: number,
+  body: { time?: string; title?: string; description?: string }
+) => api.patch(`/schedule-items/${itemId}`, body);
+
+// 노드 삭제
+export const deleteScheduleItem = (itemId: number) =>
+  api.delete(`/schedule-items/${itemId}`);
+
+// 순서 변경
+export const reorderScheduleItems = (itemIds: number[]) =>
+  api.patch("/schedule-items/reorder", { itemIds });
+
+// 다른 날로 이동
+export const moveScheduleItem = (itemId: number, targetScheduleId: number) =>
+  api.patch(`/schedule-items/${itemId}/move`, { targetScheduleId });

--- a/src/features/workspace/components/schedule/modal/AiScheduleModal.tsx
+++ b/src/features/workspace/components/schedule/modal/AiScheduleModal.tsx
@@ -1,12 +1,13 @@
 // src/features/workspace/components/schedule/modal/AiScheduleModal.tsx
 
 import React, { useState, useEffect, useMemo } from "react";
+import { generateSchedule } from "../../../../../api/schedule.api";
+import { searchPlaces } from "../../../../../api/place.api";
 import "../../../styles/modals.css";
 import {
   CATEGORY_TO_BACKEND,
   TRANSPORT_TO_BACKEND,
   PACE_TO_BACKEND,
-  STORAGE_KEYS,
 } from "../../../hooks/schedule.constants";
 
 interface Place {
@@ -69,6 +70,8 @@ export interface TimelineNode {
     memo?: string;
     imageUrl?: string;
     rating?: number;
+    lat?: number;
+    lng?: number;
   };
 }
 
@@ -82,11 +85,12 @@ interface AiScheduleModalProps {
   savedPlaces: Place[];
   startDate: string;
   endDate: string;
+  tripId: number;
   /** 모달 안에서 바로 장소를 추가할 수 있도록 부모의 핸들러를 받음 */
   onAddPlace: (place: Place) => void;
 }
 
-const API_BASE = import.meta.env.VITE_API_BASE_URL ?? "http://localhost:8000";
+
 
 function calcNDays(start: string, end: string): number {
   try {
@@ -112,6 +116,7 @@ const AiScheduleModal: React.FC<AiScheduleModalProps> = ({
   savedPlaces,
   startDate,
   endDate,
+  tripId,
   onAddPlace,
 }) => {
   const [settings, setSettings] = useState<AiScheduleSettings>({
@@ -246,6 +251,7 @@ const AiScheduleModal: React.FC<AiScheduleModalProps> = ({
     const resolvedHotels = [...manualHotels, ...autoHotels];
 
     const body = {
+      tripId,
       places: visitPlaces.map((p) => ({
         name: p.name,
         lat: p.lat,
@@ -303,117 +309,55 @@ const AiScheduleModal: React.FC<AiScheduleModalProps> = ({
     setPinWarnings([]);
 
     try {
-      const res = await fetch(`${API_BASE}/schedule/generate`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(body),
-      });
-
-      if (!res.ok) {
-        const err = await res.json().catch(() => ({}));
-        throw new Error(err.detail || `서버 오류 (${res.status})`);
-      }
-
-      const data = await res.json();
-      if (!data.success || !data.itinerary)
+      const { data } = await generateSchedule(body);
+      // Spring이 ScheduleResponse[] 형태로 반환
+      // [{ scheduleId, day, items: [{ id, time, title, description, orderIndex }] }]
+      if (!data || !Array.isArray(data) || data.length === 0)
         throw new Error("일정 생성에 실패했습니다.");
 
-      // ── pin_warnings 수집 (백엔드에서 반환) ──
-      const collectedPinWarnings: string[] = [];
-      Object.values(data.itinerary).forEach((dayData: any) => {
-        if (Array.isArray(dayData.pin_warnings)) {
-          collectedPinWarnings.push(...dayData.pin_warnings);
-        }
-      });
-
-      // ── API 응답 → TimelineNode 변환 ──
+      // ── API 응답(Spring ScheduleResponse[]) → TimelineNode 변환 ──
       const generatedSchedule: Record<string, TimelineNode[]> = {};
       const dayKeys: string[] = [];
 
-      Object.entries(data.itinerary).forEach(([dayKey, dayData]: [string, any]) => {
-        const dayNum = dayKey.replace("day_", "");
-        const label = `DAY ${dayNum}`;
+      (data as any[]).forEach((schedule: any) => {
+        const label = `DAY ${schedule.day}`;
         dayKeys.push(label);
 
-        generatedSchedule[label] = (dayData.places || []).map((p: any) => {
-          const matched = savedPlaces.find((sp) => sp.name === p.place);
-          // 이동시간 추정치임을 desc에 명시
-          const travelNote =
-            p.travel_minutes != null
-              ? `이동 약 ${p.travel_minutes}분 (추정)`
-              : null;
-
+        generatedSchedule[label] = (schedule.items || []).map((item: any) => {
+          // 완전 일치 먼저, 없으면 부분 일치로 폴백
+          const matched = savedPlaces.find((sp) => sp.name === item.title)
+            ?? savedPlaces.find((sp) =>
+              item.title && (
+                sp.name.includes(item.title) || item.title.includes(sp.name)
+              )
+            );
           return {
-            time: p.time || "00:00",
-            title: p.place || "",
-            desc: [
-              p.address,
-              p.stay_minutes ? `${p.stay_minutes}분 체류` : null,
-              travelNote,
-              p.type === "hotel_checkin"
-                ? "🏨 체크인"
-                : p.type === "hotel"
-                ? "🏨 숙소"
-                : p.type === "departure"
-                ? "✈️ 출발"
-                : p.type === "arrival"
-                ? "📍 집결"
-                : null,
-            ]
-              .filter(Boolean)
-              .join(" · "),
+            id: item.id,
+            scheduleId: schedule.scheduleId,
+            time: item.time || "00:00",
+            title: item.title || "",
+            desc: item.description || "",
             placeInfo: {
-              name: p.place || "",
-              address: p.address || "",
-              category: p.category || "",
+              name: item.title || "",
+              address: item.description || "",
+              category: matched?.category || "",
               description: matched?.description || "",
               memo: matched?.memo || "",
               imageUrl: matched?.imageUrl,
               rating: matched?.rating,
+              lat: matched?.lat,
+              lng: matched?.lng,
             },
           };
         });
       });
 
-      // ── localStorage 저장 ──
-      try {
-        const existing = localStorage.getItem(STORAGE_KEYS.TIMELINE);
-        const timelineData: Record<string, TimelineNode[]> = existing
-          ? JSON.parse(existing)
-          : {};
-        dayKeys.forEach((label) => {
-          timelineData[label] = generatedSchedule[label];
-        });
-        localStorage.setItem(STORAGE_KEYS.TIMELINE, JSON.stringify(timelineData));
-
-        const existingLogs = localStorage.getItem(STORAGE_KEYS.DATE_LOGS);
-        const dateLogs: string[] = existingLogs ? JSON.parse(existingLogs) : [];
-        dayKeys.forEach((label) => {
-          if (!dateLogs.includes(label)) dateLogs.push(label);
-        });
-        localStorage.setItem(STORAGE_KEYS.DATE_LOGS, JSON.stringify(dateLogs));
-      } catch (storageErr) {
-        console.error("[AiScheduleModal] localStorage 저장 실패:", storageErr);
-        // 저장 실패해도 콜백은 호출 (인메모리 상태는 유지)
-      }
-
       setLoadingProgress(100);
 
-      // pin 경고가 있으면 잠깐 표시 후 닫기
-      if (collectedPinWarnings.length > 0) {
-        setPinWarnings(collectedPinWarnings);
-        setIsLoading(false);
-        // 경고 확인 후 사용자가 직접 닫도록 (또는 3초 후 자동 완료)
-        setTimeout(() => {
-          onGenerate(settings, generatedSchedule, dayKeys);
-          onClose();
-        }, 4000);
-      } else {
-        setTimeout(() => {
-          onGenerate(settings, generatedSchedule, dayKeys);
-          onClose();
-        }, 400);
-      }
+      setTimeout(() => {
+        onGenerate(settings, generatedSchedule, dayKeys);
+        onClose();
+      }, 400);
     } catch (e: any) {
       setErrorMsg(e.message || "일정 생성 중 오류가 발생했습니다.");
       setIsLoading(false);
@@ -449,18 +393,14 @@ const AiScheduleModal: React.FC<AiScheduleModalProps> = ({
     setHotelSearchResults([]);
 
     try {
-      const res = await fetch(
-        `${API_BASE}/schedule/search?query=${encodeURIComponent(q)}&display=8`
-      );
-      if (!res.ok) throw new Error(`서버 오류 (${res.status})`);
-      const data = await res.json();
+      const { data: searchData } = await searchPlaces(q, 8);
 
-      if (!data.success || !data.places?.length) {
+      if (!searchData.success || !searchData.places?.length) {
         setHotelSearchError(`'${q}' 검색 결과가 없습니다.`);
         return;
       }
 
-      const mapped: Place[] = data.places.map((p: any, idx: number) => ({
+      const mapped: Place[] = searchData.places.map((p: any, idx: number) => ({
         id: `hotel_search_${Date.now()}_${idx}`,
         name: p.name,
         category: "숙소",          // 숙소 검색이므로 카테고리 고정
@@ -507,18 +447,14 @@ const AiScheduleModal: React.FC<AiScheduleModalProps> = ({
     setDeptSearchResults([]);
 
     try {
-      const res = await fetch(
-        `${API_BASE}/schedule/search?query=${encodeURIComponent(q)}&display=8`
-      );
-      if (!res.ok) throw new Error(`서버 오류 (${res.status})`);
-      const data = await res.json();
+      const { data: deptData } = await searchPlaces(q, 8);
 
-      if (!data.success || !data.places?.length) {
+      if (!deptData.success || !deptData.places?.length) {
         setDeptSearchError(`'${q}' 검색 결과가 없습니다.`);
         return;
       }
 
-      const mapped: Place[] = data.places.map((p: any, idx: number) => ({
+      const mapped: Place[] = deptData.places.map((p: any, idx: number) => ({
         id: `dept_search_${Date.now()}_${idx}`,
         name: p.name,
         category: "교통",   // 출발지 검색 결과는 교통 카테고리로 저장

--- a/src/features/workspace/hooks/useTimeline.ts
+++ b/src/features/workspace/hooks/useTimeline.ts
@@ -1,6 +1,13 @@
 // src/features/workspace/hooks/useTimeline.ts
 import { useEffect, useState, useCallback } from "react";
-import { STORAGE_KEYS, STORAGE_SCHEMA_VERSION } from "../hooks/schedule.constants";
+import {
+  getSchedules,
+  createScheduleItem,
+  updateScheduleItem,
+  deleteScheduleItem,
+  reorderScheduleItems,
+  moveScheduleItem,
+} from "../../../api/schedule.api";
 
 interface PlaceInfo {
   name: string;
@@ -10,233 +17,266 @@ interface PlaceInfo {
   memo?: string;
   imageUrl?: string;
   rating?: number;
+  lat?: number;
+  lng?: number;
 }
 
 export interface TimelineNode {
+  id?: number;
+  scheduleId?: number;
   time: string;
   title: string;
   desc: string;
   placeInfo?: PlaceInfo;
 }
 
-// ─── localStorage 안전 헬퍼 ──────────────────────────────────
-
-function safeGetStorage(key: string): string | null {
-  try {
-    return localStorage.getItem(key);
-  } catch (e) {
-    console.warn(`[useTimeline] localStorage.getItem("${key}") 실패:`, e);
-    return null;
-  }
+interface ScheduleItemResponse {
+  id: number;
+  time: string;
+  title: string;
+  category?: string;
+  description: string;
+  orderIndex: number;
+  lat?: number;
+  lng?: number;
 }
 
-function safeSetStorage(key: string, value: string): boolean {
-  try {
-    localStorage.setItem(key, value);
-    return true;
-  } catch (e) {
-    // QuotaExceededError 등
-    console.error(`[useTimeline] localStorage.setItem("${key}") 실패:`, e);
-    return false;
-  }
+interface ScheduleResponse {
+  scheduleId: number;
+  day: number;
+  items: ScheduleItemResponse[];
 }
 
-function safeParseJSON<T>(raw: string | null, fallback: T): T {
-  if (!raw) return fallback;
-  try {
-    return JSON.parse(raw) as T;
-  } catch (e) {
-    console.warn("[useTimeline] JSON 파싱 실패:", e);
-    return fallback;
-  }
+function toTimelineNodes(scheduleId: number, items: ScheduleItemResponse[]): TimelineNode[] {
+  return items.map((item) => ({
+    id: item.id,
+    scheduleId,
+    time: item.time,
+    title: item.title,
+    desc: item.description,
+    placeInfo: {
+      name: item.title,
+      address: item.description,
+      category: item.category,
+      lat: item.lat,
+      lng: item.lng,
+    },
+  }));
 }
 
-// ─── 스키마 마이그레이션 ─────────────────────────────────────
-// 버전이 다를 경우 기존 데이터를 안전하게 초기화하고 버전을 갱신합니다.
-
-function runMigrationIfNeeded(): void {
-  const savedVersion = safeParseJSON<number>(
-    safeGetStorage(STORAGE_KEYS.SCHEMA_VERSION),
-    0
-  );
-
-  if (savedVersion < STORAGE_SCHEMA_VERSION) {
-    console.info(
-      `[useTimeline] 스키마 마이그레이션: v${savedVersion} → v${STORAGE_SCHEMA_VERSION}`
-    );
-    // v1 이하: 타임라인/날짜 데이터 구조 변경 가능성 — 기존 데이터 초기화
-    if (savedVersion < 2) {
-      // 기존 타임라인 데이터는 유지하되 구조가 맞는지 검증
-      const raw = safeGetStorage(STORAGE_KEYS.TIMELINE);
-      const data = safeParseJSON<Record<string, unknown>>(raw, {});
-      const isValid =
-        typeof data === "object" &&
-        !Array.isArray(data) &&
-        Object.values(data).every((v) => Array.isArray(v));
-
-      if (!isValid) {
-        console.warn("[useTimeline] 기존 타임라인 데이터 구조 불일치 — 초기화");
-        safeSetStorage(STORAGE_KEYS.TIMELINE, "{}");
-        safeSetStorage(STORAGE_KEYS.DATE_LOGS, "[]");
-      }
-    }
-    safeSetStorage(
-      STORAGE_KEYS.SCHEMA_VERSION,
-      JSON.stringify(STORAGE_SCHEMA_VERSION)
-    );
-  }
+function toDayKey(day: number): string {
+  return `DAY ${day}`;
 }
 
-// ─── 훅 본체 ────────────────────────────────────────────────
-
-export const useTimeline = (currentDay: string) => {
+export const useTimeline = (currentDay: string, tripId: number | null) => {
   const [nodes, setNodes] = useState<TimelineNode[]>([]);
-  const [storageError, setStorageError] = useState<string | null>(null);
+  const [allDays, setAllDays] = useState<Record<string, TimelineNode[]>>({});
+  const [scheduleIdMap, setScheduleIdMap] = useState<Record<string, number>>({});
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
-  // 앱 첫 마운트 시 마이그레이션 실행
-  useEffect(() => {
-    runMigrationIfNeeded();
-  }, []);
-
-  /* =========================
-     1️⃣ DAY 변경 시 저장된 일정 불러오기
-  ========================= */
-  useEffect(() => {
-    if (!currentDay || currentDay === "DAY ALL") {
-      setNodes([]);
-      return;
+  const fetchAll = useCallback(async () => {
+    if (!tripId) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const { data } = await getSchedules(tripId);
+      const mapped: Record<string, TimelineNode[]> = {};
+      const idMap: Record<string, number> = {};
+      data.forEach((schedule: ScheduleResponse) => {
+        const key = toDayKey(schedule.day);
+        mapped[key] = toTimelineNodes(schedule.scheduleId, schedule.items);
+        idMap[key] = schedule.scheduleId;
+      });
+      setAllDays(mapped);
+      setScheduleIdMap(idMap);
+    } catch {
+      setError("일정을 불러오지 못했습니다.");
+    } finally {
+      setLoading(false);
     }
+  }, [tripId]);
 
-    const raw = safeGetStorage(STORAGE_KEYS.TIMELINE);
-    const data = safeParseJSON<Record<string, TimelineNode[]>>(raw, {});
-    setNodes(data[currentDay] ?? []);
-  }, [currentDay]);
+  useEffect(() => { fetchAll(); }, [fetchAll]);
 
-  /* =========================
-     2️⃣ nodes 변경 시 자동 저장
-  ========================= */
   useEffect(() => {
-    if (!currentDay || currentDay === "DAY ALL") return;
+    if (!currentDay || currentDay === "DAY ALL") { setNodes([]); return; }
+    setNodes(allDays[currentDay] ?? []);
+  }, [currentDay, allDays]);
 
-    const raw = safeGetStorage(STORAGE_KEYS.TIMELINE);
-    const data = safeParseJSON<Record<string, TimelineNode[]>>(raw, {});
-    data[currentDay] = nodes;
-
-    const ok = safeSetStorage(STORAGE_KEYS.TIMELINE, JSON.stringify(data));
-    if (!ok) {
-      setStorageError(
-        "저장 공간이 부족합니다. 일정이 저장되지 않을 수 있습니다."
-      );
-    } else {
-      setStorageError(null);
-    }
-  }, [nodes, currentDay]);
-
-  /* =========================
-     3️⃣ 노드 추가
-  ========================= */
-  const addNode = useCallback(() => {
-    setNodes((prev) => [...prev, { time: "00:00", title: "NEW", desc: "" }]);
-  }, []);
-
-  /* =========================
-     4️⃣ 노드 수정
-  ========================= */
-  const updateNode = useCallback(
-    (idx: number, field: string, value: string) => {
-      setNodes((prev) =>
-        prev.map((n, i) => (i === idx ? { ...n, [field]: value } : n))
-      );
-    },
-    []
-  );
-
-  /* =========================
-     5️⃣ 노드 삭제
-  ========================= */
-  const deleteNode = useCallback((idx: number) => {
-    setNodes((prev) => prev.filter((_, i) => i !== idx));
-  }, []);
-
-  /* =========================
-     6️⃣ 노드 순서 변경 (드래그앤드롭 결과 반영)
-  ========================= */
-  const reorderNodes = useCallback((fromIdx: number, toIdx: number) => {
-    setNodes((prev) => {
-      const next = [...prev];
-      const [moved] = next.splice(fromIdx, 1);
-      next.splice(toIdx, 0, moved);
-      return next;
-    });
-  }, []);
-
-  /* =========================
-     7️⃣ 노드를 다른 날로 이동
-  ========================= */
-  const moveNodeToDay = useCallback(
-    (idx: number, targetDay: string) => {
-      const node = nodes[idx];
-      if (!node) return;
-
-      const nextNodes = nodes.filter((_, i) => i !== idx);
-      setNodes(nextNodes);
-
-      const raw = safeGetStorage(STORAGE_KEYS.TIMELINE);
-      const data = safeParseJSON<Record<string, TimelineNode[]>>(raw, {});
-      data[currentDay] = nextNodes;
-      data[targetDay] = [...(data[targetDay] ?? []), node];
-
-      const ok = safeSetStorage(STORAGE_KEYS.TIMELINE, JSON.stringify(data));
-      if (!ok) {
-        setStorageError(
-          "저장 공간이 부족합니다. 일정 이동이 저장되지 않을 수 있습니다."
-        );
-      }
-    },
-    [nodes, currentDay]
-  );
-
-  /* =========================
-     8️⃣ 외부 데이터로 타임라인 교체 (AI 생성 결과 반영)
-        페이지 새로고침 없이 상태 직접 업데이트
-  ========================= */
   const loadFromExternal = useCallback(
     (allDaysData: Record<string, TimelineNode[]>) => {
-      const raw = safeGetStorage(STORAGE_KEYS.TIMELINE);
-      const existing = safeParseJSON<Record<string, TimelineNode[]>>(raw, {});
-      const merged = { ...existing, ...allDaysData };
-
-      const ok = safeSetStorage(
-        STORAGE_KEYS.TIMELINE,
-        JSON.stringify(merged)
-      );
-      if (!ok) {
-        setStorageError(
-          "저장 공간이 부족합니다. 일정이 저장되지 않을 수 있습니다."
-        );
-        return;
-      }
-      setStorageError(null);
-
-      if (
-        currentDay &&
-        currentDay !== "DAY ALL" &&
-        allDaysData[currentDay]
-      ) {
+      setAllDays((prev) => ({ ...prev, ...allDaysData }));
+      if (currentDay && currentDay !== "DAY ALL" && allDaysData[currentDay]) {
         setNodes(allDaysData[currentDay]);
       }
+      // scheduleIdMap도 업데이트 — 노드의 scheduleId로 역추적
+      setScheduleIdMap((prev) => {
+        const next = { ...prev };
+        Object.entries(allDaysData).forEach(([dayKey, nodes]) => {
+          const scheduleId = nodes.find((n) => n.scheduleId != null)?.scheduleId;
+          if (scheduleId != null) {
+            next[dayKey] = scheduleId;
+          }
+        });
+        return next;
+      });
     },
     [currentDay]
   );
 
+  const addNode = useCallback(async () => {
+    const scheduleId = scheduleIdMap[currentDay];
+    if (!scheduleId) return;
+    try {
+      const { data } = await createScheduleItem({
+        scheduleId, time: "00:00", title: "NEW", description: "",
+      });
+      const newNode: TimelineNode = {
+        id: data.id, scheduleId,
+        time: data.time, title: data.title, desc: data.description,
+      };
+      setNodes((prev) => {
+        const next = [...prev, newNode];
+        setAllDays((d) => ({ ...d, [currentDay]: next }));
+        return next;
+      });
+    } catch {
+      setError("노드 추가에 실패했습니다.");
+    }
+  }, [currentDay, scheduleIdMap]);
+
+  // 장소 검색으로 노드 추가 — 장소 정보를 그대로 노드로 생성
+  const addNodeFromPlace = useCallback(async (place: {
+    name: string;
+    category?: string;
+    address?: string;
+    lat?: number;
+    lng?: number;
+    description?: string;
+    memo?: string;
+    rating?: number;
+  }) => {
+    const scheduleId = scheduleIdMap[currentDay];
+    if (!scheduleId) return;
+    try {
+      const { data } = await createScheduleItem({
+        scheduleId,
+        time: "00:00",
+        title: place.name,
+        description: place.address ?? "",
+      });
+      const newNode: TimelineNode = {
+        id: data.id,
+        scheduleId,
+        time: data.time,
+        title: data.title,
+        desc: data.description,
+        placeInfo: {
+          name: place.name,
+          category: place.category ?? "",
+          address: place.address ?? "",
+          lat: place.lat,
+          lng: place.lng,
+          description: place.description,
+          memo: place.memo,
+          rating: place.rating,
+        },
+      };
+      setNodes((prev) => {
+        const next = [...prev, newNode];
+        setAllDays((d) => ({ ...d, [currentDay]: next }));
+        return next;
+      });
+    } catch {
+      setError("노드 추가에 실패했습니다.");
+    }
+  }, [currentDay, scheduleIdMap]);
+
+  const updateNode = useCallback(async (idx: number, field: string, value: string) => {
+    const node = nodes[idx];
+    if (!node?.id) return;
+
+    setNodes((prev) => {
+      const next = prev.map((n, i) => (i === idx ? { ...n, [field]: value } : n));
+      setAllDays((d) => ({ ...d, [currentDay]: next }));
+      return next;
+    });
+
+    const patch: { time?: string; title?: string; description?: string } = {};
+    if (field === "time") patch.time = value;
+    else if (field === "title") patch.title = value;
+    else if (field === "desc") patch.description = value;
+
+    try {
+      await updateScheduleItem(node.id, patch);
+    } catch {
+      setError("노드 수정에 실패했습니다.");
+      fetchAll();
+    }
+  }, [nodes, currentDay, fetchAll]);
+
+  const deleteNode = useCallback(async (idx: number) => {
+    const node = nodes[idx];
+    if (!node?.id) return;
+
+    setNodes((prev) => {
+      const next = prev.filter((_, i) => i !== idx);
+      setAllDays((d) => ({ ...d, [currentDay]: next }));
+      return next;
+    });
+
+    try {
+      await deleteScheduleItem(node.id);
+    } catch {
+      setError("노드 삭제에 실패했습니다.");
+      fetchAll();
+    }
+  }, [nodes, currentDay, fetchAll]);
+
+  const reorderNodes = useCallback(async (fromIdx: number, toIdx: number) => {
+    const next = [...nodes];
+    const [moved] = next.splice(fromIdx, 1);
+    next.splice(toIdx, 0, moved);
+
+    setNodes(next);
+    setAllDays((d) => ({ ...d, [currentDay]: next }));
+
+    const itemIds = next.map((n) => n.id).filter((id): id is number => id != null);
+    try {
+      await reorderScheduleItems(itemIds);
+    } catch {
+      setError("순서 변경에 실패했습니다.");
+      fetchAll();
+    }
+  }, [nodes, currentDay, fetchAll]);
+
+  const moveNodeToDay = useCallback(async (idx: number, targetDay: string) => {
+    const node = nodes[idx];
+    if (!node?.id) return;
+
+    const targetScheduleId = scheduleIdMap[targetDay];
+    if (!targetScheduleId) return;
+
+    const nextNodes = nodes.filter((_, i) => i !== idx);
+    setNodes(nextNodes);
+    setAllDays((prev) => ({
+      ...prev,
+      [currentDay]: nextNodes,
+      [targetDay]: [...(prev[targetDay] ?? []), { ...node, scheduleId: targetScheduleId }],
+    }));
+
+    try {
+      await moveScheduleItem(node.id, targetScheduleId);
+    } catch {
+      setError("일정 이동에 실패했습니다.");
+      fetchAll();
+    }
+  }, [nodes, currentDay, scheduleIdMap, fetchAll]);
+
   return {
-    nodes,
-    storageError,   // 컴포넌트에서 에러 배너 표시용
-    addNode,
-    updateNode,
-    deleteNode,
-    reorderNodes,
-    moveNodeToDay,
-    loadFromExternal,
+    nodes, allDays, loading, error,
+    addNode, addNodeFromPlace, updateNode, deleteNode, reorderNodes, moveNodeToDay,
+    loadFromExternal, refetch: fetchAll,
   };
 };


### PR DESCRIPTION
## 🔗 관련 이슈

* Parent: #22
* Closes: #116 

---

## 🎨 작업 내용 (What)

* AI 일정 생성 기능을 Spring API(`/schedules/ai`) 기반으로 구현
* 서버 응답 데이터를 Timeline 구조로 변환하는 로직 추가
* 일정 조회 및 CRUD를 서버 API 기반으로 전환
* Day별 일정 상태(allDays) 관리 구조 도입 및 동기화 처리

---

## 🧭 작업 목적 (Why)

기존에는 프론트 중심으로 일정 데이터를 생성 및 관리했으나,
이를 서버 중심 구조로 변경하여 데이터 일관성 확보 및 실제 서비스 환경에 맞는 구조로 개선

---

## 🧩 변경 범위

* [ ] UI / Layout
* [ ] 컴포넌트 구조
* [x] 상태 관리 로직
* [x] API 연동
* [ ] 스타일

---

## 🧪 테스트 방법

* [x] 로컬 실행 확인
* [x] AI 일정 생성 API 호출 확인
* [x] 생성된 일정이 Day별로 정상 렌더링 되는지 확인
* [x] 일정 추가/수정/삭제 동작 확인
* [x] 일정 순서 변경 및 이동 기능 확인
* [x] 에러 콘솔 확인

---

## ⚠️ 참고 사항

* AI 일정 생성은 `/schedules/ai` API 의존
* 서버 응답 구조 변경 시 Timeline 변환 로직 수정 필요
* 일정 상태(allDays)는 서버 데이터 기준으로 관리됨

---

## ✅ 체크리스트

* [x] main 브랜치 직접 push 하지 않음
* [x] feature 브랜치에서 작업함
* [x] 불필요한 console.log 제거
* [x] PR 단위가 과도하게 크지 않음
