### PR TITLE
[FE] feature: Workspace 및 DayDetail 화면을 서버 데이터 기반으로 연결

### DIFF
--- a/src/features/workspace/components/layout/WorkspaceCenter.tsx
+++ b/src/features/workspace/components/layout/WorkspaceCenter.tsx
@@ -1,15 +1,17 @@
 // src/features/workspace/components/layout/WorkspaceCenter.tsx
 
-import React, { useState, useMemo } from "react";
+import React, { useState, useMemo, useEffect } from "react";
 
 import "../../styles/center.css";
 import "../../styles/layout.css";
 
 import { useWorkspaceCore } from "../../hooks/useWorkspaceCore";
 import { useTimeline } from "../../hooks/useTimeline";
+import { usePlaces } from "../../hooks/usePlaces";
 import { useTopOption } from "../../hooks/useTopOption";
 import { useExpenses } from "../../hooks/useExpenses";
 import type { ExpenseMember } from "../../hooks/expense.ui.types";
+import { useParams } from "react-router-dom";
 
 import { ExpenseView } from "../expense";
 import { VoucherView } from "../voucher";
@@ -30,18 +32,35 @@ interface Props {
 }
 
 const WorkspaceCenter: React.FC<Props> = ({ noticeStore }) => {
-  const { activeView, currentDay, trip, updateTripData } = useWorkspaceCore();
+  const { activeView, currentDay, trip, updateTripData, syncDateLogs } = useWorkspaceCore();
 
-  const { nodes, addNode, updateNode, deleteNode, reorderNodes, moveNodeToDay, loadFromExternal } = useTimeline(currentDay);
+  const params = useParams<{ tripId: string }>();
+  const tripId = Number(params.tripId) || null;
 
-  const dayKeys: string[] = useMemo(() => {
-    try {
-      const saved = localStorage.getItem("tripmoa_timeline_data");
-      return saved ? Object.keys(JSON.parse(saved)) : [];
-    } catch {
-      return [];
-    }
-  }, [nodes]);
+  // usePlaces: 장소 목록 (localStorage 대체)
+  const { places: savedPlaces, addPlace } = usePlaces(tripId);
+
+  // useTimeline: tripId 전달
+  const {
+    nodes,
+    allDays,
+    addNode,
+    addNodeFromPlace,
+    updateNode,
+    deleteNode,
+    reorderNodes,
+    moveNodeToDay,
+    loadFromExternal,
+  } = useTimeline(currentDay, tripId);
+
+  // allDays 변경 시 사이드바 탭 동기화
+  useEffect(() => {
+    const keys = Object.keys(allDays);
+    if (keys.length > 0) syncDateLogs(keys);
+  }, [allDays]);
+
+  // dayKeys: allDays 상태에서 바로 추출 (localStorage 불필요)
+  const dayKeys: string[] = useMemo(() => Object.keys(allDays), [allDays]);
 
   const {
     notices,
@@ -75,44 +94,26 @@ const WorkspaceCenter: React.FC<Props> = ({ noticeStore }) => {
       <div className="ws-top">
         <div className="ws-title-wrap">
           <span id="privacy-badge">
-            <i
-              className={`fa-solid ${isPrivate ? "fa-lock" : "fa-lock-open"}`}
-            />
+            <i className={`fa-solid ${isPrivate ? "fa-lock" : "fa-lock-open"}`} />
           </span>
-
           <div className="ws-title">{trip.title}</div>
         </div>
 
-        <div
-          className={`ws-opt-wrapper ${open ? "active" : ""}`}
-          ref={dropdownRef}
-        >
+        <div className={`ws-opt-wrapper ${open ? "active" : ""}`} ref={dropdownRef}>
           <button className="ws-opt-btn" onClick={toggle}>
             <i className="fa-solid fa-ellipsis"></i>
           </button>
-
           <div className={`ws-dropdown ${open ? "active" : ""}`}>
-            <div
-              className="ws-dd-item"
-              onClick={(e) => {
-                e.stopPropagation();
-                openTripEdit();
-              }}
-            >
+            <div className="ws-dd-item" onClick={(e) => { e.stopPropagation(); openTripEdit(); }}>
               <i className="fa-solid fa-pen-to-square"></i> 여행 수정
             </div>
-
             <div className="ws-dd-item">
               <i className="fa-solid fa-users"></i> 멤버 관리
             </div>
-
             <div className="ws-dd-item" onClick={togglePrivacy}>
-              <i
-                className={`fa-solid ${isPrivate ? "fa-lock" : "fa-lock-open"}`}
-              ></i>
+              <i className={`fa-solid ${isPrivate ? "fa-lock" : "fa-lock-open"}`}></i>
               <span>{isPrivate ? "공개로 전환" : "비공개로 전환"}</span>
             </div>
-
             <div className="ws-dd-item" onClick={downloadPDF}>
               <i className="fa-solid fa-file-pdf"></i> PDF 다운로드
             </div>
@@ -121,18 +122,13 @@ const WorkspaceCenter: React.FC<Props> = ({ noticeStore }) => {
       </div>
 
       <div className="ws-body">
-        <div
-          id="view-timeline"
-          className={`content-view ${
-            activeView === "timeline" ? "active" : ""
-          }`}
-        >
+        <div id="view-timeline" className={`content-view ${activeView === "timeline" ? "active" : ""}`}>
           {currentDay === "DAY ALL" ? (
             <DayAllView
+              tripId={tripId ?? 0}
               tripTitle={trip.title}
               startDate={trip.startDate}
               endDate={trip.endDate}
-              //추가
               onScheduleGenerated={loadFromExternal}
             />
           ) : (
@@ -142,8 +138,11 @@ const WorkspaceCenter: React.FC<Props> = ({ noticeStore }) => {
               startDate={trip.startDate}
               endDate={trip.endDate}
               nodes={nodes}
+              savedPlaces={savedPlaces}
               dayKeys={dayKeys}
               addNode={addNode}
+              addNodeFromPlace={addNodeFromPlace}
+              addPlace={addPlace}
               updateNode={updateNode}
               deleteNode={deleteNode}
               reorderNodes={reorderNodes}
@@ -152,20 +151,10 @@ const WorkspaceCenter: React.FC<Props> = ({ noticeStore }) => {
           )}
         </div>
 
-        <div
-          id="view-expenses"
-          className={`content-view ${
-            activeView === "expenses" ? "active" : ""
-          }`}
-        >
+        <div id="view-expenses" className={`content-view ${activeView === "expenses" ? "active" : ""}`}>
           <div className="ws-inner">
-            <ExpenseView
-              store={expenseStore}
-              onOpenSettleDetail={(m) => setSettleTarget(m)}
-            />
-
+            <ExpenseView store={expenseStore} onOpenSettleDetail={(m) => setSettleTarget(m)} />
             <ExpenseModal store={expenseStore} />
-
             {settleTarget && (
               <SettleDetailModal
                 store={expenseStore}
@@ -176,10 +165,7 @@ const WorkspaceCenter: React.FC<Props> = ({ noticeStore }) => {
           </div>
         </div>
 
-        <div
-          id="view-voucher"
-          className={`content-view ${activeView === "voucher" ? "active" : ""}`}
-        >
+        <div id="view-voucher" className={`content-view ${activeView === "voucher" ? "active" : ""}`}>
           <VoucherView
             vouchers={voucherStore.vouchers}
             onAdd={() => setIsVoucherModalOpen(true)}
@@ -187,25 +173,18 @@ const WorkspaceCenter: React.FC<Props> = ({ noticeStore }) => {
             onDownload={voucherStore.downloadVoucher}
             onPreview={voucherStore.previewVoucher}
           />
-
           {isVoucherModalOpen && (
             <VoucherModal
               onClose={() => setIsVoucherModalOpen(false)}
               onSave={(request, file) => {
-                if (!file) {
-                  alert("파일을 첨부해주세요.");
-                  return;
-                }
+                if (!file) { alert("파일을 첨부해주세요."); return; }
                 return voucherStore.addVoucher(request, file);
               }}
             />
           )}
         </div>
 
-        <div
-          id="view-notice"
-          className={`content-view ${activeView === "notice" ? "active" : ""}`}
-        >
+        <div id="view-notice" className={`content-view ${activeView === "notice" ? "active" : ""}`}>
           <NoticeView
             notices={notices}
             isLoading={isNoticeLoading}
@@ -221,10 +200,7 @@ const WorkspaceCenter: React.FC<Props> = ({ noticeStore }) => {
         <WorkspaceModals
           init={trip}
           onClose={closeEdit}
-          onSave={(data) => {
-            void updateTripData(data);
-            closeEdit();
-          }}
+          onSave={(data) => { void updateTripData(data); closeEdit(); }}
         />
       )}
 

--- a/src/features/workspace/components/schedule/DayDetailView.tsx
+++ b/src/features/workspace/components/schedule/DayDetailView.tsx
@@ -2,6 +2,7 @@
 
 import React, { useMemo, useState, useEffect, useRef } from "react";
 import PlaceDetailModal from "../schedule/modal/PlaceDetailModal";
+import AddPlaceModal from "../schedule/modal/AddPlaceModal";
 import { useNaverMap } from "../../hooks/useNaverMap";
 import { CATEGORY_COLOR, getCategoryIcon } from "../../hooks/schedule.constants";
 
@@ -14,6 +15,8 @@ interface PlaceInfo {
   category?: string;
   description?: string;
   memo?: string;
+  lat?: number;
+  lng?: number;
 }
 
 interface TimelineNode {
@@ -39,9 +42,21 @@ interface DayDetailViewProps {
   startDate: string;
   endDate: string;
   nodes: TimelineNode[];
+  savedPlaces: SavedPlace[];
   dayKeys?: string[];
   storageError?: string | null;
   addNode: () => void;
+  addNodeFromPlace: (place: {
+    name: string;
+    category?: string;
+    address?: string;
+    lat?: number;
+    lng?: number;
+    description?: string;
+    memo?: string;
+    rating?: number;
+  }) => Promise<void>;
+  addPlace: (place: Omit<SavedPlace, "id">) => Promise<void>;
   updateNode: (idx: number, field: string, value: string) => void;
   deleteNode: (idx: number) => void;
   reorderNodes: (fromIdx: number, toIdx: number) => void;
@@ -53,15 +68,19 @@ const DayDetailView: React.FC<DayDetailViewProps> = ({
   tripTitle,
   startDate,
   nodes,
+  savedPlaces,
   dayKeys = [],
   storageError = null,
   addNode,
+  addNodeFromPlace,
+  addPlace,
   updateNode,
   deleteNode,
   reorderNodes,
   moveNodeToDay,
 }) => {
   const [selectedPlace, setSelectedPlace] = useState<PlaceInfo | null>(null);
+  const [isAddNodeModalOpen, setIsAddNodeModalOpen] = useState(false);
   const [mapSelectedPlace, setMapSelectedPlace] = useState<SavedPlace | null>(null);
 
   const { mapLoaded, mapKey } = useNaverMap();
@@ -70,24 +89,6 @@ const DayDetailView: React.FC<DayDetailViewProps> = ({
   const mapInstanceRef = useRef<any>(null);
   const markersRef = useRef<any[]>([]);
   const infoWindowRef = useRef<any>(null);
-
-  // saved_places에서 lat/lng 참조 — storage 변경도 감지
-  const [savedPlaces, setSavedPlaces] = useState<SavedPlace[]>([]);
-
-  useEffect(() => {
-    const load = () => {
-      const saved = localStorage.getItem("saved_places");
-      if (saved) {
-        try {
-          const parsed = JSON.parse(saved);
-          if (Array.isArray(parsed)) setSavedPlaces(parsed);
-        } catch { /* 파싱 실패 무시 */ }
-      }
-    };
-    load();
-    window.addEventListener("storage", load);
-    return () => window.removeEventListener("storage", load);
-  }, []);
 
   const dragFromIdx = React.useRef<number | null>(null);
   const [dragOverIdx, setDragOverIdx] = useState<number | null>(null);
@@ -104,15 +105,37 @@ const DayDetailView: React.FC<DayDetailViewProps> = ({
     return start.toISOString().split("T")[0];
   }, [dayTitle, startDate]);
 
-  // 노드에서 좌표를 가진 장소만 추출 (saved_places 매칭)
+  // 노드에서 좌표를 가진 장소만 추출
+  // 1순위: placeInfo에 lat/lng 직접 포함 (AI 생성 일정)
+  // 2순위: savedPlaces에서 이름으로 매칭 (수동 추가 노드)
   const mapPlaces = useMemo(() => {
     return nodes
       .filter((n) => n.placeInfo?.name)
       .map((n, idx) => {
-        const matched = savedPlaces.find(
-          (sp) => sp.name === n.placeInfo!.name
-        );
-        return matched
+        const info = n.placeInfo!;
+
+        // 1순위: placeInfo에 좌표 직접 있는 경우
+        if (info.lat != null && info.lng != null) {
+          return {
+            id: String(idx),
+            name: info.name,
+            category: info.category || "",
+            address: info.address || "",
+            lat: info.lat,
+            lng: info.lng,
+            rating: info.rating,
+            _idx: idx,
+            _time: n.time,
+          };
+        }
+
+        // 2순위: savedPlaces에서 이름 매칭
+        const matched = savedPlaces.find((sp) => sp.name === info.name)
+          ?? savedPlaces.find((sp) =>
+            info.name && (sp.name.includes(info.name) || info.name.includes(sp.name))
+          );
+
+        return matched && matched.lat != null && matched.lng != null
           ? { ...matched, _idx: idx, _time: n.time }
           : null;
       })
@@ -259,7 +282,7 @@ const DayDetailView: React.FC<DayDetailViewProps> = ({
           <div style={{ display: "flex", gap: "10px" }}>
             {isEditing && (
               <button
-                onClick={addNode}
+                onClick={() => setIsAddNodeModalOpen(true)}
                 style={{ padding: "10px 20px", background: "#fff", color: "#000", border: "2px solid #000", fontWeight: "bold", fontSize: "14px", cursor: "pointer", borderRadius: "4px" }}
               >
                 + 노드 추가
@@ -411,22 +434,55 @@ const DayDetailView: React.FC<DayDetailViewProps> = ({
                           <span style={{ fontSize: "18px", flexShrink: 0, lineHeight: 1 }}>{icon}</span>
                         )}
 
-                        {/* 클릭 시 상세 모달 */}
-                        <div
-                          style={{ flex: 1, minWidth: 0, cursor: (!isEditing && n.placeInfo) ? "pointer" : "default" }}
-                          onClick={() => { if (!isEditing) handleNodeClick(n); }}
-                        >
-                          <div style={{ display: "flex", alignItems: "center", gap: "8px", marginBottom: "3px" }}>
-                            <h3 style={{ fontSize: "14px", fontWeight: "700", margin: 0, overflow: "hidden", textOverflow: isEditing ? "unset" : "ellipsis", whiteSpace: isEditing ? "normal" : "nowrap", color: "#111" }}>
-                              {n.title}
-                            </h3>
-                            {n.placeInfo?.rating && (
-                              <span style={{ fontSize: "11px", color: "#ff9800", flexShrink: 0 }}>⭐ {n.placeInfo.rating}</span>
-                            )}
-                          </div>
-                          <p style={{ fontSize: "12px", color: "#aaa", margin: 0, overflow: "hidden", textOverflow: isEditing ? "unset" : "ellipsis", whiteSpace: isEditing ? "normal" : "nowrap", lineHeight: 1.5 }}>
-                            {n.desc}
-                          </p>
+                        {/* 클릭 시 상세 모달 / 편집 모드 시 input */}
+                        <div style={{ flex: 1, minWidth: 0 }}>
+                          {isEditing && !isFixed ? (
+                            <div style={{ display: "flex", flexDirection: "column", gap: "6px" }}>
+                              <div style={{ display: "flex", gap: "6px", alignItems: "center" }}>
+                                <input
+                                  type="text"
+                                  value={n.time}
+                                  onChange={(e) => updateNode(idx, "time", e.target.value)}
+                                  placeholder="HH:MM"
+                                  style={{ width: "64px", padding: "4px 8px", border: "1.5px solid #ddd", borderRadius: "4px", fontSize: "12px", fontFamily: "var(--font-mono)" }}
+                                  onClick={(e) => e.stopPropagation()}
+                                />
+                                <input
+                                  type="text"
+                                  value={n.title}
+                                  onChange={(e) => updateNode(idx, "title", e.target.value)}
+                                  placeholder="장소명"
+                                  style={{ flex: 1, padding: "4px 8px", border: "1.5px solid #ddd", borderRadius: "4px", fontSize: "13px", fontWeight: "600" }}
+                                  onClick={(e) => e.stopPropagation()}
+                                />
+                              </div>
+                              <input
+                                type="text"
+                                value={n.desc}
+                                onChange={(e) => updateNode(idx, "desc", e.target.value)}
+                                placeholder="설명 (주소 등)"
+                                style={{ width: "100%", padding: "4px 8px", border: "1.5px solid #ddd", borderRadius: "4px", fontSize: "12px", color: "#888", boxSizing: "border-box" }}
+                                onClick={(e) => e.stopPropagation()}
+                              />
+                            </div>
+                          ) : (
+                            <div
+                              style={{ cursor: n.placeInfo ? "pointer" : "default" }}
+                              onClick={() => { if (!isEditing) handleNodeClick(n); }}
+                            >
+                              <div style={{ display: "flex", alignItems: "center", gap: "8px", marginBottom: "3px" }}>
+                                <h3 style={{ fontSize: "14px", fontWeight: "700", margin: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", color: "#111" }}>
+                                  {n.title}
+                                </h3>
+                                {n.placeInfo?.rating && (
+                                  <span style={{ fontSize: "11px", color: "#ff9800", flexShrink: 0 }}>⭐ {n.placeInfo.rating}</span>
+                                )}
+                              </div>
+                              <p style={{ fontSize: "12px", color: "#aaa", margin: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", lineHeight: 1.5 }}>
+                                {n.desc}
+                              </p>
+                            </div>
+                          )}
                         </div>
 
                         {n.placeInfo?.category && (
@@ -532,7 +588,6 @@ const DayDetailView: React.FC<DayDetailViewProps> = ({
           placeInfo={selectedPlace}
           onClose={() => setSelectedPlace(null)}
           onViewOnMap={() => {
-            // 지도 마커와 연동: 같은 이름의 장소를 mapSelectedPlace로 설정
             const matched = mapPlaces.find((p) => p.name === selectedPlace.name);
             if (matched) {
               setMapSelectedPlace(matched);
@@ -544,6 +599,43 @@ const DayDetailView: React.FC<DayDetailViewProps> = ({
               }
             }
             setSelectedPlace(null);
+          }}
+        />
+      )}
+
+      {/* 노드 추가용 장소 검색 모달 */}
+      {isAddNodeModalOpen && (
+        <AddPlaceModal
+          onClose={() => setIsAddNodeModalOpen(false)}
+          existingPlaces={savedPlaces}
+          onAddPlace={async (place) => {
+            // 1. 노드로 추가
+            await addNodeFromPlace({
+              name: place.name,
+              category: place.category,
+              address: place.address,
+              lat: place.lat,
+              lng: place.lng,
+              description: place.description,
+              memo: place.memo,
+              rating: place.rating,
+            });
+            // 2. DAY ALL 장소 목록에도 추가 (중복 체크는 AddPlaceModal에서)
+            const alreadyInPlaces = savedPlaces.some(
+              (p) => p.name === place.name && p.lat === place.lat
+            );
+            if (!alreadyInPlaces) {
+              await addPlace({
+                name: place.name,
+                category: place.category,
+                address: place.address,
+                // description: place.description,
+                // memo: place.memo ?? "",
+                lat: place.lat,
+                lng: place.lng,
+              });
+            }
+            setIsAddNodeModalOpen(false);
           }}
         />
       )}

--- a/src/features/workspace/hooks/useWorkspaceCore.tsx
+++ b/src/features/workspace/hooks/useWorkspaceCore.tsx
@@ -1,4 +1,4 @@
-// src\features\workspace\hooks\useWorkspaceCore.tsx
+// src/features/workspace/hooks/useWorkspaceCore.tsx
 import { createContext, useContext, useEffect, useMemo, useState } from "react";
 import type { ReactNode } from "react";
 import { useParams } from "react-router-dom";
@@ -23,23 +23,7 @@ export interface TripInfo {
   endDate: string;
 }
 
-/**
- * [참고]
- * - 일정은 기존 로컬 로직 유지
- * - 공지사항은 그룹만 관리하고, 아이템은 useNotices에서 분리 관리
- *
- * 기존에는 공지 그룹 내부에 아이템까지 포함한 뒤 name/index 기반으로 수정, 삭제를 처리했지만,
- * 현재는 공지 그룹을 groupId 기반으로 분리하여 서버 중심 구조로 변경했다.
- *
- * 일정은 아직 기존 구조를 유지해야 하므로 관련 함수는 그대로 두고,
- * 공지사항만 add/rename/delete 전용 함수를 추가했다.
- *
- * 추후 일정도 id 기반으로 변경되면,
- * 수정/삭제 로직을 공통 패턴으로 합칠 수 있다.
- */
-
 interface WorkspaceCoreState {
-  /* state */
   dateLogs: string[];
   noticeGroups: NoticeGroupResponse[];
   activeView: WorkspaceViewType;
@@ -54,7 +38,6 @@ interface WorkspaceCoreState {
   isTripLoading: boolean;
   updateTripData: (data: TripInfo) => Promise<void>;
 
-  /* actions */
   selectTab: (title: string, view: WorkspaceViewType) => void;
   selectNoticeGroup: (groupId: number) => void;
   reloadNoticeGroups: () => Promise<void>;
@@ -63,67 +46,50 @@ interface WorkspaceCoreState {
   renameDateLog: (index: number) => void;
   deleteDateLog: (index: number) => void;
 
+  // AI 일정 생성 후 dayKeys를 dateLogs에 동기화
+  syncDateLogs: (dayKeys: string[]) => void;
+
   addNoticeGroup: () => Promise<void>;
   renameNoticeGroup: (groupId: number) => Promise<void>;
   deleteNoticeGroup: (groupId: number) => Promise<void>;
 
-  // 기존 Sidebar 호환용
   renameItem: (type: "date" | "notice", index: number) => void;
   deleteItem: (type: "date" | "notice", index: number) => void;
 
-  /* internal setters */
   setHideRight: (v: boolean) => void;
   setActiveView: (v: WorkspaceViewType) => void;
 }
 
-/* =========================
-   상수
-========================= */
-const LS_DATE_LOGS = "tripmoa_date_logs";
 const LS_TRIP_DATA = "tripData";
 const LS_CURRENT_NOTICE_GROUP_ID = "tripmoa_current_notice_group_id";
 const DEFAULT_DAY_LABEL = "DAY ALL";
 
 const normalizeName = (name: string) => name.trim().toLowerCase();
 
-const sortNoticeGroups = (groups: NoticeGroupResponse[]) => {
-  return [...groups].sort((a, b) => {
-    if (a.sortOrder !== b.sortOrder) return a.sortOrder - b.sortOrder;
-    return a.groupId - b.groupId;
-  });
-};
+const sortNoticeGroups = (groups: NoticeGroupResponse[]) =>
+  [...groups].sort((a, b) =>
+    a.sortOrder !== b.sortOrder ? a.sortOrder - b.sortOrder : a.groupId - b.groupId
+  );
 
-const pickFallbackNoticeGroupId = (
-  groups: NoticeGroupResponse[],
-): number | null => {
+const pickFallbackNoticeGroupId = (groups: NoticeGroupResponse[]): number | null => {
   if (groups.length === 0) return null;
-
-  const defaultGroup = groups.find((group) => group.isDefault);
-  if (defaultGroup) return defaultGroup.groupId;
-
-  return groups[0].groupId;
+  return groups.find((g) => g.isDefault)?.groupId ?? groups[0].groupId;
 };
 
-/* =========================
-   Core Hook (Provider 내부 전용)
-========================= */
 const useWorkspaceCoreInternal = (): WorkspaceCoreState => {
   const params = useParams<{ tripId: string }>();
   const tripId = Number(params.tripId);
 
+  // dateLogs: localStorage 제거 — allDays 기반으로 syncDateLogs로만 업데이트
   const [dateLogs, setDateLogs] = useState<string[]>([]);
   const [noticeGroups, setNoticeGroups] = useState<NoticeGroupResponse[]>([]);
-  const [isDateLoaded, setIsDateLoaded] = useState(false);
   const [isNoticeGroupsLoading, setIsNoticeGroupsLoading] = useState(false);
 
   const [activeView, setActiveView] = useState<WorkspaceViewType>("timeline");
   const [currentDay, setCurrentDay] = useState<string>(DEFAULT_DAY_LABEL);
-  const [currentNoticeGroupId, setCurrentNoticeGroupId] = useState<
-    number | null
-  >(null);
+  const [currentNoticeGroupId, setCurrentNoticeGroupId] = useState<number | null>(null);
   const [hideRight, setHideRight] = useState<boolean>(false);
 
-  // ── 여행 기본 정보 ──────────────────────────────────────────
   const [trip, setTrip] = useState<TripInfo>(() => {
     try {
       const saved = localStorage.getItem(LS_TRIP_DATA);
@@ -135,87 +101,39 @@ const useWorkspaceCoreInternal = (): WorkspaceCoreState => {
   const [isTripLoading, setIsTripLoading] = useState(false);
 
   const currentNoticeStorageKey = useMemo(
-    () =>
-      `${LS_CURRENT_NOTICE_GROUP_ID}_${Number.isFinite(tripId) ? tripId : "unknown"}`,
-    [tripId],
+    () => `${LS_CURRENT_NOTICE_GROUP_ID}_${Number.isFinite(tripId) ? tripId : "unknown"}`,
+    [tripId]
   );
 
   const currentNoticeGroup = useMemo(() => {
     if (currentNoticeGroupId == null) return "";
-    return (
-      noticeGroups.find((group) => group.groupId === currentNoticeGroupId)
-        ?.name ?? ""
-    );
+    return noticeGroups.find((g) => g.groupId === currentNoticeGroupId)?.name ?? "";
   }, [noticeGroups, currentNoticeGroupId]);
 
-  /* =========================
-     1. localStorage 로드
-  ========================= */
-  useEffect(() => {
-    const storedDates = localStorage.getItem(LS_DATE_LOGS);
-    if (storedDates) {
-      try {
-        const parsed = JSON.parse(storedDates);
-        if (Array.isArray(parsed)) {
-          setDateLogs(parsed);
-        }
-      } catch {
-        // 파싱 실패 시 무시
-      }
-    }
-
-    setIsDateLoaded(true);
-  }, []);
-
-  /* =========================
-     2. date localStorage 저장
-  ========================= */
-  useEffect(() => {
-    if (!isDateLoaded) return;
-    localStorage.setItem(LS_DATE_LOGS, JSON.stringify(dateLogs));
-  }, [dateLogs, isDateLoaded]);
-
-  /* =========================
-     3. 공지 선택값 로드 (trip 별)
-  ========================= */
+  // 공지 선택값 로드/저장 (localStorage 유지 — 공지는 서버 기반이라 선택값 정도는 OK)
   useEffect(() => {
     const stored = localStorage.getItem(currentNoticeStorageKey);
-    if (!stored) {
-      setCurrentNoticeGroupId(null);
-      return;
-    }
-
+    if (!stored) { setCurrentNoticeGroupId(null); return; }
     const parsed = Number(stored);
     setCurrentNoticeGroupId(Number.isFinite(parsed) ? parsed : null);
   }, [currentNoticeStorageKey]);
 
-  /* =========================
-     4. 공지 선택값 저장 (trip 별)
-  ========================= */
   useEffect(() => {
     if (currentNoticeGroupId == null) {
       localStorage.removeItem(currentNoticeStorageKey);
       return;
     }
-
     localStorage.setItem(currentNoticeStorageKey, String(currentNoticeGroupId));
   }, [currentNoticeGroupId, currentNoticeStorageKey]);
 
-  /* =========================
-     5. 여행 정보 API 조회
-  ========================= */
+  // 여행 정보 API 조회
   useEffect(() => {
     if (!Number.isFinite(tripId) || tripId <= 0) return;
-
     setIsTripLoading(true);
     getTripDetail(tripId)
       .then((res) => {
         const d = res.data;
-        const t: TripInfo = {
-          title: d.title,
-          startDate: d.tripStartDate,
-          endDate: d.tripEndDate,
-        };
+        const t: TripInfo = { title: d.title, startDate: d.tripStartDate, endDate: d.tripEndDate };
         setTrip(t);
         setTripMembers(d.members ?? []);
         localStorage.setItem(LS_TRIP_DATA, JSON.stringify(t));
@@ -240,77 +158,37 @@ const useWorkspaceCoreInternal = (): WorkspaceCoreState => {
     }
   };
 
-  /* =========================
-     6. 공지 그룹 전체 조회
-  ========================= */
+  // 공지 그룹 조회
   const reloadNoticeGroups = async () => {
-    if (!Number.isFinite(tripId) || tripId <= 0) {
-      setNoticeGroups([]);
-      return;
-    }
-
+    if (!Number.isFinite(tripId) || tripId <= 0) { setNoticeGroups([]); return; }
     setIsNoticeGroupsLoading(true);
     try {
       const response = await getNoticeGroups(tripId);
-      const groups = sortNoticeGroups(response.data ?? []);
-      setNoticeGroups(groups);
-    } catch (error) {
-      console.error("공지 그룹 조회 실패:", error);
+      setNoticeGroups(sortNoticeGroups(response.data ?? []));
+    } catch {
       setNoticeGroups([]);
     } finally {
       setIsNoticeGroupsLoading(false);
     }
   };
 
-  useEffect(() => {
-    void reloadNoticeGroups();
-  }, [tripId]);
+  useEffect(() => { void reloadNoticeGroups(); }, [tripId]);
 
-  /* =========================
-     6. 공지 그룹 선택 보정
-     - 저장된 groupId가 있으면 유지
-     - 없으면 기본 그룹(isDefault) 우선
-     - 그것도 없으면 첫 번째 그룹
-  ========================= */
   useEffect(() => {
-    if (noticeGroups.length === 0) {
-      setCurrentNoticeGroupId(null);
-      return;
-    }
-
-    const exists = noticeGroups.some(
-      (group) => group.groupId === currentNoticeGroupId,
-    );
+    if (noticeGroups.length === 0) { setCurrentNoticeGroupId(null); return; }
+    const exists = noticeGroups.some((g) => g.groupId === currentNoticeGroupId);
     if (exists) return;
-
     setCurrentNoticeGroupId(pickFallbackNoticeGroupId(noticeGroups));
   }, [noticeGroups, currentNoticeGroupId]);
 
-  /* =========================
-     7. 탭 선택
-     - timeline/expenses/voucher는 기존 유지
-     - notice는 기존 문자열 선택도 잠시 지원
-  ========================= */
   const selectTab = (title: string, view: WorkspaceViewType) => {
     setActiveView(view);
     setHideRight(false);
-
-    if (view === "timeline") {
-      setCurrentDay(title);
-      return;
-    }
-
+    if (view === "timeline") { setCurrentDay(title); return; }
     if (view === "notice") {
-      const matched = noticeGroups.find(
-        (group) => normalizeName(group.name) === normalizeName(title),
-      );
-
-      if (matched) {
-        setCurrentNoticeGroupId(matched.groupId);
-      } else if (currentNoticeGroupId == null) {
-        setCurrentNoticeGroupId(pickFallbackNoticeGroupId(noticeGroups));
-      }
-
+      const matched = noticeGroups.find((g) => normalizeName(g.name) === normalizeName(title));
+      if (matched) setCurrentNoticeGroupId(matched.groupId);
+      else if (currentNoticeGroupId == null) setCurrentNoticeGroupId(pickFallbackNoticeGroupId(noticeGroups));
       return;
     }
   };
@@ -321,32 +199,19 @@ const useWorkspaceCoreInternal = (): WorkspaceCoreState => {
     setCurrentNoticeGroupId(groupId);
   };
 
-  /* =========================
-     8. 일정(date) 로컬 액션
-  ========================= */
+  // ── dateLogs 관련 ─────────────────────────────────────────
   const addDateLog = () => {
-    const name = prompt(
-      "추가할 일정 이름을 입력하세요.",
-      `DAY ${dateLogs.length + 1}`,
-    );
-    if (!name) return;
-
-    const trimmed = name.trim();
-    if (!trimmed) return;
-
-    setDateLogs((prev) => [...prev, trimmed]);
+    const name = prompt("추가할 일정 이름을 입력하세요.", `DAY ${dateLogs.length + 1}`);
+    if (!name?.trim()) return;
+    setDateLogs((prev) => [...prev, name.trim()]);
   };
 
   const renameDateLog = (index: number) => {
     const current = dateLogs[index];
     if (current == null) return;
-
     const newName = prompt("이름을 변경하세요:", current);
-    if (!newName || !newName.trim()) return;
-
-    setDateLogs((prev) =>
-      prev.map((day, i) => (i === index ? newName.trim() : day)),
-    );
+    if (!newName?.trim()) return;
+    setDateLogs((prev) => prev.map((d, i) => (i === index ? newName.trim() : d)));
   };
 
   const deleteDateLog = (index: number) => {
@@ -354,188 +219,100 @@ const useWorkspaceCoreInternal = (): WorkspaceCoreState => {
     setDateLogs((prev) => prev.filter((_, i) => i !== index));
   };
 
-  /* =========================
-     9. 공지 그룹 CRUD (서버 기반)
-  ========================= */
+  /**
+   * AI 일정 생성 완료 또는 서버에서 일정 로드 후
+   * allDays의 키를 dateLogs에 반영 — 사이드바 탭 동기화
+   */
+  const syncDateLogs = (dayKeys: string[]) => {
+    setDateLogs((prev) => {
+      const newKeys = dayKeys.filter((k) => !prev.includes(k));
+      return newKeys.length > 0 ? [...prev, ...newKeys] : prev;
+    });
+  };
+
+  // 공지 그룹 CRUD
   const addNoticeGroup = async () => {
     if (!Number.isFinite(tripId) || tripId <= 0) return;
-
     let name: string | null = "새 공지사항";
-
     while (true) {
       name = prompt("추가할 공지 그룹 이름을 입력하세요.", name || "");
       if (name === null) return;
-
       const trimmed = name.trim();
       if (!trimmed) return;
-
-      const duplicated = noticeGroups.some(
-        (group) => normalizeName(group.name) === normalizeName(trimmed),
-      );
-      if (duplicated) {
-        alert("이미 존재하는 이름입니다.");
-        continue;
+      if (noticeGroups.some((g) => normalizeName(g.name) === normalizeName(trimmed))) {
+        alert("이미 존재하는 이름입니다."); continue;
       }
-
       try {
         const response = await createNoticeGroupApi(tripId, { name: trimmed });
-        const createdGroup = response.data;
-
         await reloadNoticeGroups();
-        setCurrentNoticeGroupId(createdGroup.groupId);
+        setCurrentNoticeGroupId(response.data.groupId);
         setActiveView("notice");
-      } catch (error) {
-        console.error("공지 그룹 생성 실패:", error);
-        alert("공지 그룹 생성에 실패했습니다.");
-      }
+      } catch { alert("공지 그룹 생성에 실패했습니다."); }
       return;
     }
   };
 
   const renameNoticeGroup = async (groupId: number) => {
     if (!Number.isFinite(tripId) || tripId <= 0) return;
-
-    const targetGroup = noticeGroups.find((group) => group.groupId === groupId);
-    if (!targetGroup) return;
-
-    if (targetGroup.isDefault) return;
-
-    let newName: string | null = targetGroup.name;
-
+    const target = noticeGroups.find((g) => g.groupId === groupId);
+    if (!target || target.isDefault) return;
+    let newName: string | null = target.name;
     while (true) {
       newName = prompt("이름을 변경하세요:", newName || "");
       if (newName === null) return;
-
       const trimmed = newName.trim();
-      if (!trimmed || trimmed === targetGroup.name) return;
-
-      const duplicated = noticeGroups.some(
-        (group) =>
-          group.groupId !== groupId &&
-          normalizeName(group.name) === normalizeName(trimmed),
-      );
-      if (duplicated) {
-        alert("이미 존재하는 이름입니다.");
-        continue;
+      if (!trimmed || trimmed === target.name) return;
+      if (noticeGroups.some((g) => g.groupId !== groupId && normalizeName(g.name) === normalizeName(trimmed))) {
+        alert("이미 존재하는 이름입니다."); continue;
       }
-
-      try {
-        await renameNoticeGroupApi(tripId, groupId, { name: trimmed });
-        await reloadNoticeGroups();
-      } catch (error) {
-        console.error("공지 그룹 이름 수정 실패:", error);
-        alert("공지 그룹 이름 수정에 실패했습니다.");
-      }
+      try { await renameNoticeGroupApi(tripId, groupId, { name: trimmed }); await reloadNoticeGroups(); }
+      catch { alert("공지 그룹 이름 수정에 실패했습니다."); }
       return;
     }
   };
 
   const deleteNoticeGroup = async (groupId: number) => {
     if (!Number.isFinite(tripId) || tripId <= 0) return;
-
-    const targetGroup = noticeGroups.find((group) => group.groupId === groupId);
-    if (!targetGroup) return;
-
-    if (targetGroup.isDefault) return;
+    const target = noticeGroups.find((g) => g.groupId === groupId);
+    if (!target || target.isDefault) return;
     if (!confirm("정말 삭제하시겠습니까?")) return;
-
-    try {
-      await deleteNoticeGroupApi(tripId, groupId);
-      await reloadNoticeGroups();
-    } catch (error) {
-      console.error("공지 그룹 삭제 실패:", error);
-      alert("공지 그룹 삭제에 실패했습니다.");
-    }
+    try { await deleteNoticeGroupApi(tripId, groupId); await reloadNoticeGroups(); }
+    catch { alert("공지 그룹 삭제에 실패했습니다."); }
   };
 
-  /* =========================
-     10. 기존 Sidebar 호환용 래퍼
-     - notice 분기는 이제 groupId 기반 함수로 위임
-     - date는 기존처럼 index 사용
-  ========================= */
   const renameItem = (type: "date" | "notice", index: number) => {
-    if (type === "date") {
-      renameDateLog(index);
-      return;
-    }
-
-    const targetGroup = noticeGroups[index];
-    if (!targetGroup) return;
-    void renameNoticeGroup(targetGroup.groupId);
+    if (type === "date") { renameDateLog(index); return; }
+    const target = noticeGroups[index];
+    if (target) void renameNoticeGroup(target.groupId);
   };
 
   const deleteItem = (type: "date" | "notice", index: number) => {
-    if (type === "date") {
-      deleteDateLog(index);
-      return;
-    }
-
-    const targetGroup = noticeGroups[index];
-    if (!targetGroup) return;
-    void deleteNoticeGroup(targetGroup.groupId);
+    if (type === "date") { deleteDateLog(index); return; }
+    const target = noticeGroups[index];
+    if (target) void deleteNoticeGroup(target.groupId);
   };
 
   return {
-    dateLogs,
-    noticeGroups,
-    activeView,
-    currentDay,
-    currentNoticeGroupId,
-    currentNoticeGroup,
-    hideRight,
-    isNoticeGroupsLoading,
-
-    trip,
-    tripMembers,
-    isTripLoading,
-    updateTripData,
-
-    selectTab,
-    selectNoticeGroup,
-    reloadNoticeGroups,
-
-    addDateLog,
-    renameDateLog,
-    deleteDateLog,
-
-    addNoticeGroup,
-    renameNoticeGroup,
-    deleteNoticeGroup,
-
-    renameItem,
-    deleteItem,
-
-    setHideRight,
-    setActiveView,
+    dateLogs, noticeGroups, activeView, currentDay,
+    currentNoticeGroupId, currentNoticeGroup, hideRight, isNoticeGroupsLoading,
+    trip, tripMembers, isTripLoading, updateTripData,
+    selectTab, selectNoticeGroup, reloadNoticeGroups,
+    addDateLog, renameDateLog, deleteDateLog, syncDateLogs,
+    addNoticeGroup, renameNoticeGroup, deleteNoticeGroup,
+    renameItem, deleteItem, setHideRight, setActiveView,
   };
 };
 
-/* =========================
-   Context + Provider
-========================= */
 const WorkspaceCoreContext = createContext<WorkspaceCoreState | null>(null);
 
-export const WorkspaceCoreProvider = ({
-  children,
-}: {
-  children: ReactNode;
-}) => {
+export const WorkspaceCoreProvider = ({ children }: { children: ReactNode }) => {
   const core = useWorkspaceCoreInternal();
   const value = useMemo(() => core, [core]);
-
-  return (
-    <WorkspaceCoreContext.Provider value={value}>
-      {children}
-    </WorkspaceCoreContext.Provider>
-  );
+  return <WorkspaceCoreContext.Provider value={value}>{children}</WorkspaceCoreContext.Provider>;
 };
 
 export const useWorkspaceCore = (): WorkspaceCoreState => {
   const ctx = useContext(WorkspaceCoreContext);
-  if (!ctx) {
-    throw new Error(
-      "useWorkspaceCore must be used within WorkspaceCoreProvider",
-    );
-  }
+  if (!ctx) throw new Error("useWorkspaceCore must be used within WorkspaceCoreProvider");
   return ctx;
 };


### PR DESCRIPTION
## 🔗 관련 이슈

* Closes #95
* Closes #40
* Parent: #20

---

## 🎨 작업 내용 (What)

* Workspace 및 DayDetail 화면을 서버 기반 일정 데이터와 연결
* Day별 타임라인 UI 렌더링 구현
* 일정 클릭 시 상세 정보 및 지도 연동 기능 추가
* DayAll → DayDetail → Workspace 흐름 연결

---

## 🧭 작업 목적 (Why)

서버에서 관리되는 일정 데이터를 실제 사용자 화면에 반영하여
일정 조회 및 수정이 가능한 전체 흐름을 완성하기 위함

---

## 🧩 변경 범위

* [x] UI / Layout
* [x] 컴포넌트 구조
* [x] 상태 관리 로직
* [ ] API 연동
* [ ] 스타일

---

## 🧪 테스트 방법

* [x] 로컬 실행 확인
* [x] DayDetail 화면 렌더링 확인
* [x] 일정 클릭 시 상세 정보 표시 확인
* [x] 지도 마커 및 위치 연동 확인
* [x] Workspace 내 화면 전환 정상 동작 확인
* [x] 에러 콘솔 확인

---

## ⚠️ 참고 사항

* Workspace는 Timeline 상태(allDays)에 의존
* DayDetail은 서버 데이터 기반으로 렌더링됨
* 이전 local 상태 기반 흐름 제거됨

---

## ✅ 체크리스트

* [x] main 브랜치 직접 push 하지 않음
* [x] feature 브랜치에서 작업함
* [x] 불필요한 console.log 제거
* [x] PR 단위가 과도하게 크지 않음
