### PR TITLE
[FE] refactor: 인증 상태 관리 및 제재 계정 안내 흐름 개선

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -13,7 +13,8 @@ export type AuthLogoutReason =
   | "manual"
   | "withdraw"
   | "refresh-expired"
-  | "remote-tab";
+  | "remote-tab"
+  | "suspended";
 
 // refreshToken 쿠키 자동 전송
 export const api = axios.create({
@@ -36,6 +37,12 @@ export const clearAccessToken = () => {
 // 인증 관련 클라이언트 상태 초기화
 export const clearAuthState = () => {
   clearAccessToken();
+
+  localStorage.removeItem("tripData");
+
+  Object.keys(localStorage)
+    .filter((key) => key.startsWith("tripmoa_current_notice_group_id"))
+    .forEach((key) => localStorage.removeItem(key));
 };
 
 // 인증 상태 변경 이벤트 발행
@@ -82,7 +89,13 @@ const refreshTokens = async (): Promise<RefreshTokenResponse> => {
         { withCredentials: true },
       )
       .then((res) => {
-        const { accessToken, authenticated } = res.data;
+        const { accessToken, authenticated, reason } = res.data;
+
+        if (authenticated === false && reason === "SUSPENDED") {
+          clearAuthState();
+          notifyAuthLogout("suspended");
+          throw new Error("Suspended");
+        }
 
         if (!accessToken || authenticated === false) {
           clearAuthState();

--- a/src/features/user/pages/AuthContext.tsx
+++ b/src/features/user/pages/AuthContext.tsx
@@ -15,6 +15,9 @@ import {
   type AuthLogoutReason,
   notifyAuthLogout,
 } from "../../../api/api";
+import { getMySanctionStatus } from "../../../api/sanction.api";
+import { ActionPromptModal } from "../../../shared/components/ActionPromptModal";
+import { markWarningPopupRead } from "../../../api/sanction.api";
 
 type AuthContextType = {
   isAuthenticated: boolean;
@@ -42,6 +45,9 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
   const [userId, setUserId] = useState<number | null>(null);
   const [logoutMessage, setLogoutMessage] = useState<string | null>(null);
   const didBootstrap = useRef(false);
+  const [warningMessage, setWarningMessage] = useState<string | null>(null);
+  const [showWarningModal, setShowWarningModal] = useState(false);
+  const [logoutHeadline, setLogoutHeadline] = useState("계정 이용 제한");
 
   /**
    * 클라이언트 인증 상태 초기화 후 비로그인 상태 전환
@@ -54,8 +60,8 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
 
   const clearLogoutMessage = useCallback(() => {
     setLogoutMessage(null);
+    setLogoutHeadline("계정 이용 제한");
   }, []);
-
   /**
    * refreshToken 쿠키 기준으로 인증 상태 복구
    */
@@ -85,8 +91,26 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     if (didBootstrap.current) return;
     didBootstrap.current = true;
 
+    const checkSanction = async () => {
+      try {
+        const res = await getMySanctionStatus();
+
+        if (res.data.showWarningPopup) {
+          setWarningMessage(res.data.warningMessage);
+          setShowWarningModal(true);
+        }
+      } catch (e) {
+        console.error("제재 상태 조회 실패", e);
+      }
+    };
+
     const runBootstrap = async () => {
-      await refreshAuth();
+      const success = await refreshAuth();
+
+      if (success) {
+        await checkSanction();
+      }
+
       setAuthReady(true);
     };
 
@@ -118,7 +142,16 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
       }
 
       if (reason === "withdraw") {
-        setLogoutMessage("회원 탈퇴가 완료되었습니다.");
+        setLogoutHeadline("회원 탈퇴 완료");
+        setLogoutMessage("회원 탈퇴가 정상적으로 완료되었습니다.");
+        return;
+      }
+
+      if (reason === "suspended") {
+        setLogoutHeadline("계정 이용 제한");
+        setLogoutMessage(
+          `신고 정책으로 정지된 계정입니다.\n문의가 필요한 경우 고객센터 이메일로 문의해주세요.\n${import.meta.env.VITE_SUPPORT_EMAIL}`,
+        );
         return;
       }
 
@@ -164,6 +197,11 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     };
   }, []);
 
+  const handleCloseWarning = async () => {
+    await markWarningPopupRead();
+    setShowWarningModal(false);
+  };
+
   return (
     <AuthContext.Provider
       value={{
@@ -179,6 +217,30 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
       }}
     >
       {children}
+
+      <ActionPromptModal
+        open={showWarningModal}
+        title="서비스 이용 경고"
+        headline="신고가 누적되었습니다"
+        description={
+          (warningMessage ??
+            "신고가 누적되었습니다.\n반복될 경우 서비스 이용이 제한될 수 있습니다.") +
+          "\n\n문의가 필요한 경우 마이페이지 > 신고 관리 탭에서\n이메일 문의 기능을 이용해주세요."
+        }
+        confirmText="확인했습니다"
+        onClose={handleCloseWarning}
+        onConfirm={handleCloseWarning}
+      />
+
+      <ActionPromptModal
+        open={!!logoutMessage}
+        title="서비스 이용 안내"
+        headline={logoutHeadline}
+        description={logoutMessage ?? ""}
+        confirmText="확인"
+        onClose={clearLogoutMessage}
+        onConfirm={clearLogoutMessage}
+      />
     </AuthContext.Provider>
   );
 };

--- a/src/features/user/pages/Login.tsx
+++ b/src/features/user/pages/Login.tsx
@@ -1,18 +1,38 @@
-import React, { useEffect } from "react";
+// src/features/user/pages/Login.tsx
+
+import React, { useEffect, useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
 import { TicketLayout } from "../components/common/TicketLayout";
 import { TicketInfo } from "../components/common/TicketInfo";
 import { LoginForm } from "../components/LoginForm";
-import { useAuth } from "../../../features/user/pages/AuthContext";
+import { AccountSuspendedNotice } from "../components/AccountSuspendedNotice";
 
 const Login: React.FC = () => {
-  const { logoutMessage, clearLogoutMessage } = useAuth();
+  const location = useLocation();
+  const navigate = useNavigate();
+  const [showSuspendedNotice, setShowSuspendedNotice] = useState(false);
 
   useEffect(() => {
-    if (!logoutMessage) return;
+    const params = new URLSearchParams(location.search);
+    const error = params.get("error");
 
-    alert(logoutMessage);
-    clearLogoutMessage();
-  }, [logoutMessage, clearLogoutMessage]);
+    if (!error) return;
+
+    if (error === "cancelled") {
+      // 취소는 조용히 처리하거나 안내 메시지만
+      navigate("/login", { replace: true });
+      return;
+    }
+
+    if (error === "SUSPENDED") {
+      setShowSuspendedNotice(true);
+      navigate("/login", { replace: true });
+      return;
+    }
+
+    alert("로그인에 실패했습니다.");
+    navigate("/login", { replace: true });
+  }, [location.search, navigate]);
 
   return (
     <TicketLayout
@@ -25,7 +45,18 @@ const Login: React.FC = () => {
           tagline="Social login only"
         />
       }
-      rightContent={<LoginForm />}
+      rightContent={
+        showSuspendedNotice ? (
+          <AccountSuspendedNotice
+            onBack={() => {
+              setShowSuspendedNotice(false);
+              navigate("/login", { replace: true });
+            }}
+          />
+        ) : (
+          <LoginForm />
+        )
+      }
     />
   );
 };

--- a/src/types/auth.types.ts
+++ b/src/types/auth.types.ts
@@ -4,13 +4,22 @@
 // Enums & Common
 // ===================
 
+export type AgeVerificationStatus = "UNVERIFIED" | "VERIFIED" | "UNDERAGE";
+
 export type Gender = "MALE" | "FEMALE" | "OTHER" | null;
 
 export type ProfileType = "CUSTOM" | "AVATAR";
 
 export type RefreshTokenResponse = {
   accessToken?: string;
-  authenticated?: boolean;
+  authenticated: boolean;
+  reason?: "SUSPENDED" | string;
+  message?: string;
+};
+
+export type TravelStyleOption = {
+  id: number;
+  name: string;
 };
 
 // ===================
@@ -46,22 +55,43 @@ export interface CheckEmailResponse {
   name: string | null;
 }
 
+export interface AgeVerificationResponse {
+  ageVerified: boolean;
+  ageVerificationStatus: AgeVerificationStatus;
+}
+
 export interface UserResponse {
+  // 식별
   id: number;
+
+  // 기본 정보
   nickname: string;
   name: string | null;
   email: string | null;
-  provider: string | null;
   notificationEmail: string | null;
   gender: Gender;
+  birthDate: string | null; // "YYYY-MM-DD"
   mbti: string | null;
+
+  // 프로필 이미지
   profileImage: string | null;
-  profileType?: ProfileType;
+  profileType: ProfileType;
   avatarEmoji: string | null;
   avatarColor: string | null;
-  birthDate: string | null; // LocalDate -> "YYYY-MM-DD"
+
+  // 소셜 계정
+  provider: string | null;
+  linkedProviders: string[];
+
+  // 잠금 여부
   nameLocked: boolean;
   genderLocked: boolean;
   birthLocked: boolean;
+
+  // 인증
+  ageVerified: boolean;
+  ageVerificationStatus: AgeVerificationStatus;
+
+  // 여행 스타일
   travelStyles: string[];
 }


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #126

---

## 🎨 작업 내용 (What)

- 인증 상태 초기화 로직 정리 (`api.ts`)
- 로그아웃 사유별 처리 흐름 분리 (`AuthContext.tsx`)
- 다중 탭 로그아웃 동기화 적용
- 제재 계정 및 경고 상태 안내 UI 적용
- Header 인증 상태 분기 개선

---

## 🧭 작업 목적 (Why)

기존에는 로그아웃, 토큰 만료, 회원 탈퇴, 제재 계정 상태가 동일하게 처리되어  
사용자가 현재 상태를 명확히 인지하기 어려운 문제가 있었다.

또한 accessToken을 메모리 기반으로 전환하면서  
클라이언트 인증 상태 초기화 범위를 명확히 정리할 필요가 있었고,  
여러 탭에서 인증 상태가 불일치하는 문제를 해결하기 위해 로그아웃 동기화가 필요했다.

이에 따라 인증 상태 관리 흐름을 재구성하고,  
로그아웃 사유 기반으로 사용자 안내를 분리하여 UX를 개선하였다.

---

## 🧩 변경 범위
- [x] UI / Layout
- [x] 컴포넌트 구조
- [x] 상태 관리 로직
- [x] API 연동
- [x] 스타일

---

## 🧪 테스트 방법

- [x] 로컬 실행 확인
- [x] 주요 시나리오 테스트
  - 제재 계정 로그인 → 이용 제한 안내 표시
  - 회원 탈퇴 → 완료 안내 표시
  - 한 탭에서 로그아웃 → 다른 탭 자동 로그아웃
- [x] 에러 콘솔 확인

---

## ⚠️ 참고 사항

- refresh token은 HttpOnly 쿠키 기반으로 동작하며, accessToken은 메모리에서만 관리됨
- 로그아웃 이벤트는 `auth:logout` 커스텀 이벤트로 전파됨
- 다중 탭 동기화는 localStorage `logout-event` 키를 통해 처리됨
- 제재 계정의 경우 단순 로그인 실패가 아니라 별도 안내 모달이 표시되도록 변경됨

---

## ✅ 체크리스트
- [x] main 브랜치 직접 push 하지 않음
- [x] feature 브랜치에서 작업함
- [x] 불필요한 console.log 제거
- [x] PR 단위가 과도하게 크지 않음