### PR TITLE
[FE] refactor: 공용 안내 모달 및 접근 제어 훅 추가

### DIFF
--- a/src/shared/components/ActionPromptModal.tsx
+++ b/src/shared/components/ActionPromptModal.tsx
@@ -1,0 +1,72 @@
+import "../styles/ActionPromptModal.css";
+
+interface ActionPromptModalProps {
+  open: boolean;
+  title: string;
+  headline: string;
+  description: string;
+  cancelText?: string;
+  confirmText?: string;
+  onClose: () => void;
+  onConfirm: () => void;
+}
+
+export function ActionPromptModal({
+  open,
+  title,
+  headline,
+  description,
+  cancelText = "닫기",
+  confirmText = "확인",
+  onClose,
+  onConfirm,
+}: ActionPromptModalProps) {
+  if (!open) return null;
+
+  return (
+    <div
+      className="modal-overlay active"
+      onMouseDown={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div
+        className="modal-window detail-window"
+        onMouseDown={(e) => e.stopPropagation()}
+      >
+        <div className="modal-header">
+          <span className="mh-title">{title}</span>
+        </div>
+
+        <div
+          className="modal-body"
+          style={{ textAlign: "center", padding: "48px 32px" }}
+        >
+          <p className="text-xl font-black uppercase tracking-tight mb-2">
+            {headline}
+          </p>
+          <p className="text-sm text-black/50 font-bold mb-8">{description}</p>
+
+          <div className="flex gap-4 justify-center">
+            <button
+              onClick={onClose}
+              className="px-6 py-3 border-3 border-black bg-white font-black uppercase text-sm hover:bg-[#eee] transition-all"
+              style={{ border: "3px solid #000" }}
+              type="button"
+            >
+              {cancelText}
+            </button>
+
+            <button
+              onClick={onConfirm}
+              className="px-6 py-3 font-black uppercase text-sm transition-all button bgBlackHoverable"
+              type="button"
+            >
+              {confirmText}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/shared/components/Header.tsx
+++ b/src/shared/components/Header.tsx
@@ -4,26 +4,30 @@ import { useNavigate } from "react-router-dom";
 import { logout } from "../../api/auth.api";
 import { useAuth } from "../../features/user/pages/AuthContext";
 import { useUserProfile } from "../../features/user/hooks/useUserSetting";
+import { useAccessGuard } from "../hooks/useAccessGuard";
+import { ActionPromptModal } from "./ActionPromptModal";
 
 function HeaderProfileMenu() {
   const navigate = useNavigate();
   const { profile } = useUserProfile();
 
   const fallbackProfile = {
+    profileType: "AVATAR" as const,
     avatarEmoji: "😊",
     avatarColor: "#FFE5E5",
-    profileImage: null,
+    profileImage: "",
   };
 
   const displayProfile = profile ?? fallbackProfile;
-
   const handleLogout = async () => {
     await logout();
     navigate("/", { replace: true });
   };
 
   const handleSettingsClick = () => {
-    navigate("/setting");
+    navigate("/setting", {
+      state: { closeTo: location.pathname + location.search },
+    });
   };
 
   return (
@@ -32,16 +36,18 @@ function HeaderProfileMenu() {
         <div
           className="profile-circle"
           style={{
-            background: displayProfile.profileImage
-              ? "transparent"
-              : displayProfile.avatarColor,
+            background:
+              displayProfile.profileType === "CUSTOM"
+                ? "transparent"
+                : displayProfile.avatarColor || "#FFE5E5",
             overflow: "hidden",
             display: "flex",
             alignItems: "center",
             justifyContent: "center",
           }}
         >
-          {displayProfile.profileImage ? (
+          {displayProfile.profileType === "CUSTOM" &&
+          displayProfile.profileImage ? (
             <img
               src={displayProfile.profileImage}
               alt="Profile"
@@ -53,7 +59,7 @@ function HeaderProfileMenu() {
             />
           ) : (
             <span style={{ fontSize: "1.2rem" }}>
-              {displayProfile.avatarEmoji}
+              {displayProfile.avatarEmoji || "😊"}
             </span>
           )}
         </div>
@@ -74,16 +80,12 @@ function HeaderProfileMenu() {
 export default function Header() {
   const navigate = useNavigate();
   const { isAuthenticated, authReady } = useAuth();
-
+  const { requireLogin, showLoginModal, closeLoginModal, moveToLogin } =
+    useAccessGuard();
   const handleLogoClick = () => navigate("/");
 
   const handlePlanClick = () => {
-    if (!isAuthenticated) {
-      navigate("/login", {
-        state: { message: "로그인 이후 이용 가능합니다.", from: "/mytrips" },
-      });
-      return;
-    }
+    if (!requireLogin()) return;
 
     navigate("/mytrips");
   };
@@ -108,6 +110,16 @@ export default function Header() {
             >
               MY PLAN ❯
             </button>
+            <ActionPromptModal
+              open={showLoginModal}
+              title="로그인이 필요합니다"
+              headline="로그인 후 이용할 수 있어요"
+              description="게시글 작성은 로그인한 사용자만 이용할 수 있습니다."
+              cancelText="취소"
+              confirmText="로그인"
+              onClose={closeLoginModal}
+              onConfirm={moveToLogin}
+            />
           </li>
 
           <li className="nav-group">

--- a/src/shared/components/index.ts
+++ b/src/shared/components/index.ts
@@ -1,4 +1,8 @@
+// src/shared/components/index.ts
+
 export { default as Layout } from "./Layout";
 export { default as Header } from "./Header";
 export { default as Footer } from "./Footer";
 export { default as BaseModal } from "./BaseModal";
+export { ActionPromptModal } from "./ActionPromptModal";
+export { AvatarDisplay } from "./AvatarDisplay";

--- a/src/shared/hooks/index.ts
+++ b/src/shared/hooks/index.ts
@@ -1,0 +1,4 @@
+// src/shared/hooks/index.ts
+
+export * from "./avatar";
+export * from "./useAccessGuard";

--- a/src/shared/hooks/useAccessGuard.ts
+++ b/src/shared/hooks/useAccessGuard.ts
@@ -1,0 +1,77 @@
+import { useCallback, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useAuth } from "../../features/user/pages/AuthContext";
+import type { AgeVerificationStatus } from "../../types";
+
+interface AccessGuardProfile {
+  ageVerified?: boolean;
+  ageVerificationStatus?: AgeVerificationStatus;
+}
+
+export function useAccessGuard(profile?: AccessGuardProfile | null) {
+  const navigate = useNavigate();
+  const { isAuthenticated } = useAuth();
+
+  const [showLoginModal, setShowLoginModal] = useState(false);
+  const [showAdultModal, setShowAdultModal] = useState(false);
+
+  const closeLoginModal = useCallback(() => {
+    setShowLoginModal(false);
+  }, []);
+
+  const closeAdultModal = useCallback(() => {
+    setShowAdultModal(false);
+  }, []);
+
+  const moveToLogin = useCallback(() => {
+    setShowLoginModal(false);
+    navigate("/login");
+  }, [navigate]);
+
+  const moveToMypageForVerification = useCallback(() => {
+    setShowAdultModal(false);
+    navigate("/mypage");
+  }, [navigate]);
+
+  // 비로그인 상태에서 로그인 필요한 경우
+  const requireLogin = useCallback(() => {
+    if (!isAuthenticated) {
+      setShowLoginModal(true);
+      return false;
+    }
+    return true;
+  }, [isAuthenticated]);
+
+  // 로그인 상태에서 성인 인증 필요한 경우 (미성년자 차단 + 인증 안된 성인)
+  const requireAdultVerified = useCallback(() => {
+    if (!isAuthenticated) {
+      setShowLoginModal(true);
+      return false;
+    }
+
+    // 미성년자 먼저 차단
+    if (profile?.ageVerificationStatus === "UNDERAGE") {
+      alert("만 19세 미만은 이용할 수 없습니다.");
+      return false;
+    }
+
+    // 인증 안된 성인
+    if (!profile?.ageVerified) {
+      setShowAdultModal(true);
+      return false;
+    }
+
+    return true;
+  }, [isAuthenticated, profile]);
+
+  return {
+    showLoginModal,
+    showAdultModal,
+    closeLoginModal,
+    closeAdultModal,
+    moveToLogin,
+    moveToMypageForVerification,
+    requireLogin,
+    requireAdultVerified,
+  };
+}

--- a/src/shared/styles/ActionPromptModal.css
+++ b/src/shared/styles/ActionPromptModal.css
@@ -1,0 +1,185 @@
+/* ========== 외부 구조 (workspace 스타일) ========== */
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
+}
+
+.modal-overlay.active {
+  display: flex;
+}
+
+.modal-window {
+  background: white;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.1);
+  overflow: hidden;
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.write-window {
+  width: 90%;
+  max-width: 800px;
+}
+
+.sent-window {
+  width: 90%;
+  max-width: 700px;
+}
+
+.received-window {
+  width: 90%;
+  max-width: 900px;
+}
+
+.detail-window {
+  width: 90%;
+  max-width: 500px;
+}
+
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 20px 24px;
+  background: #000;
+  color: #fff;
+  border-bottom: 2px solid #000;
+}
+
+.mh-title {
+  font-family: "Share Tech Mono", monospace;
+  font-size: 18px;
+  font-weight: bold;
+}
+
+.mh-close {
+  background: none;
+  border: 2px solid #fff;
+  color: #fff;
+  padding: 6px 12px;
+  font-family: "Share Tech Mono", monospace;
+  font-weight: bold;
+  cursor: pointer;
+  transition: 0.2s;
+}
+
+.mh-close:hover {
+  background: #fff;
+  color: #000;
+}
+
+/* ========== 내부 컨텐츠 (원래 neobrutalism 디자인) ========== */
+.modal-body {
+  padding: 24px;
+  overflow-y: auto;
+  background: #fff;
+  font-family: var(--font-mono);
+}
+
+/* Neobrutalism 스타일 유지 */
+.modal {
+  border: 3px solid #000;
+}
+
+.header {
+  border-bottom: 3px solid #000;
+}
+
+.infoBox {
+  border: 2px solid #000;
+}
+
+.infoBoxLarge {
+  border: 3px solid #000;
+}
+
+.button {
+  border: 3px solid #000;
+  box-shadow: 4px 4px 0px rgba(0, 0, 0, 1);
+}
+
+.card {
+  border: 3px solid #000;
+}
+
+.cardApproved {
+  box-shadow: 0 0 0 4px #22c55e;
+}
+
+.cardRejected {
+  box-shadow: 0 0 0 4px #ef4444;
+}
+
+.bgBlack {
+  background-color: #000 !important;
+  color: #fff !important;
+}
+
+.bgBlackHoverable {
+  background-color: #000 !important;
+  color: #fff !important;
+}
+
+.bgBlackHoverable:hover {
+  background-color: #fff !important;
+  color: #000 !important;
+}
+
+.bgWhiteHoverable:hover {
+  background-color: #000 !important;
+  color: #fff !important;
+}
+
+.bgGreen {
+  background-color: #22c55e !important;
+  color: #fff !important;
+}
+
+.bgRed {
+  background-color: #ef4444 !important;
+  color: #fff !important;
+}
+
+.overlay {
+  background-color: rgba(0, 0, 0, 0.5);
+}
+
+.badge {
+  background-color: #000 !important;
+  color: #fff !important;
+}
+
+@keyframes shake {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  20% {
+    transform: translateX(-8px);
+  }
+  40% {
+    transform: translateX(8px);
+  }
+  60% {
+    transform: translateX(-5px);
+  }
+  80% {
+    transform: translateX(5px);
+  }
+}
+
+.animate-shake {
+  animation: shake 0.4s cubic-bezier(0.36, 0.07, 0.19, 0.97) both;
+  transform: translate3d(0, 0, 0);
+  backface-visibility: hidden;
+  perspective: 1000px;
+}


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #123

---

## 🎨 작업 내용 (What)

- 공용 안내 모달 컴포넌트(`ActionPromptModal`) 추가
- 접근 제어 훅(`useAccessGuard`) 추가
- Header 접근 제어 로직 개선
- Header 프로필 표시 로직 개선

---

## 🧭 작업 목적 (Why)

기존에는 로그인 필요 / 성인 인증 필요 등의 접근 제어 로직이  
각 컴포넌트에 분산될 가능성이 있어 중복 코드와 유지보수 문제가 발생할 수 있었다.

또한 사용자에게 안내할 때 `alert` 또는 단순 페이지 이동 방식으로 처리되어  
일관된 UX 제공이 어려운 상태였다.

이에 따라 접근 제어 로직을 훅으로 분리하고,  
공용 안내 모달을 도입하여 재사용성과 UX 일관성을 개선하였다.

---

## 🧩 변경 범위
- [ ] UI / Layout
- [x] 컴포넌트 구조
- [x] 상태 관리 로직
- [ ] API 연동
- [ ] 스타일

---

## 🧪 테스트 방법

- [x] 로컬 실행 확인

- [x] 주요 시나리오 테스트
  - 비로그인 상태에서 MY PLAN 클릭 → 로그인 안내 모달 표시
  - 모달에서 "로그인" 클릭 → 로그인 페이지 이동
  - 로그인 상태에서 정상 접근 가능

- [x] 에러 콘솔 확인

---

## ⚠️ 참고 사항

- `useAccessGuard`는 이후 다른 기능(게시글 작성, 동행 신청 등)에도 재사용 가능
- 현재 미성년자 처리만 `alert`로 되어 있어 추후 공용 모달로 통일 필요
- `ActionPromptModal`은 공용 컴포넌트로 다양한 안내 상황에 확장 가능

---

## ✅ 체크리스트
- [x] main 브랜치 직접 push 하지 않음
- [x] feature 브랜치에서 작업함
- [x] 불필요한 console.log 제거
- [x] PR 단위가 과도하게 크지 않음