### PR TITLE
[FE] refactor: 마이페이지 탭 구조 분리 및 사용자 정보 관리 개선

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,8 @@ import UserSettings from "./features/user/pages/UserSetting";
 import OAuthSuccess from "./features/user/pages/OAuthSuccess";
 import ProtectedRoute from "./features/user/pages/ProtectedRoute";
 import { AuthProvider } from "./features/user/pages/AuthContext";
+import NoticePage from "./features/user/pages/NoticePage";
+import FaqPage from "./features/user/pages/FaqPage";
 
 export default function App() {
   return (
@@ -25,6 +27,8 @@ export default function App() {
         {/* 보호된 라우트: 설정 페이지 */}
         <Route element={<ProtectedRoute />}>
           <Route path="/setting" element={<UserSettings />} />
+          <Route path="/notice" element={<NoticePage />} />
+          <Route path="/faq" element={<FaqPage />} />
         </Route>
 
         {/* 레이아웃 있는 페이지 */}

--- a/src/api/auth.api.ts
+++ b/src/api/auth.api.ts
@@ -6,6 +6,8 @@ import type {
   CheckEmailResponse,
   UserResponse,
   UserUpdateRequestDto,
+  TravelStyleOption,
+  AgeVerificationResponse,
 } from "../types/auth.types";
 
 const LOGOUT_SYNC_KEY = "logout-event";
@@ -13,6 +15,11 @@ const LOGOUT_SYNC_KEY = "logout-event";
 // 로그인된 사용자 정보 조회
 export const getMyInfo = () => {
   return api.get<UserResponse>("/users/me");
+};
+
+// 여행 스타일 목록 조회
+export const getTravelStyles = () => {
+  return api.get<TravelStyleOption[]>("/users/styles");
 };
 
 // 이메일 가입 여부 확인
@@ -23,6 +30,10 @@ export const checkEmail = (data: CheckEmailRequest) => {
 // 내 정보 수정
 export const updateMyInfo = (data: UserUpdateRequestDto) => {
   return api.patch<void>("/users/me", data);
+};
+
+export const verifyAdult = () => {
+  return api.patch<AgeVerificationResponse>("/users/me/age-verification");
 };
 
 // 로그아웃 상태를 다른 탭에도 동기화

--- a/src/features/user/components/AccountSettingsTab.tsx
+++ b/src/features/user/components/AccountSettingsTab.tsx
@@ -1,0 +1,305 @@
+// src/features/user/components/AccountSettingsTab.tsx
+
+import { useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import { ChevronDown, ChevronUp } from "lucide-react";
+import type { UserProfile } from "../hooks/useUserSetting";
+import styles from "../styles/UserSetting.module.css";
+
+type AccountSettingsTabProps = {
+  profile: UserProfile;
+  onOpenVerifyModal: () => void;
+  onOpenBirthDateModal: () => void;
+  onOpenDeleteModal: () => void;
+};
+
+const SOCIAL_MAP = {
+  KAKAO: { class: styles.kakao, label: "K", name: "카카오 계정" },
+  GOOGLE: { class: styles.google, label: "G", name: "구글 계정" },
+  NAVER: { class: styles.naver, label: "N", name: "네이버 계정" },
+} as const;
+
+type SocialKey = keyof typeof SOCIAL_MAP;
+
+// 소셜 정보가 없을 때 보여줄 기본값
+const UNKNOWN_SOCIAL = { class: "", label: "?", name: "알 수 없는 계정" };
+
+function SocialItem({
+  providerKey,
+  detail,
+  connected,
+}: {
+  providerKey: string;
+  detail: string;
+  connected: boolean;
+}) {
+  const social = SOCIAL_MAP[providerKey as SocialKey] ?? UNKNOWN_SOCIAL;
+
+  return (
+    <div className={styles.socialItem}>
+      <div className={styles.socialInfo}>
+        <span className={`${styles.socialIcon} ${social.class}`}>
+          {social.label}
+        </span>
+        <div className={styles.socialText}>
+          <p className={styles.socialName}>{social.name}</p>
+          <p className={styles.socialDetail}>{detail}</p>
+        </div>
+      </div>
+      <span
+        className={`${styles.connectionBadge} ${
+          !connected ? styles.notConnected : ""
+        }`}
+      >
+        {connected ? "연결됨" : "연결 안 됨"}
+      </span>
+    </div>
+  );
+}
+
+export default function AccountSettingsTab({
+  profile,
+  onOpenVerifyModal,
+  onOpenBirthDateModal,
+  onOpenDeleteModal,
+}: AccountSettingsTabProps) {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [openSections, setOpenSections] = useState({ social: false });
+
+  const toggleSection = (section: "social") => {
+    setOpenSections((prev) => ({ ...prev, [section]: !prev[section] }));
+  };
+
+  const handleOpenVerificationFlow = () => {
+    if (!profile.birthDate) {
+      onOpenBirthDateModal();
+      return;
+    }
+
+    onOpenVerifyModal();
+  };
+
+  // linkedProviders가 없는 경우도 안전하게 처리
+  const linkedProviders: string[] = profile.linkedProviders ?? [];
+
+  return (
+    <div className={styles.settingsWrapper}>
+      <section className={styles.section}>
+        <div
+          className={styles.accordionHeader}
+          onClick={() => toggleSection("social")}
+        >
+          <h2 className={styles.sectionTitle}>계정 관리</h2>
+          {openSections.social ? (
+            <ChevronUp size={20} />
+          ) : (
+            <ChevronDown size={20} />
+          )}
+        </div>
+
+        {openSections.social && (
+          <div className={styles.accordionContent}>
+            {/* 메인 소셜 계정 */}
+            <div className={styles.accountBlock}>
+              <div className={styles.socialStatusCard}>
+                <h3 className={styles.subTitle}>연동된 계정 정보</h3>
+                <SocialItem
+                  providerKey={profile.provider ?? ""}
+                  detail={profile.email ?? "연결된 이메일 정보가 없습니다."}
+                  connected={!!profile.email}
+                />
+              </div>
+            </div>
+
+            {/* 추가 연동 소셜 계정 — 있을 때만 표시 */}
+            {linkedProviders.length > 0 && (
+              <div className={styles.accountBlock}>
+                <div className={styles.socialStatusCard}>
+                  <h3 className={styles.subTitle}>추가 연동된 계정</h3>
+                  {linkedProviders.map((provider) => (
+                    <SocialItem
+                      key={provider}
+                      providerKey={provider}
+                      detail="추가 연동된 계정"
+                      connected={true}
+                    />
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+        {/* 공개여부 설정 비활성화*/}
+        {/* <div className={styles.accountBlock}>
+              <div className={styles.socialStatusCard}>
+                <h3 className={styles.subTitle}>공개여부 설정</h3>
+                <div className={styles.privacyToggleArea}>
+                  {PRIVACY_ITEMS.map((item) => (
+                    <div key={item.id} className={styles.toggleRow}>
+                      <span>{item.label}</span>
+                      <label className={styles.switch}>
+                        <input
+                          type="checkbox"
+                          checked={Boolean(profile[item.id])}
+                          onChange={(e) =>
+                            onImmediateToggle(item.id, e.target.checked)
+                          }
+                        />
+                        <span className={styles.slider}></span>
+                      </label>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div> */}
+      </section>
+
+      {/* 알림 설정 비활성화 */}
+      {/* <section className={styles.section}>
+        <div
+          className={styles.accordionHeader}
+          onClick={() => toggleSection("notifications")}
+        >
+          <h2 className={styles.sectionTitle}>알림 설정</h2>
+          {openSections.notifications ? (
+            <ChevronUp size={20} />
+          ) : (
+            <ChevronDown size={20} />
+          )}
+        </div>
+
+        {openSections.notifications && (
+          <div className={styles.accordionContent}>
+            <div className={styles.settingList}>
+              {NOTIFICATION_ITEMS.map((item) => (
+                <div key={item.id} className={styles.settingItem}>
+                  <div className={styles.settingText}>
+                    <p className={styles.settingLabel}>{item.label}</p>
+                    <p className={styles.settingDesc}>{item.desc}</p>
+                  </div>
+                  <label className={styles.switch}>
+                    <input
+                      type="checkbox"
+                      checked={Boolean(profile[item.id])}
+                      onChange={(e) =>
+                        updateProfile({ [item.id]: e.target.checked })
+                      }
+                    />
+                    <span className={styles.slider}></span>
+                  </label>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </section> */}
+
+      {/* 서비스 이용 인증 */}
+      <section className={styles.section}>
+        <h2 className={styles.sectionTitle}>서비스 이용 인증</h2>
+        <div className={styles.adultVerifyBox}>
+          {profile.ageVerificationStatus === "UNDERAGE" ? (
+            <>
+              <p className={styles.verifyTitle}>🚫 만 19세 이상 이용 안내</p>
+              <p className={styles.verifyDesc}>
+                입력하신 생년월일 기준으로 현재 서비스 이용이 제한됩니다.
+              </p>
+              <p className={styles.legalWarning}>
+                트립모아는 안전한 동행 및 여행 계획 공유를 위해 성인 전용으로
+                운영됩니다. 생년월일 정보는 수정할 수 없으므로, 문제가 있다면
+                고객센터로 문의해주세요.
+              </p>
+              <button className={styles.primaryButton} disabled type="button">
+                이용 제한
+              </button>
+            </>
+          ) : (
+            <>
+              <p className={styles.verifyTitle}>🔞 만 19세 이상 이용 안내</p>
+              <p className={styles.verifyDesc}>
+                트립모아는 안전한 동행 및 여행 계획 공유를 위해{" "}
+                <strong>성인 전용</strong>으로 운영됩니다.
+              </p>
+              <p className={styles.legalWarning}>
+                * 허위 정보 입력 시 서비스 이용 제한 및 책임은 사용자 본인에게
+                있습니다.
+              </p>
+              <button
+                className={styles.primaryButton}
+                onClick={handleOpenVerificationFlow}
+                disabled={profile.ageVerificationStatus === "VERIFIED"}
+                type="button"
+              >
+                {profile.ageVerificationStatus === "VERIFIED"
+                  ? "인증 완료"
+                  : "성인 인증하기"}
+              </button>
+            </>
+          )}
+        </div>
+      </section>
+
+      <section className={styles.section}>
+        <h2 className={styles.sectionTitle}>고객 지원</h2>
+        <div className={styles.supportGrid}>
+          <button
+            className={styles.supportBtn}
+            onClick={() =>
+              navigate("/notice", {
+                state: {
+                  returnTo: "/setting",
+                  activeTab: "계정 및 설정",
+                  closeTo: location.state?.closeTo ?? "/",
+                },
+              })
+            }
+            type="button"
+          >
+            공지사항
+          </button>
+
+          <button
+            className={styles.supportBtn}
+            onClick={() =>
+              navigate("/faq", {
+                state: {
+                  returnTo: "/setting",
+                  activeTab: "계정 및 설정",
+                  closeTo: location.state?.closeTo ?? "/",
+                },
+              })
+            }
+            type="button"
+          >
+            FAQ
+          </button>
+
+          <button
+            className={styles.supportBtnPrimary}
+            onClick={() =>
+              window.open("http://pf.kakao.com/_wdmjX/chat", "_blank")
+            }
+            type="button"
+          >
+            카카오톡 1:1 문의
+          </button>
+        </div>
+      </section>
+
+      <section className={`${styles.section} ${styles.danger}`}>
+        <h2 className={styles.sectionTitle}>회원 탈퇴</h2>
+        <p className={styles.desc}>
+          탈퇴 시 프로필 정보만 삭제되며 여행 데이터는 삭제되지 않습니다.
+        </p>
+        <button
+          className={styles.dangerButton}
+          onClick={onOpenDeleteModal}
+          type="button"
+        >
+          회원 탈퇴하기
+        </button>
+      </section>
+    </div>
+  );
+}

--- a/src/features/user/components/MyInfoTab.tsx
+++ b/src/features/user/components/MyInfoTab.tsx
@@ -1,0 +1,266 @@
+// src/features/user/components/MyInfoTab.tsx
+
+import React, { useState } from "react";
+import type { UserProfile } from "../hooks/useUserSetting";
+
+import styles from "../styles/UserSetting.module.css";
+import { Camera } from "lucide-react";
+
+type MyInfoTabProps = {
+  profile: UserProfile;
+  updateProfile: (patch: Partial<UserProfile>) => void;
+  isEmailValid: boolean;
+  isBirthValid: boolean;
+  MBTI_TYPES: string[];
+  regenerateAvatar: () => void;
+  triggerPhotoUpload: () => void;
+  toggleTravelStyle: (style: string) => void;
+  fileInputRef: React.RefObject<HTMLInputElement | null>;
+  handlePhotoChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  travelStyleOptions: string[];
+};
+
+export default function MyInfoTab({
+  profile,
+  updateProfile,
+  isEmailValid,
+  isBirthValid,
+  MBTI_TYPES,
+  regenerateAvatar,
+  triggerPhotoUpload,
+  toggleTravelStyle,
+  fileInputRef,
+  handlePhotoChange,
+  travelStyleOptions,
+}: MyInfoTabProps) {
+  // 추천 목록 표시 여부 상태
+  const [showSuggestions, setShowSuggestions] = useState(false);
+
+  // 입력값 필터링 (영어만 허용 및 대문자 변환)
+  const handleMBTIChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value.replace(/[^A-Za-z]/g, "").toUpperCase();
+    updateProfile({ mbti: value });
+    setShowSuggestions(true);
+  };
+
+  const filteredMBTI = MBTI_TYPES.filter((type) =>
+    type.startsWith(profile.mbti || ""),
+  );
+
+  return (
+    <section className={styles.section}>
+      <h2 className={styles.sectionTitle}>프로필 정보</h2>
+
+      <div className={styles.profileRow}>
+        <div
+          className={styles.avatar}
+          onClick={regenerateAvatar}
+          title="클릭 시 랜덤 아바타 변경"
+          style={{
+            background:
+              profile.profileType === "CUSTOM"
+                ? "transparent"
+                : profile.avatarColor || "#e5e7eb",
+          }}
+        >
+          {profile.profileType === "CUSTOM" && profile.profileImage ? (
+            <img src={profile.profileImage} alt="Profile" />
+          ) : (
+            <span className={styles.avatarEmoji}>{profile.avatarEmoji}</span>
+          )}
+          <div className={styles.avatarOverlay}>
+            <Camera size={20} />
+          </div>
+        </div>
+
+        <div className={styles.avatarInfo}>
+          <p className={styles.avatarDesc}>
+            동그란 프로필을 클릭하면 랜덤 아바타로 바뀝니다.
+          </p>
+          <button
+            className={styles.secondaryButton}
+            onClick={triggerPhotoUpload}
+            type="button"
+          >
+            대표 사진 업로드
+          </button>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/*"
+            style={{ display: "none" }}
+            onChange={handlePhotoChange}
+          />
+        </div>
+      </div>
+
+      <div className={styles.grid}>
+        <div className={styles.field}>
+          <label className={styles.label}>
+            닉네임<span className={styles.required}>*</span>
+          </label>
+          <input
+            className={`${styles.input} ${
+              !profile.nickname ? styles.inputError : ""
+            }`}
+            value={profile.nickname || ""}
+            placeholder="닉네임은 필수 입력 항목입니다."
+            onChange={(e) => updateProfile({ nickname: e.target.value })}
+          />
+          {!profile.nickname && (
+            <span className={styles.errorText}>
+              닉네임은 필수 입력 사항입니다.
+            </span>
+          )}
+        </div>
+
+        <div className={styles.field}>
+          <label className={styles.label}>이름</label>
+          <input
+            className={`${styles.input} ${
+              profile.nameLocked ? styles.inputLocked : ""
+            }`}
+            value={profile.name || ""}
+            readOnly={profile.nameLocked}
+            onChange={(e) => updateProfile({ name: e.target.value })}
+          />
+        </div>
+
+        <div className={styles.field}>
+          <label className={styles.label}>알림 수신 이메일</label>
+          <input
+            className={`${styles.input} ${
+              profile.notificationEmail && !isEmailValid
+                ? styles.inputError
+                : ""
+            }`}
+            placeholder="example@email.com"
+            value={profile.notificationEmail || ""}
+            onChange={(e) =>
+              updateProfile({ notificationEmail: e.target.value })
+            }
+          />
+          {profile.notificationEmail && !isEmailValid && (
+            <span className={styles.errorText}>
+              올바른 이메일 형식을 입력해주세요.
+            </span>
+          )}
+        </div>
+
+        <div className={styles.field}>
+          <label className={styles.label}>성별</label>
+          <input
+            className={`${styles.input} ${
+              profile.genderLocked ? styles.inputLocked : ""
+            }`}
+            value={profile.gender || ""}
+            readOnly={profile.genderLocked}
+            placeholder="예 : 남 / 여"
+            onChange={(e) => updateProfile({ gender: e.target.value })}
+          />
+        </div>
+
+        <div className={styles.field}>
+          <label className={styles.label}>
+            생년월일<span className={styles.required}>*</span>
+          </label>
+          <input
+            type="date"
+            className={`${styles.input} ${
+              profile.birthLocked
+                ? styles.inputLocked
+                : profile.birthDate && !isBirthValid
+                  ? styles.inputError
+                  : !profile.birthDate
+                    ? styles.inputRequired
+                    : ""
+            }`}
+            value={profile.birthDate || ""}
+            min="1900-01-01"
+            max={new Date().toISOString().split("T")[0]}
+            readOnly={profile.birthLocked}
+            onChange={(e) => updateProfile({ birthDate: e.target.value })}
+          />
+
+          {/* 안내 분리 */}
+          {!profile.birthDate && (
+            <span className={styles.requiredText}>
+              생년월일은 필수 입력 사항입니다.
+            </span>
+          )}
+          {profile.birthDate && !isBirthValid && (
+            <span className={styles.errorText}>
+              올바른 날짜를 입력해주세요.
+            </span>
+          )}
+        </div>
+
+        <div className={styles.field}>
+          <label className={styles.label}>MBTI</label>
+          <div className={styles.autocompleteWrapper}>
+            <input
+              className={`${styles.input} ${
+                profile.mbti &&
+                !MBTI_TYPES.includes(profile.mbti) &&
+                profile.mbti.length === 4
+                  ? styles.inputError
+                  : ""
+              }`}
+              style={{ width: "100%" }}
+              value={profile.mbti || ""}
+              onChange={handleMBTIChange}
+              onFocus={() => setShowSuggestions(true)}
+              onBlur={() => setTimeout(() => setShowSuggestions(false), 200)}
+              placeholder="예: ENFP"
+              maxLength={4}
+            />
+
+            {showSuggestions && filteredMBTI.length > 0 && profile.mbti && (
+              <ul className={styles.suggestionList}>
+                {filteredMBTI.map((type) => (
+                  <li
+                    key={type}
+                    className={styles.suggestionItem}
+                    onMouseDown={() => updateProfile({ mbti: type })}
+                  >
+                    <span className={styles.clockIcon}>👉</span>
+                    {type}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+
+          {profile.mbti &&
+            !MBTI_TYPES.includes(profile.mbti) &&
+            profile.mbti.length === 4 && (
+              <span className={styles.errorText}>
+                유효하지 않은 MBTI 유형입니다.
+              </span>
+            )}
+        </div>
+      </div>
+
+      <div className={styles.travelStyleSection}>
+        <label className={styles.label}>여행 스타일</label>
+        <p className={styles.desc}>
+          관심있는 여행 스타일을 선택해주세요 (복수 선택 가능)
+        </p>
+        <div className={styles.travelStyleGrid}>
+          {(travelStyleOptions ?? []).map((style, index) => (
+            <button
+              key={`${style}-${index}`}
+              className={`${styles.travelStyleBtn} ${
+                profile.travelStyles?.includes(style) ? styles.active : ""
+              }`}
+              onClick={() => toggleTravelStyle(style)}
+              type="button"
+            >
+              {style}
+            </button>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/features/user/components/ReportManagementTab.tsx
+++ b/src/features/user/components/ReportManagementTab.tsx
@@ -1,0 +1,178 @@
+// src/features/user/components/ReportManagementTab.tsx
+
+import { useEffect, useState } from "react";
+import { getMyReportHistory } from "../../../api/report.api";
+import type { MyReportHistoryResponse } from "../../../types";
+import styles from "../styles/UserSetting.module.css";
+
+const locationLabel = {
+  COMMENT: "댓글",
+  CHAT: "채팅",
+} as const;
+
+export default function ReportManagementTab() {
+  const [reportHistory, setReportHistory] =
+    useState<MyReportHistoryResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [page, setPage] = useState(0);
+
+  useEffect(() => {
+    const loadReportHistory = async () => {
+      try {
+        setLoading(true);
+        setError("");
+
+        const res = await getMyReportHistory(page, 5);
+        setReportHistory(res.data);
+      } catch (err: any) {
+        setError(
+          err?.response?.data?.message || "신고 내역을 불러오지 못했습니다.",
+        );
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadReportHistory();
+  }, [page]);
+
+  const reports = reportHistory?.reports ?? [];
+
+  return (
+    <>
+      <section className={styles.section}>
+        <h2 className={styles.sectionTitle}>나의 신고 누적 현황</h2>
+
+        {loading && <p>신고 내역을 불러오는 중...</p>}
+        {error && <p className={styles.errorText}>{error}</p>}
+
+        <div className={styles.reportSummary}>
+          <div className={styles.statusBox}>
+            <span className={styles.statusLabel}>현재 제재 단계</span>
+            <span className={styles.statusValue}>
+              {reportHistory ? `${reportHistory.currentLevelLabel}` : "-"}
+            </span>
+          </div>
+
+          <div className={styles.statusBox}>
+            <span className={styles.statusLabel}>누적 신고 횟수</span>
+            <span className={styles.statusValue}>
+              {reportHistory ? `${reportHistory.totalReportCount}회` : "-"}
+            </span>
+          </div>
+        </div>
+
+        <table className={styles.reportTable}>
+          <thead>
+            <tr>
+              <th>위치</th>
+              <th>사유</th>
+              <th>날짜</th>
+            </tr>
+          </thead>
+
+          <tbody>
+            {!loading && reports.length === 0 && (
+              <tr>
+                <td colSpan={3}>신고 내역이 없습니다.</td>
+              </tr>
+            )}
+
+            {reports.map((report) => (
+              <tr key={report.reportId}>
+                <td>
+                  {locationLabel[
+                    report.location as keyof typeof locationLabel
+                  ] ?? report.location}
+                </td>
+                <td>{report.reason}</td>
+                <td>
+                  {new Date(report.reportedAt).toLocaleDateString("ko-KR")}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "center",
+            gap: "10px",
+            marginTop: "16px",
+          }}
+        >
+          <button
+            disabled={page === 0}
+            onClick={() => setPage((prev) => prev - 1)}
+          >
+            이전
+          </button>
+
+          <span>
+            {reportHistory ? `${page + 1} / ${reportHistory.totalPages}` : "-"}
+          </span>
+
+          <button
+            disabled={!reportHistory || page + 1 >= reportHistory.totalPages}
+            onClick={() => setPage((prev) => prev + 1)}
+          >
+            다음
+          </button>
+        </div>
+      </section>
+
+      <section className={styles.section}>
+        <h2 className={styles.sectionTitle}>신고 및 제재 안내</h2>
+        <div className={styles.guideCard}>
+          <ul className={styles.guideList}>
+            <li>
+              <strong>1단계:</strong> 신고자 화면에서 메시지 숨김
+            </li>
+            <li>
+              <strong>2단계:</strong> 전체 화면에서 "신고된 메시지"로 치환
+            </li>
+            <li>
+              <strong>3단계:</strong> 서비스 로그인 시 경고 팝업 노출
+            </li>
+            <li>
+              <strong>4단계:</strong> 계정 상태 '정지' 처리 및 접속 차단
+            </li>
+          </ul>
+
+          <div className={styles.importantNote}>
+            <p className={styles.noteTitle}>
+              ⚠️ 여행 계획(Trip) 관련 중요 공지
+            </p>
+            <p className={styles.noteText}>
+              여행 계획 내에서 신고가 누적될 경우,{" "}
+              <strong>해당 계획에서 즉시 강제 퇴출</strong>당합니다. 작성하신
+              내용은 팀원들을 위해 <strong>'소유주 양도'</strong>로 유지되며,
+              퇴출 사실은 팀원들에게 즉시 통보됩니다.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section className={styles.section}>
+        <button
+          type="button"
+          className={styles.secondaryButton}
+          style={{ width: "100%" }}
+          onClick={async () => {
+            const email = import.meta.env.VITE_SUPPORT_EMAIL;
+
+            try {
+              await navigator.clipboard.writeText(email);
+              alert(`문의 이메일이 복사되었습니다.\n${email}`);
+            } catch {
+              alert(`문의 이메일: ${email}`);
+            }
+          }}
+        >
+          신고 관련 이메일 문의하기
+        </button>
+      </section>
+    </>
+  );
+}

--- a/src/features/user/components/index.ts
+++ b/src/features/user/components/index.ts
@@ -1,3 +1,6 @@
 // components/user/index.ts
-export { LoginForm } from './LoginForm';
-export * from './User.constant';
+
+export { LoginForm } from "./LoginForm";
+export { default as AccountSettingsTab } from "./AccountSettingsTab";
+export { default as MyInfoTab } from "./MyInfoTab";
+export { default as ReportManagementTab } from "./ReportManagementTab";

--- a/src/features/user/components/modal/DeleteAccountModal.tsx
+++ b/src/features/user/components/modal/DeleteAccountModal.tsx
@@ -1,0 +1,54 @@
+// src/features/user/components/modal/DeleteAccountModal.tsx
+
+import React from "react";
+import { AlertTriangle, X } from "lucide-react";
+import { MODAL_MESSAGES } from "../../hooks/User.constant";
+import styles from "../../styles/UserSetting.module.css";
+
+type DeleteAccountModalProps = {
+  open: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+};
+
+export default function DeleteAccountModal({
+  open,
+  onClose,
+  onConfirm,
+}: DeleteAccountModalProps) {
+  if (!open) return null;
+
+  return (
+    <div className={styles.modalOverlay} onClick={onClose}>
+      <div className={styles.modalContent} onClick={(e) => e.stopPropagation()}>
+        <button className={styles.modalCloseBtn} onClick={onClose}>
+          <X size={20} />
+        </button>
+
+        <div className={`${styles.modalIcon} ${styles.danger}`}>
+          <AlertTriangle size={48} />
+        </div>
+
+        <h2 className={styles.modalTitle}>{MODAL_MESSAGES.DELETE.TITLE}</h2>
+
+        <p className={styles.modalText}>
+          {MODAL_MESSAGES.DELETE.DESCRIPTION.split("\n").map((line, i, arr) => (
+            <React.Fragment key={i}>
+              {i === 1 ? <strong>{line}</strong> : line}
+              {i < arr.length - 1 && <br />}
+            </React.Fragment>
+          ))}
+        </p>
+
+        <div className={styles.modalButtons}>
+          <button className={styles.modalCancelBtn} onClick={onClose}>
+            취소
+          </button>
+          <button className={styles.modalDangerBtn} onClick={onConfirm}>
+            {MODAL_MESSAGES.DELETE.BUTTON}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/user/components/modal/VerifyModal.tsx
+++ b/src/features/user/components/modal/VerifyModal.tsx
@@ -1,0 +1,54 @@
+// src/features/user/components/modal/VerifyModal.tsx
+
+import React from "react";
+import { Shield, X } from "lucide-react";
+import { MODAL_MESSAGES } from "../../hooks/User.constant";
+import styles from "../../styles/UserSetting.module.css";
+
+type VerifyModalProps = {
+  open: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+};
+
+export default function VerifyModal({
+  open,
+  onClose,
+  onConfirm,
+}: VerifyModalProps) {
+  if (!open) return null;
+
+  return (
+    <div className={styles.modalOverlay} onClick={onClose}>
+      <div className={styles.modalContent} onClick={(e) => e.stopPropagation()}>
+        <button className={styles.modalCloseBtn} onClick={onClose}>
+          <X size={20} />
+        </button>
+
+        <div className={styles.modalIcon}>
+          <Shield size={48} />
+        </div>
+
+        <h2 className={styles.modalTitle}>{MODAL_MESSAGES.VERIFY.TITLE}</h2>
+
+        <p className={styles.modalText}>
+          {MODAL_MESSAGES.VERIFY.DESCRIPTION.split("\n").map((line, i, arr) => (
+            <React.Fragment key={i}>
+              {i === 2 ? <strong>{line}</strong> : line}
+              {i < arr.length - 1 && <br />}
+            </React.Fragment>
+          ))}
+        </p>
+
+        <div className={styles.modalButtons}>
+          <button className={styles.modalCancelBtn} onClick={onClose}>
+            취소
+          </button>
+          <button className={styles.modalConfirmBtn} onClick={onConfirm}>
+            {MODAL_MESSAGES.VERIFY.BUTTON}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/user/components/modal/index.ts
+++ b/src/features/user/components/modal/index.ts
@@ -1,0 +1,2 @@
+export { default as VerifyModal } from "./VerifyModal";
+export { default as DeleteAccountModal } from "./DeleteAccountModal";

--- a/src/features/user/hooks/User.constant.ts
+++ b/src/features/user/hooks/User.constant.ts
@@ -1,10 +1,16 @@
 // constants/user.constants.ts
 
-export const STORAGE_KEYS = {
-  USER_PROFILE: "tripmoa_user_profile",
-} as const;
+export const GENDER_OPTIONS = [
+  { label: "남성", value: "MALE" },
+  { label: "여성", value: "FEMALE" },
+  { label: "기타", value: "OTHER" },
+] as const;
 
-export const GENDERS = ["남성", "여성", "기타"] as const;
+export const PRIVACY_ITEMS = [
+  { id: "isPrivateName", label: "이름" },
+  { id: "isPrivateAge", label: "나이" },
+  { id: "isPrivateGender", label: "성별" },
+] as const;
 
 export const MBTI_TYPES = [
   "INTJ",
@@ -24,25 +30,6 @@ export const MBTI_TYPES = [
   "ESTP",
   "ESFP",
 ];
-
-export const TRAVEL_STYLES = [
-  "맛집탐방",
-  "액티비티",
-  "힐링",
-  "문화탐방",
-  "쇼핑",
-  "자연",
-  "사진",
-  "야경",
-  "로컬체험",
-  "카페투어",
-  "축제",
-  "역사탐방",
-  "야외활동",
-  "미식투어",
-  "럭셔리",
-  "배낭여행",
-] as const;
 
 // 랜덤 아바타용 이모지
 export const AVATAR_EMOJIS = [
@@ -116,25 +103,14 @@ export const AVATAR_COLORS = [
   "#FFC8B8",
 ] as const;
 
-export const DEFAULT_PROFILE = {
-  photo: "",
-  nickname: "",
-  name: "",
-  birthDate: "",
-  gender: "",
-  mbti: "",
-  travelStyles: [] as string[],
-  isVerified: false,
-} as const;
-
 // 모달 내용
 export const MODAL_MESSAGES = {
   VERIFY: {
-    TITLE: "본인 인증",
+    TITLE: "성인 이용 안내",
     DESCRIPTION:
-      "실제 서비스에서는 휴대폰 인증, 아이핀 인증 등이 진행됩니다.\n데모에서는 바로 인증이 완료됩니다.",
-    BUTTON: "인증하기",
-    SUCCESS: "✅ 본인 인증이 완료되었습니다!",
+      "현재 휴대폰 본인인증 기능은 제공되지 않습니다.\n생년월일 정보를 기준으로 성인 여부를 확인합니다.\n미성년자의 이용에 대한 책임은 본인에게 있습니다.",
+    BUTTON: "확인",
+    SUCCESS: "안내 확인이 완료되었습니다!",
   },
   DELETE: {
     TITLE: "계정을 탈퇴하시겠습니까?",
@@ -144,7 +120,7 @@ export const MODAL_MESSAGES = {
     SUCCESS: "계정이 탈퇴되었습니다. 그동안 이용해주셔서 감사합니다.",
   },
   SAVE: {
-    SUCCESS: "✅ 프로필이 저장되었습니다!",
+    SUCCESS: "프로필이 저장되었습니다!",
   },
 } as const;
 

--- a/src/features/user/hooks/index.ts
+++ b/src/features/user/hooks/index.ts
@@ -1,1 +1,4 @@
-export { useUserProfile } from './useUserSetting';
+// src/features/user/hooks/index.ts
+
+export { useUserProfile } from "./useUserSetting";
+export * from "../hooks/User.constant";

--- a/src/features/user/hooks/useUserSetting.ts
+++ b/src/features/user/hooks/useUserSetting.ts
@@ -1,13 +1,24 @@
 import { useState, useEffect, useRef } from "react";
 import { useNavigate } from "react-router-dom";
-import { generateRandomAvatar } from "../components/User.constant";
-import { MBTI_TYPES } from "../components/User.constant";
-import { getMyInfo, updateMyInfo, withdraw } from "../../../api/auth.api";
+import { generateRandomAvatar, MBTI_TYPES } from "./User.constant";
+import {
+  getMyInfo,
+  updateMyInfo,
+  withdraw,
+  verifyAdult,
+  getTravelStyles,
+} from "../../../api/auth.api";
 import { useAuth } from "../pages/AuthContext";
+import type {
+  UserResponse,
+  ProfileType,
+  UserUpdateRequestDto,
+  AgeVerificationStatus,
+} from "../../../types";
 
 export interface UserProfile {
-  // 기본 필드
   profileImage: string;
+  profileType: ProfileType;
   nickname: string;
   name: string;
   notificationEmail: string;
@@ -17,176 +28,273 @@ export interface UserProfile {
   travelStyles: string[];
   email?: string;
   provider?: "KAKAO" | "GOOGLE" | "NAVER";
+  linkedProviders: string[];
 
-  // 상태 필드
-  isVerified: boolean;
-  avatarEmoji?: string;
-  avatarColor?: string;
+  ageVerified: boolean;
+  ageVerificationStatus: AgeVerificationStatus;
 
-  // 잠금 필드
+  avatarEmoji: string;
+  avatarColor: string;
+
   nameLocked: boolean;
   genderLocked: boolean;
   birthLocked: boolean;
 
-  // 개인정보 공개 설정 필드
-  isPrivateName: boolean; // 이름 비공개 여부
-  isPrivateAge: boolean; // 나이 비공개 여부
-  isPrivateGender: boolean; // 성별 비공개 여부
-  isAdultConfirmed: boolean; // 성인 인증 확인 여부
+  isPrivateName: boolean;
+  isPrivateAge: boolean;
+  isPrivateGender: boolean;
 
-  // 알림 설정 필드
-  tripAlert: boolean; // 여행 일정 알림
-  marketingAgreed: boolean; // 마케팅 수신 동의
-  emailAgreed: boolean; // 이메일 수신 동의
+  tripAlert: boolean;
+  marketingAgreed: boolean;
+  emailAgreed: boolean;
 
-  // 동적 키 접근을 위한 인덱스 시그니처 추가
   [key: string]: any;
 }
 
+const calculateAge = (birthDate: string): number => {
+  if (!birthDate) return 0;
+
+  const today = new Date();
+  const birth = new Date(birthDate);
+  let age = today.getFullYear() - birth.getFullYear();
+  const monthDiff = today.getMonth() - birth.getMonth();
+
+  if (monthDiff < 0 || (monthDiff === 0 && today.getDate() < birth.getDate())) {
+    age--;
+  }
+
+  return age;
+};
+
+const deriveAgeVerificationStatus = (
+  birthDate: string | null,
+  ageVerified: boolean,
+): AgeVerificationStatus => {
+  if (ageVerified) return "VERIFIED";
+  if (!birthDate) return "UNVERIFIED";
+
+  return calculateAge(birthDate) < 19 ? "UNDERAGE" : "UNVERIFIED";
+};
+
+const toAgeStatus = (
+  status: AgeVerificationStatus | null | undefined,
+  fallback: AgeVerificationStatus,
+): AgeVerificationStatus => {
+  if (
+    status === "VERIFIED" ||
+    status === "UNDERAGE" ||
+    status === "UNVERIFIED"
+  ) {
+    return status;
+  }
+  return fallback;
+};
+
+const mapUserResponseToProfile = (data: UserResponse): UserProfile => {
+  const displayGender =
+    data.gender === "MALE" ? "남성" : data.gender === "FEMALE" ? "여성" : "";
+
+  const derivedAgeStatus = deriveAgeVerificationStatus(
+    data.birthDate,
+    data.ageVerified ?? false,
+  );
+
+  return {
+    profileImage: data.profileImage ?? "",
+    profileType: data.profileType ?? (data.profileImage ? "CUSTOM" : "AVATAR"),
+    nickname: data.nickname ?? "",
+    name: data.name ?? "",
+    notificationEmail: data.notificationEmail ?? "",
+    birthDate: data.birthDate ?? "",
+    gender: displayGender,
+    mbti: data.mbti ?? "",
+    travelStyles: data.travelStyles ?? [],
+    email: data.email ?? "",
+    provider:
+      data.provider === "KAKAO" ||
+      data.provider === "GOOGLE" ||
+      data.provider === "NAVER"
+        ? data.provider
+        : undefined,
+    linkedProviders: data.linkedProviders ?? [],
+
+    ageVerified: data.ageVerified ?? false,
+    ageVerificationStatus: toAgeStatus(
+      data.ageVerificationStatus,
+      derivedAgeStatus,
+    ),
+
+    avatarEmoji: data.avatarEmoji ?? "",
+    avatarColor: data.avatarColor ?? "",
+
+    nameLocked: !!data.nameLocked,
+    genderLocked: !!data.genderLocked,
+    birthLocked: !!data.birthLocked,
+
+    isPrivateName: false,
+    isPrivateAge: false,
+    isPrivateGender: false,
+
+    tripAlert: false,
+    marketingAgreed: false,
+    emailAgreed: false,
+  };
+};
+
 export function useUserProfile() {
   const navigate = useNavigate();
-  const fileInputRef = useRef<HTMLInputElement>(null);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
   const { isAuthenticated, authReady, clearAuth } = useAuth();
 
   const [profile, setProfile] = useState<UserProfile | null>(null);
   const [hasChanges, setHasChanges] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
+  const [travelStyleOptions, setTravelStyleOptions] = useState<string[]>([]);
+  const [originalProfile, setOriginalProfile] = useState<UserProfile | null>(
+    null,
+  );
+
+  const getComparableProfile = (profile: UserProfile) => ({
+    nickname: profile.nickname,
+    name: profile.name,
+    notificationEmail: profile.notificationEmail,
+    gender: profile.gender,
+    birthDate: profile.birthDate,
+    mbti: profile.mbti,
+    travelStyles: [...(profile.travelStyles ?? [])].sort(),
+    profileType: profile.profileType,
+    profileImage: profile.profileImage,
+    avatarEmoji: profile.avatarEmoji,
+    avatarColor: profile.avatarColor,
+  });
+
+  useEffect(() => {
+    if (!profile || !originalProfile) {
+      setHasChanges(false);
+      return;
+    }
+
+    const current = getComparableProfile(profile);
+    const original = getComparableProfile(originalProfile);
+
+    setHasChanges(JSON.stringify(current) !== JSON.stringify(original));
+  }, [profile, originalProfile]);
+
+  useEffect(() => {
+    getTravelStyles()
+      .then((res) => {
+        setTravelStyleOptions(res.data.map((style) => style.name));
+      })
+      .catch((error) => {
+        console.error("여행 스타일 목록 조회 실패", error);
+      });
+  }, []);
 
   useEffect(() => {
     if (!authReady) return;
-
     if (!isAuthenticated) {
       setProfile(null);
       return;
     }
-
     getMyInfo()
       .then((res) => {
-        const data = res.data;
-
-        if (data.gender === "MALE") data.gender = "남성";
-        else if (data.gender === "FEMALE") data.gender = "여성";
-
-        setProfile(data);
+        const mapped = mapUserResponseToProfile(res.data);
+        setProfile(mapped);
+        setOriginalProfile(mapped);
       })
       .catch(() => {
         clearAuth();
         navigate("/login", { replace: true });
       });
-  }, [authReady, isAuthenticated, navigate, clearAuth]);
+  }, [authReady, isAuthenticated]);
 
-  // 나이 계산
-  const calculateAge = (birthDate: string): number => {
-    if (!birthDate) return 0;
-    const today = new Date();
-    const birth = new Date(birthDate);
-    let age = today.getFullYear() - birth.getFullYear();
-    const monthDiff = today.getMonth() - birth.getMonth();
-    if (
-      monthDiff < 0 ||
-      (monthDiff === 0 && today.getDate() < birth.getDate())
-    ) {
-      age--;
-    }
-    return age;
-  };
-
-  // 프로필 저장
   const saveProfile = async () => {
-    if (!profile) return;
+    if (!profile) return false;
     setIsSaving(true);
 
     try {
+      const normalizedGender = profile.gender?.trim().toUpperCase();
+
       const genderForServer = ["남성", "남자", "남", "MALE", "M"].includes(
-        profile.gender?.toUpperCase(),
+        normalizedGender,
       )
         ? "MALE"
-        : ["여성", "여자", "여", "FEMALE", "F"].includes(
-              profile.gender?.toUpperCase(),
-            )
+        : ["여성", "여자", "여", "FEMALE", "F"].includes(normalizedGender)
           ? "FEMALE"
           : null;
 
-      const payload = {
+      const payload: UserUpdateRequestDto = {
         nickname: profile.nickname,
-        name: profile.name || null,
-        notificationEmail: profile.notificationEmail || null,
-        gender: genderForServer,
-        birthDate: profile.birthDate || null,
-        mbti: profile.mbti || null,
+        name: profile.name || undefined,
+        notificationEmail: profile.notificationEmail || undefined,
+        gender: genderForServer || undefined,
+        birthDate: profile.birthDate || undefined,
+        mbti: profile.mbti || undefined,
         travelStyles: profile.travelStyles || [],
-        profileImage: profile.profileImage,
-        avatarEmoji: profile.avatarEmoji,
-        avatarColor: profile.avatarColor,
+        profileType: profile.profileType,
+        profileImage:
+          profile.profileType === "CUSTOM"
+            ? profile.profileImage || undefined
+            : undefined,
+        avatarEmoji:
+          profile.profileType === "AVATAR"
+            ? profile.avatarEmoji || undefined
+            : undefined,
+        avatarColor:
+          profile.profileType === "AVATAR"
+            ? profile.avatarColor || undefined
+            : undefined,
       };
 
       await updateMyInfo(payload);
 
-      const displayGender =
-        genderForServer === "MALE"
-          ? "남성"
-          : genderForServer === "FEMALE"
-            ? "여성"
-            : "";
-
-      setProfile((prev) => {
-        if (!prev) return null;
-
-        // 빈 문자열("")은 false로 처리되어 값이 없을 땐 잠기지 않음
-        return {
-          ...prev,
-          gender: displayGender,
-          nameLocked: !!prev.name,
-          genderLocked: !!displayGender,
-          birthLocked: !!prev.birthDate,
-        };
-      });
-      setHasChanges(false);
+      const refreshed = await getMyInfo();
+      const mapped = mapUserResponseToProfile(refreshed.data);
+      setProfile(mapped);
+      setOriginalProfile(mapped);
 
       return true;
-    } catch (error) {
-      alert("저장에 실패했습니다. 다시 시도해주세요.");
+    } catch {
       return false;
     } finally {
       setIsSaving(false);
     }
   };
 
-  // 프로필 수정
   const updateProfile = (updates: Partial<UserProfile>) => {
     setProfile((prev) => (prev ? { ...prev, ...updates } : prev));
-    setHasChanges(true);
   };
 
-  // 사진 업로드 트리거
   const triggerPhotoUpload = () => {
     fileInputRef.current?.click();
   };
 
-  // 아바타 랜덤 변경
   const regenerateAvatar = () => {
     const { emoji, color } = generateRandomAvatar();
+
     updateProfile({
+      profileType: "AVATAR",
       avatarEmoji: emoji,
       avatarColor: color,
       profileImage: "",
     });
   };
 
-  // 랜덤 사진 변경
   const handlePhotoChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
-    if (file) {
-      const reader = new FileReader();
-      reader.onload = (event) => {
-        updateProfile({ profileImage: event.target?.result as string });
-        e.target.value = "";
-      };
-      reader.readAsDataURL(file);
-    }
+    if (!file) return;
+
+    const reader = new FileReader();
+    reader.onload = (event) => {
+      updateProfile({
+        profileType: "CUSTOM",
+        profileImage: (event.target?.result as string) || "",
+      });
+      e.target.value = "";
+    };
+    reader.readAsDataURL(file);
   };
 
-  // 여행 스타일 토글
   const toggleTravelStyle = (style: string) => {
     if (!profile) return;
 
@@ -199,58 +307,113 @@ export function useUserProfile() {
     }
   };
 
-  // MBTI 유효성 검사: 비어있거나, 4글자이면서 유효 목록에 포함되어야 함
+  const isValidBirthDate = (birthDate?: string): boolean => {
+    if (!birthDate) return false;
+
+    // YYYY-MM-DD 형식만 허용
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(birthDate)) return false;
+
+    const [year, month, day] = birthDate.split("-").map(Number);
+    const date = new Date(year, month - 1, day);
+
+    if (
+      date.getFullYear() !== year ||
+      date.getMonth() !== month - 1 ||
+      date.getDate() !== day
+    ) {
+      return false;
+    }
+
+    const today = new Date();
+
+    if (date > today) return false;
+
+    if (year < 1900) return false;
+
+    return true;
+  };
+
   const isMBTIValid =
     !profile?.mbti ||
     (profile.mbti.length === 4 && MBTI_TYPES.includes(profile.mbti));
 
-  // 이메일 검증: 값이 있을 때만 형식 확인
   const isEmailValid =
     !profile?.notificationEmail ||
     /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(profile.notificationEmail);
 
-  // 생년월일 검증: 입력값이 아예 없거나, 있다면 10자(YYYY-MM-DD)여야 함
-  const isBirthValid = !!profile?.birthDate && profile.birthDate.length === 10;
-
-  // 나이 계산
   const age = profile ? calculateAge(profile.birthDate) : 0;
 
-  // 통합 유효성 검사: 모든 조건이 만족되어야만 버튼이 활성화됨
-  // 닉네임(필수), MBTI(형식 준수), 이메일(형식 준수), 생년월일(필수 및 완성)
+  const isBirthValid = isValidBirthDate(profile?.birthDate);
+
   const isFormValid =
     !!profile?.nickname && isMBTIValid && isEmailValid && isBirthValid;
 
-  // 본인 인증
-  const verify = async (): Promise<void> => {
-    return new Promise((resolve) => {
-      setTimeout(() => {
-        updateProfile({ isVerified: true });
-        resolve();
-      }, 1000);
-    });
+  const verify = async (): Promise<
+    "SUCCESS" | "UNDERAGE" | "NEED_BIRTH_DATE" | "FAIL"
+  > => {
+    if (!profile) return "FAIL";
+
+    if (!profile.birthDate) {
+      return "NEED_BIRTH_DATE";
+    }
+
+    try {
+      const res = await verifyAdult();
+
+      const nextStatus = toAgeStatus(
+        res.data.ageVerificationStatus,
+        deriveAgeVerificationStatus(profile.birthDate, res.data.ageVerified),
+      );
+
+      updateProfile({
+        ageVerified: res.data.ageVerified,
+        ageVerificationStatus: nextStatus,
+      });
+
+      if (nextStatus === "UNDERAGE") {
+        return "UNDERAGE";
+      }
+
+      if (nextStatus === "VERIFIED") {
+        return "SUCCESS";
+      }
+
+      return "FAIL";
+    } catch (error: any) {
+      const code = error?.response?.data?.code;
+
+      if (code === "USER_400_001") {
+        return "NEED_BIRTH_DATE";
+      }
+
+      if (code === "USER_403_003") {
+        updateProfile({
+          ageVerified: false,
+          ageVerificationStatus: "UNDERAGE",
+        });
+        return "UNDERAGE";
+      }
+      return "FAIL";
+    }
   };
 
-  // 계정 탈퇴
   const deleteAccount = async () => {
-    // async 추가
     try {
-      await withdraw(); // 백엔드 API 호출 추가
-
-      // API 호출 성공 후 로컬 데이터 정리
-      localStorage.clear();
+      await withdraw();
+      clearAuth();
       setProfile(null);
-      navigate("/");
       return true;
     } catch (error) {
       console.error("탈퇴 처리 중 오류 발생:", error);
-      alert("회원 탈퇴에 실패했습니다. 다시 시도해주세요.");
-      return false;
+      throw error;
     }
   };
 
   return {
-    // State
     profile,
+    originalProfile,
+    savedAgeStatus: originalProfile?.ageVerificationStatus ?? "UNVERIFIED",
+    savedBirthDate: originalProfile?.birthDate ?? "",
     hasChanges,
     isSaving,
     isFormValid,
@@ -259,8 +422,8 @@ export function useUserProfile() {
     MBTI_TYPES,
     fileInputRef,
     age,
+    travelStyleOptions,
 
-    // Actions
     updateProfile,
     saveProfile,
     handlePhotoChange,

--- a/src/features/user/pages/FaqPage.tsx
+++ b/src/features/user/pages/FaqPage.tsx
@@ -1,0 +1,151 @@
+// src/features/user/pages/FaqPage.tsx
+
+import { ChevronLeft, CircleHelp, MessageCircleQuestion } from "lucide-react";
+import { useLocation, useNavigate } from "react-router-dom";
+import styles from "../styles/UserSetting.module.css";
+
+const FAQ_PREVIEW = [
+  {
+    question: "성인 인증은 어떻게 진행하나요?",
+    answer: "생년월일 등록 후 계정 및 설정 탭에서 인증을 진행할 수 있습니다.",
+  },
+  {
+    question: "회원 탈퇴 시 여행 데이터도 함께 삭제되나요?",
+    answer:
+      "현재는 프로필 정보만 삭제되며, 일부 여행 데이터는 별도로 보관될 수 있습니다.",
+  },
+  {
+    question: "문의는 어디로 하면 되나요?",
+    answer:
+      "카카오톡 1:1 문의를 통해 문의 내용을 남겨주시면 순차적으로 답변드립니다.",
+  },
+];
+
+export default function FaqPage() {
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const handleBack = () => {
+    navigate(location.state?.returnTo ?? "/setting", {
+      replace: true,
+      state: {
+        activeTab: location.state?.activeTab ?? "계정 및 설정",
+        closeTo: location.state?.closeTo ?? "/",
+      },
+    });
+  };
+
+  return (
+    <div className={styles.page}>
+      <div className={styles.ticket}>
+        <div className={styles.header}>
+          <button
+            type="button"
+            className={styles.closeButton}
+            onClick={handleBack}
+            title="뒤로가기"
+          >
+            <ChevronLeft size={24} />
+          </button>
+
+          <div className={styles.headerContent}>
+            <h1 className={styles.title}>FAQ</h1>
+            <p className={styles.desc} style={{ marginTop: "8px" }}>
+              자주 묻는 질문을 한곳에서 빠르게 확인할 수 있도록 준비 중입니다.
+            </p>
+          </div>
+        </div>
+
+        <section className={styles.section}>
+          <div
+            style={{
+              border: "1px solid #e5e7eb",
+              borderRadius: "16px",
+              padding: "24px",
+              background: "#fff",
+              boxShadow: "0 8px 24px rgba(15, 23, 42, 0.04)",
+            }}
+          >
+            <div
+              style={{
+                width: "56px",
+                height: "56px",
+                borderRadius: "50%",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                margin: "0 auto 16px",
+                background: "#f4f7fb",
+              }}
+            >
+              <CircleHelp size={28} />
+            </div>
+
+            <h2
+              style={{
+                textAlign: "center",
+                fontSize: "20px",
+                fontWeight: 700,
+                marginBottom: "10px",
+              }}
+            >
+              FAQ 페이지 준비 중
+            </h2>
+
+            <p
+              style={{
+                textAlign: "center",
+                color: "#6b7280",
+                lineHeight: 1.6,
+                marginBottom: "20px",
+              }}
+            >
+              계정, 인증, 문의, 이용 방법과 관련한 자주 묻는 질문을
+              <br />
+              보기 쉽게 정리해 제공할 예정입니다.
+            </p>
+
+            <div style={{ display: "grid", gap: "12px", marginBottom: "20px" }}>
+              {FAQ_PREVIEW.map((item) => (
+                <div
+                  key={item.question}
+                  style={{
+                    padding: "16px",
+                    borderRadius: "12px",
+                    background: "#f9fafb",
+                  }}
+                >
+                  <div
+                    style={{
+                      display: "flex",
+                      gap: "8px",
+                      alignItems: "center",
+                      fontWeight: 700,
+                      marginBottom: "8px",
+                    }}
+                  >
+                    <MessageCircleQuestion size={18} />
+                    <span>{item.question}</span>
+                  </div>
+                  <p style={{ color: "#6b7280", lineHeight: 1.6 }}>
+                    {item.answer}
+                  </p>
+                </div>
+              ))}
+            </div>
+
+            <div style={{ display: "flex", justifyContent: "center" }}>
+              <button
+                type="button"
+                className={styles.primaryButton}
+                onClick={handleBack}
+              >
+                계정 및 설정으로 돌아가기
+              </button>
+            </div>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/features/user/pages/NoticePage.tsx
+++ b/src/features/user/pages/NoticePage.tsx
@@ -1,0 +1,143 @@
+// src/features/user/pages/NoticePage.tsx
+
+import { Bell, ChevronLeft, Megaphone } from "lucide-react";
+import { useLocation, useNavigate } from "react-router-dom";
+import styles from "../styles/UserSetting.module.css";
+
+export default function NoticePage() {
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const handleBack = () => {
+    navigate(location.state?.returnTo ?? "/setting", {
+      replace: true,
+      state: {
+        activeTab: location.state?.activeTab ?? "계정 및 설정",
+        closeTo: location.state?.closeTo ?? "/",
+      },
+    });
+  };
+
+  return (
+    <div className={styles.page}>
+      <div className={styles.ticket}>
+        <div className={styles.header}>
+          <button
+            type="button"
+            className={styles.closeButton}
+            onClick={handleBack}
+            title="뒤로가기"
+          >
+            <ChevronLeft size={24} />
+          </button>
+
+          <div className={styles.headerContent}>
+            <h1 className={styles.title}>공지사항</h1>
+            <p className={styles.desc} style={{ marginTop: "8px" }}>
+              TripMoa의 서비스 소식과 운영 안내를 확인할 수 있는 공간입니다.
+            </p>
+          </div>
+        </div>
+
+        <section className={styles.section}>
+          <div
+            style={{
+              border: "1px solid #e5e7eb",
+              borderRadius: "16px",
+              padding: "24px",
+              background: "#fff",
+              boxShadow: "0 8px 24px rgba(15, 23, 42, 0.04)",
+            }}
+          >
+            <div
+              style={{
+                width: "56px",
+                height: "56px",
+                borderRadius: "50%",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                margin: "0 auto 16px",
+                background: "#f4f7fb",
+              }}
+            >
+              <Bell size={28} />
+            </div>
+
+            <h2
+              style={{
+                textAlign: "center",
+                fontSize: "20px",
+                fontWeight: 700,
+                marginBottom: "10px",
+              }}
+            >
+              공지사항 페이지 준비 중
+            </h2>
+
+            <p
+              style={{
+                textAlign: "center",
+                color: "#6b7280",
+                lineHeight: 1.6,
+                marginBottom: "20px",
+              }}
+            >
+              현재 TripMoa 공지사항 기능을 정리하고 있습니다.
+              <br />
+              서비스 업데이트, 점검 일정, 주요 변경사항을
+              <br />
+              이곳에서 가장 먼저 안내드릴 예정입니다.
+            </p>
+
+            <div
+              style={{
+                display: "grid",
+                gap: "12px",
+                marginBottom: "20px",
+              }}
+            >
+              <div
+                style={{
+                  display: "flex",
+                  gap: "10px",
+                  alignItems: "center",
+                  padding: "14px 16px",
+                  borderRadius: "12px",
+                  background: "#f9fafb",
+                }}
+              >
+                <Megaphone size={18} />
+                <span>서비스 점검 및 업데이트 안내 제공 예정</span>
+              </div>
+
+              <div
+                style={{
+                  display: "flex",
+                  gap: "10px",
+                  alignItems: "center",
+                  padding: "14px 16px",
+                  borderRadius: "12px",
+                  background: "#f9fafb",
+                }}
+              >
+                <Bell size={18} />
+                <span>주요 기능 변경 및 운영 정책 공지 예정</span>
+              </div>
+            </div>
+
+            <div style={{ display: "flex", justifyContent: "center" }}>
+              <button
+                type="button"
+                className={styles.primaryButton}
+                onClick={handleBack}
+              >
+                계정 및 설정으로 돌아가기
+              </button>
+            </div>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/features/user/pages/UserSetting.tsx
+++ b/src/features/user/pages/UserSetting.tsx
@@ -1,34 +1,72 @@
-import React, { useState } from "react";
-import { useEffect } from "react";
-import {
-  Shield,
-  Camera,
-  X,
-  AlertTriangle,
-  ChevronDown,
-  ChevronUp,
-} from "lucide-react";
-import { useNavigate } from "react-router-dom";
+import { useEffect, useState } from "react";
+import { Shield, X } from "lucide-react";
+import { useLocation, useNavigate } from "react-router-dom";
 import { useUserProfile } from "../hooks/useUserSetting";
-import type { UserProfile } from "../hooks/useUserSetting";
-import { TRAVEL_STYLES, MODAL_MESSAGES } from "../components/User.constant";
+import { MODAL_MESSAGES } from "../hooks/User.constant";
 import styles from "../styles/UserSetting.module.css";
-import { API_BASE_URL } from "../../../shared/config/env";
+
+import MyInfoTab from "../components/MyInfoTab";
+import AccountSettingsTab from "../components/AccountSettingsTab";
+import ReportManagementTab from "../components/ReportManagementTab";
+import VerifyModal from "../components/modal/VerifyModal";
+import DeleteAccountModal from "../components/modal/DeleteAccountModal";
+import { ActionPromptModal } from "../../../shared/components/ActionPromptModal";
+
+const TABS = ["내 정보", "계정 및 설정", "신고 관리"] as const;
+type TabType = (typeof TABS)[number];
 
 export default function UserSettings() {
   const navigate = useNavigate();
-  const [activeTab, setActiveTab] = useState("내 정보");
+  const location = useLocation();
+
+  const initialTab: TabType =
+    location.state?.activeTab === "계정 및 설정" ? "계정 및 설정" : "내 정보";
+
+  const [activeTab, setActiveTab] = useState<TabType>(initialTab);
+  const [showVerifyModal, setShowVerifyModal] = useState(false);
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const [showBirthDateModal, setShowBirthDateModal] = useState(false);
+
+  const [noticeModal, setNoticeModal] = useState<{
+    open: boolean;
+    title: string;
+    headline: string;
+    description: string;
+    onConfirm?: () => void;
+  }>({
+    open: false,
+    title: "",
+    headline: "",
+    description: "",
+  });
+
+  const showNotice = (
+    title: string,
+    headline: string,
+    description: string,
+    onConfirm?: () => void,
+  ) => {
+    setNoticeModal({ open: true, title, headline, description, onConfirm });
+  };
+
+  const closeNotice = () => {
+    const onConfirm = noticeModal.onConfirm;
+    setNoticeModal((prev) => ({ ...prev, open: false, onConfirm: undefined }));
+    onConfirm?.();
+  };
 
   const {
-    profile, // 프로필 데이터
-    updateProfile, // 업데이트 함수
-    hasChanges, // 변경 사항 여부
-    isSaving, // 저장 중 상태
-    isFormValid, // 유효성 검사
-    isEmailValid, // 이메일 유효성 검사
-    isBirthValid, // 생년월일 유효성 검사
-    MBTI_TYPES, // 추천 리스트
-    saveProfile, // 저장 함수
+    profile,
+    updateProfile,
+    savedAgeStatus,
+    savedBirthDate,
+    hasChanges,
+    isSaving,
+    isFormValid,
+    isEmailValid,
+    isBirthValid,
+    MBTI_TYPES,
+    saveProfile,
     regenerateAvatar,
     triggerPhotoUpload,
     toggleTravelStyle,
@@ -36,89 +74,114 @@ export default function UserSettings() {
     deleteAccount,
     fileInputRef,
     handlePhotoChange,
+    travelStyleOptions,
+    calculateAge,
   } = useUserProfile();
 
-  // 추천 목록 표시 여부 상태
-  const [showSuggestions, setShowSuggestions] = useState(false);
+  useEffect(() => {
+    if (location.state?.activeTab === "계정 및 설정") {
+      setActiveTab("계정 및 설정");
+      navigate(location.pathname, {
+        replace: true,
+        state: {
+          closeTo: location.state?.closeTo,
+        },
+      });
+    }
+  }, [location.state, location.pathname, navigate]);
 
-  // 입력값 필터링 (영어만 허용 및 대문자 변환)
-  const handleMBTIChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = e.target.value.replace(/[^A-Za-z]/g, "").toUpperCase();
-    updateProfile({ mbti: value });
-    setShowSuggestions(true);
-  };
-
-  const filteredMBTI = profile
-    ? MBTI_TYPES.filter((type) => type.startsWith(profile.mbti))
-    : [];
-
-  // 새로고침 경고문
   useEffect(() => {
     const handleBeforeUnload = (e: BeforeUnloadEvent) => {
-      if (hasChanges) {
-        e.preventDefault();
-        e.returnValue =
-          "저장하지 않은 변경사항이 있습니다. 정말 나가시겠습니까?";
-      }
+      if (!hasChanges) return;
+
+      e.preventDefault();
+      e.returnValue = "저장하지 않은 변경사항이 있습니다. 정말 나가시겠습니까?";
     };
 
     window.addEventListener("beforeunload", handleBeforeUnload);
-
     return () => {
       window.removeEventListener("beforeunload", handleBeforeUnload);
     };
   }, [hasChanges]);
 
-  const [showVerifyModal, setShowVerifyModal] = useState(false);
-  const [showDeleteModal, setShowDeleteModal] = useState(false);
-
-  // 토글 상태
-  const [openSections, setOpenSections] = useState({
-    social: false, // 소셜 관리 섹션 초기 상태
-    notifications: false, // 알림 설정 섹션 초기 상태
-  });
-
-  // 섹션 토글 함수
-  const toggleSection = (section: "social" | "notifications") => {
-    setOpenSections((prev) => ({ ...prev, [section]: !prev[section] }));
-  };
-
-  // 저장 핸들러
   const handleSave = async () => {
     if (!profile) return;
 
     const willBeLocked: string[] = [];
     if (!profile.nameLocked && profile.name) willBeLocked.push("이름");
     if (!profile.genderLocked && profile.gender) willBeLocked.push("성별");
-    if (!profile.birthLocked && profile.birthDate)
+    if (!profile.birthLocked && profile.birthDate) {
       willBeLocked.push("생년월일");
+    }
 
     if (willBeLocked.length > 0) {
       const confirmMessage = `${willBeLocked.join(
         ", ",
       )} 정보는 저장 후 수정이 불가능합니다.\n정말 저장하시겠습니까?`;
+
       if (!window.confirm(confirmMessage)) return;
     }
 
     const success = await saveProfile();
     if (success) {
-      alert(MODAL_MESSAGES.SAVE.SUCCESS);
+      showNotice(
+        "저장 완료",
+        "변경사항이 저장되었습니다",
+        MODAL_MESSAGES.SAVE.SUCCESS,
+      );
+    } else {
+      showNotice(
+        "저장 실패",
+        "저장에 실패했습니다",
+        "저장에 실패했습니다. 다시 시도해주세요.",
+      );
     }
   };
 
-  // 본인 인증 핸들러
   const handleVerify = async () => {
-    await verify();
-    setShowVerifyModal(false);
-    alert(MODAL_MESSAGES.VERIFY.SUCCESS);
+    if (!profile) return;
+
+    const result = await verify();
+
+    if (result === "NEED_BIRTH_DATE") {
+      setShowVerifyModal(false);
+      setShowBirthDateModal(true);
+      return;
+    }
+
+    if (result === "UNDERAGE") {
+      setShowVerifyModal(false);
+      showNotice(
+        "이용 불가",
+        "이용 연령 제한",
+        "만 19세 미만은 서비스를 이용할 수 없습니다.",
+      );
+      return;
+    }
+
+    if (result === "SUCCESS") {
+      setShowVerifyModal(false);
+      showNotice(
+        "인증 완료",
+        "성인 인증이 완료되었습니다",
+        MODAL_MESSAGES.VERIFY.SUCCESS,
+      );
+      return;
+    }
+
+    if (result === "FAIL") {
+      setShowVerifyModal(false);
+      showNotice(
+        "인증 실패",
+        "성인 인증에 실패했습니다",
+        "성인 인증 처리에 실패했습니다. 다시 시도해주세요.",
+      );
+    }
   };
 
-  // 계정 탈퇴 핸들러
   const handleDeleteAccount = async () => {
     try {
       await deleteAccount();
-
-      alert(MODAL_MESSAGES.DELETE.SUCCESS);
       setShowDeleteModal(false);
       navigate("/login", { replace: true });
     } catch (error: any) {
@@ -126,11 +189,10 @@ export default function UserSettings() {
         error?.response?.data?.message ||
         "회원 탈퇴에 실패했습니다. 잠시 후 다시 시도해주세요.";
 
-      alert(message);
+      showNotice("탈퇴 실패", "회원 탈퇴에 실패했습니다", message);
     }
   };
 
-  // X 버튼 경고문
   const handleClose = () => {
     if (hasChanges) {
       const confirmLeave = window.confirm(
@@ -139,8 +201,9 @@ export default function UserSettings() {
       if (!confirmLeave) return;
     }
 
-    navigate(-1);
+    navigate(location.state?.closeTo ?? "/", { replace: true });
   };
+
   if (!profile) {
     return (
       <div className={styles.page}>
@@ -153,44 +216,45 @@ export default function UserSettings() {
     );
   }
 
-  const SOCIAL_MAP = {
-    KAKAO: { class: styles.kakao, label: "K", name: "카카오 계정" },
-    GOOGLE: { class: styles.google, label: "G", name: "구글 계정" },
-    NAVER: { class: styles.naver, label: "N", name: "네이버 계정" },
-  };
-
-  const providerKey = (profile.provider as keyof typeof SOCIAL_MAP) || "KAKAO";
-  const currentSocial = SOCIAL_MAP[providerKey];
+  const isUnderage =
+    savedAgeStatus === "UNDERAGE" ||
+    (savedAgeStatus === "UNVERIFIED" &&
+      !!savedBirthDate &&
+      calculateAge(savedBirthDate) < 19);
 
   return (
     <div className={styles.page}>
       <div className={styles.ticket}>
-        {/* Header */}
         <div className={styles.header}>
-          {/* 왼쪽 : 인증 완료 */}
-          {profile.isVerified && (
+          {savedAgeStatus === "VERIFIED" && (
             <div className={styles.verifiedBadge}>
               <Shield size={14} />
               <span>인증 완료</span>
             </div>
           )}
-          {/* 오른쪽 : X 버튼 */}
+
+          {isUnderage && (
+            <div className={styles.restrictedBadge}>
+              <Shield size={14} />
+              <span>이용 제한</span>
+            </div>
+          )}
           <button
             className={styles.closeButton}
             onClick={handleClose}
             title="닫기"
+            type="button"
           >
             <X size={24} />
           </button>
-
           <div className={styles.headerContent}>
             <h1 className={styles.title}>MY PAGE</h1>
 
-            {/* 탭 메뉴 구성 */}
             <div className={styles.tabContainer}>
-              {["내 정보", "계정 및 설정", "신고 관리"].map((tab) => (
+              {TABS.map((tab) => (
                 <button
                   key={tab}
+                  type="button"
                   className={`${styles.tabItem} ${
                     activeTab === tab ? styles.activeTab : ""
                   }`}
@@ -203,545 +267,25 @@ export default function UserSettings() {
           </div>
         </div>
 
-        {/* 내 정보 섹션 */}
         {activeTab === "내 정보" && (
-          <>
-            <section className={styles.section}>
-              {/* 프로필 섹션 */}
-              <h2 className={styles.sectionTitle}>프로필 정보</h2>
-
-              <div className={styles.profileRow}>
-                <div
-                  className={styles.avatar}
-                  onClick={regenerateAvatar}
-                  title="클릭 시 랜덤 아바타 변경"
-                  style={{
-                    background: profile.profileImage
-                      ? "transparent"
-                      : profile.avatarColor,
-                  }}
-                >
-                  {profile.profileImage ? (
-                    <img src={profile.profileImage} alt="Profile" />
-                  ) : (
-                    <span className={styles.avatarEmoji}>
-                      {profile.avatarEmoji}
-                    </span>
-                  )}
-                  <div className={styles.avatarOverlay}>
-                    <Camera size={20} />
-                  </div>
-                </div>
-
-                <div className={styles.avatarInfo}>
-                  <p className={styles.avatarDesc}>
-                    동그란 프로필을 클릭하면 랜덤 아바타로 바뀝니다.
-                  </p>
-                  <button
-                    className={styles.secondaryButton}
-                    onClick={triggerPhotoUpload}
-                  >
-                    대표 사진 업로드
-                  </button>
-                  <input
-                    ref={fileInputRef}
-                    type="file"
-                    accept="image/*"
-                    style={{ display: "none" }}
-                    onChange={handlePhotoChange}
-                  />
-                </div>
-              </div>
-
-              <div className={styles.grid}>
-                {/* 닉네임 섹션 */}
-                <div className={styles.field}>
-                  <label className={styles.label}>
-                    닉네임<span className={styles.required}>*</span>
-                  </label>
-                  <input
-                    className={`${styles.input} ${
-                      !profile.nickname ? styles.inputError : ""
-                    }`}
-                    value={profile.nickname || ""}
-                    placeholder="닉네임은 필수 입력 항목입니다."
-                    onChange={(e) =>
-                      updateProfile({ nickname: e.target.value })
-                    }
-                  />
-                  {/* 데이터가 없거나 지웠을 때만 표시 */}
-                  {!profile.nickname && (
-                    <span className={styles.errorText}>
-                      닉네임은 필수 입력 사항입니다.
-                    </span>
-                  )}
-                </div>
-
-                {/* 이름: 소셜 데이터 기반 잠금 */}
-                <div className={styles.field}>
-                  <label className={styles.label}>이름</label>
-                  <input
-                    className={`${styles.input} ${
-                      profile.nameLocked ? styles.inputLocked : ""
-                    }`}
-                    value={profile.name || ""}
-                    readOnly={profile.nameLocked}
-                    onChange={(e) => updateProfile({ name: e.target.value })}
-                  />
-                </div>
-
-                {/* 알림 수신 이메일 */}
-                <div className={styles.field}>
-                  <label className={styles.label}>알림 수신 이메일</label>
-                  <input
-                    className={`${styles.input} ${
-                      profile.notificationEmail && !isEmailValid
-                        ? styles.inputError
-                        : ""
-                    }`}
-                    placeholder="example@email.com"
-                    value={profile.notificationEmail || ""}
-                    onChange={(e) =>
-                      updateProfile({ notificationEmail: e.target.value })
-                    }
-                  />
-                  {/* 이메일 형식이 틀렸을 때만 표시 */}
-                  {profile.notificationEmail && !isEmailValid && (
-                    <span className={styles.errorText}>
-                      올바른 이메일 형식을 입력해주세요.
-                    </span>
-                  )}
-                </div>
-
-                {/* 성별: 잠금 */}
-                <div className={styles.field}>
-                  <label className={styles.label}>성별</label>
-                  <input
-                    className={`${styles.input} ${
-                      profile.genderLocked ? styles.inputLocked : ""
-                    }`}
-                    value={profile.gender || ""}
-                    readOnly={profile.genderLocked}
-                    placeholder="예 : 남 / 여"
-                    onChange={(e) => updateProfile({ gender: e.target.value })}
-                  />
-                </div>
-
-                {/* 생년월일: 잠금 */}
-                <div className={styles.field}>
-                  <label className={styles.label}>
-                    생년월일<span className={styles.required}>*</span>
-                  </label>
-                  <input
-                    type="date"
-                    className={`${styles.input} ${
-                      profile.birthLocked ? styles.inputLocked : ""
-                    } ${!isBirthValid ? styles.inputError : ""}`} // 형식이 안 맞거나 비어있으면 에러 스타일
-                    value={profile.birthDate || ""}
-                    readOnly={profile.birthLocked}
-                    onChange={(e) =>
-                      updateProfile({ birthDate: e.target.value })
-                    }
-                  />
-                  {/* 날짜가 비어있거나 불완전할 때만 표시 */}
-                  {!isBirthValid && (
-                    <span className={styles.errorText}>
-                      {profile.birthDate
-                        ? "날짜를 끝까지 선택해주세요."
-                        : "생년월일은 필수 입력 사항입니다."}
-                    </span>
-                  )}
-                </div>
-
-                {/* MBTI: 수정 가능 */}
-                <div className={styles.field}>
-                  <label className={styles.label}>MBTI</label>
-                  <div className={styles.autocompleteWrapper}>
-                    <input
-                      className={`${styles.input} ${
-                        profile.mbti &&
-                        !MBTI_TYPES.includes(profile.mbti) &&
-                        profile.mbti.length === 4
-                          ? styles.inputError
-                          : ""
-                      }`}
-                      style={{ width: "100%" }}
-                      value={profile.mbti || ""}
-                      onChange={handleMBTIChange}
-                      onFocus={() => setShowSuggestions(true)}
-                      onBlur={() =>
-                        setTimeout(() => setShowSuggestions(false), 200)
-                      }
-                      placeholder="예: ENFP"
-                      maxLength={4}
-                    />
-
-                    {showSuggestions &&
-                      filteredMBTI.length > 0 &&
-                      profile.mbti && (
-                        <ul className={styles.suggestionList}>
-                          {filteredMBTI.map((type) => (
-                            <li
-                              key={type}
-                              className={styles.suggestionItem}
-                              onMouseDown={() => updateProfile({ mbti: type })}
-                            >
-                              <span className={styles.clockIcon}>👉</span>
-                              {type}
-                            </li>
-                          ))}
-                        </ul>
-                      )}
-                  </div>
-
-                  {/* 잘못된 MBTI 입력 시 경고 */}
-                  {profile.mbti &&
-                    !MBTI_TYPES.includes(profile.mbti) &&
-                    profile.mbti.length === 4 && (
-                      <span className={styles.errorText}>
-                        유효하지 않은 MBTI 유형입니다.
-                      </span>
-                    )}
-                </div>
-              </div>
-
-              {/* 여행 스타일 */}
-              <div className={styles.travelStyleSection}>
-                <label className={styles.label}>여행 스타일</label>
-                <p className={styles.desc}>
-                  관심있는 여행 스타일을 선택해주세요 (복수 선택 가능)
-                </p>
-                <div className={styles.travelStyleGrid}>
-                  {TRAVEL_STYLES.map((style) => (
-                    <button
-                      key={style}
-                      className={`${styles.travelStyleBtn} ${
-                        profile.travelStyles?.includes(style)
-                          ? styles.active
-                          : ""
-                      }`}
-                      onClick={() => toggleTravelStyle(style)}
-                      type="button"
-                    >
-                      {style}
-                    </button>
-                  ))}
-                </div>
-              </div>
-            </section>
-          </>
+          <MyInfoTab
+            profile={profile}
+            updateProfile={updateProfile}
+            isEmailValid={isEmailValid}
+            isBirthValid={isBirthValid}
+            MBTI_TYPES={MBTI_TYPES}
+            regenerateAvatar={regenerateAvatar}
+            triggerPhotoUpload={triggerPhotoUpload}
+            toggleTravelStyle={toggleTravelStyle}
+            fileInputRef={fileInputRef}
+            handlePhotoChange={handlePhotoChange}
+            travelStyleOptions={travelStyleOptions}
+          />
         )}
 
-        {/* 계정 및 설정 섹션 */}
-        {activeTab === "계정 및 설정" && (
-          <div className={styles.settingsWrapper}>
-            {/* 계정 관리 (아코디언) */}
-            <section className={styles.section}>
-              <div
-                className={styles.accordionHeader}
-                onClick={() => toggleSection("social")}
-              >
-                <h2 className={styles.sectionTitle}>계정 관리</h2>
-                {openSections.social ? (
-                  <ChevronUp size={20} />
-                ) : (
-                  <ChevronDown size={20} />
-                )}
-              </div>
-
-              {openSections.social && (
-                <div className={styles.accordionContent}>
-                  <div className={styles.socialStatusCard}>
-                    {/* 계정 관리 내부 소셜 정보 부분 */}
-                    <div className={styles.socialItem}>
-                      <div className={styles.socialInfo}>
-                        <span
-                          className={`${styles.socialIcon} ${currentSocial.class}`}
-                        >
-                          {currentSocial.label}
-                        </span>
-                        <div className={styles.socialText}>
-                          <p className={styles.socialName}>
-                            {currentSocial.name}
-                          </p>
-                          <p className={styles.socialDetail}>
-                            {profile.email || "연결된 이메일 정보가 없습니다."}
-                          </p>
-                        </div>
-                      </div>
-                      <span
-                        className={`${styles.connectionBadge} ${
-                          !profile.email ? styles.notConnected : ""
-                        }`}
-                      >
-                        {profile.email ? "연결됨" : "연결 안 됨"}
-                      </span>
-                    </div>
-
-                    {/* 개인정보 설정 부분 */}
-                    <div className={styles.privacyToggleArea}>
-                      {[
-                        { id: "isPrivateName", label: "이름 공개여부" },
-                        { id: "isPrivateAge", label: "나이 공개여부" },
-                        { id: "isPrivateGender", label: "성별 공개여부" },
-                      ].map((item) => (
-                        <div key={item.id} className={styles.toggleRow}>
-                          <span>{item.label}</span>
-                          <label className={styles.switch}>
-                            <input
-                              type="checkbox"
-                              checked={profile[item.id as keyof UserProfile]}
-                              onChange={(e) =>
-                                updateProfile({ [item.id]: e.target.checked })
-                              }
-                            />
-                            <span className={styles.slider}></span>
-                          </label>
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                </div>
-              )}
-            </section>
-
-            {/* 알림 설정 (아코디언) */}
-            <section className={styles.section}>
-              <div
-                className={styles.accordionHeader}
-                onClick={() => toggleSection("notifications")}
-              >
-                <h2 className={styles.sectionTitle}>알림 설정</h2>
-                {openSections.notifications ? (
-                  <ChevronUp size={20} />
-                ) : (
-                  <ChevronDown size={20} />
-                )}
-              </div>
-
-              {openSections.notifications && (
-                <div className={styles.accordionContent}>
-                  <div className={styles.settingList}>
-                    {[
-                      {
-                        id: "tripAlert",
-                        label: "여행 일정 및 초대 알림",
-                        desc: "새로운 팀원 초대 및 일정 변경 알림",
-                      },
-                      {
-                        id: "marketingAgreed",
-                        label: "마케팅 정보 수신 동의",
-                        desc: "이벤트 및 혜택 정보 안내",
-                      },
-                      {
-                        id: "emailAgreed",
-                        label: "이메일 수신 동의",
-                        desc: "주요 공지 및 업데이트 리포트",
-                      },
-                    ].map((item) => (
-                      <div key={item.id} className={styles.settingItem}>
-                        <div className={styles.settingText}>
-                          <p className={styles.settingLabel}>{item.label}</p>
-                          <p className={styles.settingDesc}>{item.desc}</p>
-                        </div>
-                        <label className={styles.switch}>
-                          <input
-                            type="checkbox"
-                            checked={profile[item.id]}
-                            onChange={(e) =>
-                              updateProfile({ [item.id]: e.target.checked })
-                            }
-                          />
-                          <span className={styles.slider}></span>
-                        </label>
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              )}
-            </section>
-
-            {/* 본인 인증 및 서비스 이용 확인 */}
-            <section className={styles.section}>
-              <h2 className={styles.sectionTitle}>서비스 이용 인증</h2>
-              <div className={styles.adultVerifyBox}>
-                <p className={styles.verifyTitle}>🔞 만 19세 이상 이용 안내</p>
-                <p className={styles.verifyDesc}>
-                  트립모아는 안전한 동행 및 여행 계획 공유를 위해{" "}
-                  <strong>성인 전용</strong>으로 운영됩니다.
-                </p>
-                <div className={styles.confirmCheckboxArea}>
-                  <label className={styles.checkboxContainer}>
-                    <input
-                      type="checkbox"
-                      checked={profile.isAdultConfirmed}
-                      disabled={profile.isAdultConfirmed}
-                      onChange={(e) =>
-                        updateProfile({ isAdultConfirmed: e.target.checked })
-                      }
-                    />
-                    <span className={styles.checkmark}></span>
-                    <span className={styles.checkboxLabel}>
-                      본인은 만 19세 이상임을 확인합니다.
-                    </span>
-                  </label>
-                </div>
-                <p className={styles.legalWarning}>
-                  * 허위 정보 입력 시 서비스 이용 제한 및 법적 책임은 사용자
-                  본인에게 있습니다.
-                </p>
-              </div>
-
-              <p className={styles.desc} style={{ marginTop: 20 }}>
-                {profile.isVerified
-                  ? "✅ 본인 인증이 완료되었습니다."
-                  : "커뮤니티 이용을 위해 본인 인증이 필요합니다."}
-              </p>
-              <button
-                className={styles.primaryButton}
-                onClick={() => setShowVerifyModal(true)}
-                disabled={profile.isVerified || !isFormValid}
-              >
-                {profile.isVerified ? "인증 완료" : "본인 인증하기"}
-              </button>
-            </section>
-
-            {/* 고객 지원 섹션 */}
-            <section className={styles.section}>
-              <h2 className={styles.sectionTitle}>고객 지원</h2>
-              <div className={styles.supportGrid}>
-                {/* 아직 페이지가 없으므로 알림창으로 대체합니다 */}
-                <button
-                  className={styles.supportBtn}
-                  onClick={() => alert("공지사항 기능은 현재 준비 중입니다.")}
-                >
-                  공지사항
-                </button>
-                <button
-                  className={styles.supportBtn}
-                  onClick={() => alert("FAQ 기능은 현재 준비 중입니다.")}
-                >
-                  FAQ
-                </button>
-                <button
-                  className={styles.supportBtnPrimary}
-                  onClick={() =>
-                    window.open("http://pf.kakao.com/_내채널ID/chat", "_blank")
-                  }
-                >
-                  카카오톡 1:1 문의
-                </button>
-              </div>
-            </section>
-
-            {/* 회원 탈퇴 */}
-            <section className={`${styles.section} ${styles.danger}`}>
-              <h2 className={styles.sectionTitle}>회원 탈퇴</h2>
-              <p className={styles.desc}>
-                탈퇴 시 프로필 정보만 삭제되며 여행 데이터는 삭제되지 않습니다.
-              </p>
-              <button
-                className={styles.dangerButton}
-                onClick={() => setShowDeleteModal(true)}
-              >
-                회원 탈퇴하기
-              </button>
-            </section>
-          </div>
-        )}
-
-        {/* 신고 관리 섹션  */}
-        {activeTab === "신고 관리" && (
-          <>
-            {/* 나의 신고 현황 */}
-            <section className={styles.section}>
-              <h2 className={styles.sectionTitle}>나의 신고 현황</h2>
-              <div className={styles.reportSummary}>
-                <div className={styles.statusBox}>
-                  <span className={styles.statusLabel}>현재 제재 단계</span>
-                  <span className={styles.statusValue}>1단계 (주의)</span>
-                </div>
-                <div className={styles.statusBox}>
-                  <span className={styles.statusLabel}>누적 신고 횟수</span>
-                  <span className={styles.statusValue}>2회</span>
-                </div>
-              </div>
-
-              <table className={styles.reportTable}>
-                <thead>
-                  <tr>
-                    <th>위치</th>
-                    <th>사유</th>
-                    <th>날짜</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr>
-                    <td>댓글</td>
-                    <td>욕설 및 비방</td>
-                    <td>2026.01.05</td>
-                  </tr>
-                  <tr>
-                    <td>채팅</td>
-                    <td>도배</td>
-                    <td>2025.12.30</td>
-                  </tr>
-                </tbody>
-              </table>
-            </section>
-
-            {/* 제재 단계 안내 및 강조 문구 */}
-            <section className={styles.section}>
-              <h2 className={styles.sectionTitle}>신고 및 제재 안내</h2>
-              <div className={styles.guideCard}>
-                <ul className={styles.guideList}>
-                  <li>
-                    <strong>1단계:</strong> 신고자 본인 화면에서 메시지 숨김
-                  </li>
-                  <li>
-                    <strong>2단계:</strong> 전체 화면에서 "신고된 메시지"로 치환
-                  </li>
-                  <li>
-                    <strong>3단계:</strong> 서비스 로그인 시 경고 팝업 노출
-                  </li>
-                  <li>
-                    <strong>4단계:</strong> 계정 상태 '정지' 처리 및 접속 차단
-                  </li>
-                </ul>
-
-                {/* 사용자 강조 문구 */}
-                <div className={styles.importantNote}>
-                  <p className={styles.noteTitle}>
-                    ⚠️ 여행 계획(Trip) 관련 중요 공지
-                  </p>
-                  <p className={styles.noteText}>
-                    여행 계획 내에서 신고가 누적될 경우,{" "}
-                    <strong>해당 계획에서 즉시 강제 퇴출</strong>당합니다.
-                    작성하신 내용은 팀원들을 위해 <strong>'작성자 미상'</strong>
-                    으로 유지되며, 퇴출 사실은 팀원들에게 즉시 통보됩니다.
-                  </p>
-                </div>
-              </div>
-            </section>
-
-            {/* 이의 제기 버튼 */}
-            <section className={styles.section}>
-              <button
-                className={styles.secondaryButton}
-                style={{ width: "100%" }}
-                onClick={() =>
-                  window.open("http://pf.kakao.com/_내채널ID/chat", "_blank")
-                }
-              >
-                신고 관련 이의 제기하기
-              </button>
-            </section>
-          </>
-        )}
-
-        {/* 저장 버튼 */}
-        {hasChanges && (
+        {activeTab === "내 정보" && hasChanges && (
           <button
+            type="button"
             className={`${styles.saveButton} ${isSaving ? styles.saving : ""}`}
             onClick={handleSave}
             disabled={!isFormValid || isSaving}
@@ -749,100 +293,54 @@ export default function UserSettings() {
             {isSaving ? "저장 중..." : "변경사항 저장"}
           </button>
         )}
+
+        {activeTab === "계정 및 설정" && (
+          <AccountSettingsTab
+            profile={profile}
+            onOpenVerifyModal={() => setShowVerifyModal(true)}
+            onOpenBirthDateModal={() => setShowBirthDateModal(true)}
+            onOpenDeleteModal={() => setShowDeleteModal(true)}
+          />
+        )}
+
+        {activeTab === "신고 관리" && <ReportManagementTab />}
       </div>
 
-      {/* 본인 인증 Model */}
-      {showVerifyModal && (
-        <div
-          className={styles.modalOverlay}
-          onClick={() => setShowVerifyModal(false)}
-        >
-          <div
-            className={styles.modalContent}
-            onClick={(e) => e.stopPropagation()}
-          >
-            <button
-              className={styles.modalCloseBtn}
-              onClick={() => setShowVerifyModal(false)}
-            >
-              <X size={20} />
-            </button>
-            <div className={styles.modalIcon}>
-              <Shield size={48} />
-            </div>
-            <h2 className={styles.modalTitle}>{MODAL_MESSAGES.VERIFY.TITLE}</h2>
-            <p className={styles.modalText}>
-              {MODAL_MESSAGES.VERIFY.DESCRIPTION.split("\n").map((line, i) => (
-                <React.Fragment key={i}>
-                  {line}
-                  {i <
-                    MODAL_MESSAGES.VERIFY.DESCRIPTION.split("\n").length -
-                      1 && <br />}
-                </React.Fragment>
-              ))}
-            </p>
-            <div className={styles.modalButtons}>
-              <button
-                className={styles.modalCancelBtn}
-                onClick={() => setShowVerifyModal(false)}
-              >
-                취소
-              </button>
-              <button className={styles.modalConfirmBtn} onClick={handleVerify}>
-                {MODAL_MESSAGES.VERIFY.BUTTON}
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
+      <VerifyModal
+        open={showVerifyModal}
+        onClose={() => setShowVerifyModal(false)}
+        onConfirm={handleVerify}
+      />
 
-      {/* 탈퇴 Model */}
-      {showDeleteModal && (
-        <div
-          className={styles.modalOverlay}
-          onClick={() => setShowDeleteModal(false)}
-        >
-          <div
-            className={styles.modalContent}
-            onClick={(e) => e.stopPropagation()}
-          >
-            <button
-              className={styles.modalCloseBtn}
-              onClick={() => setShowDeleteModal(false)}
-            >
-              <X size={20} />
-            </button>
-            <div className={`${styles.modalIcon} ${styles.danger}`}>
-              <AlertTriangle size={48} />
-            </div>
-            <h2 className={styles.modalTitle}>{MODAL_MESSAGES.DELETE.TITLE}</h2>
-            <p className={styles.modalText}>
-              {MODAL_MESSAGES.DELETE.DESCRIPTION.split("\n").map((line, i) => (
-                <React.Fragment key={i}>
-                  {i === 1 ? <strong>{line}</strong> : line}
-                  {i <
-                    MODAL_MESSAGES.DELETE.DESCRIPTION.split("\n").length -
-                      1 && <br />}
-                </React.Fragment>
-              ))}
-            </p>
-            <div className={styles.modalButtons}>
-              <button
-                className={styles.modalCancelBtn}
-                onClick={() => setShowDeleteModal(false)}
-              >
-                취소
-              </button>
-              <button
-                className={styles.modalDangerBtn}
-                onClick={handleDeleteAccount}
-              >
-                {MODAL_MESSAGES.DELETE.BUTTON}
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
+      <DeleteAccountModal
+        open={showDeleteModal}
+        onClose={() => setShowDeleteModal(false)}
+        onConfirm={handleDeleteAccount}
+      />
+
+      <ActionPromptModal
+        open={showBirthDateModal}
+        title="생년월일 입력 필요"
+        headline="생년월일을 먼저 입력해주세요"
+        description="성인 인증을 위해 프로필에 생년월일을 먼저 등록해야 합니다."
+        cancelText="취소"
+        confirmText="내 정보"
+        onClose={() => setShowBirthDateModal(false)}
+        onConfirm={() => {
+          setShowBirthDateModal(false);
+          setActiveTab("내 정보");
+        }}
+      />
+
+      <ActionPromptModal
+        open={noticeModal.open}
+        title={noticeModal.title}
+        headline={noticeModal.headline}
+        description={noticeModal.description}
+        confirmText="확인"
+        onClose={closeNotice}
+        onConfirm={closeNotice}
+      />
     </div>
   );
 }

--- a/src/features/user/pages/index.ts
+++ b/src/features/user/pages/index.ts
@@ -1,4 +1,9 @@
+// src/features/user/pages/index.ts
+
 export { default as Login } from "./Login";
 export { default as UserSetting } from "./UserSetting";
 export { default as OAuthSuccess } from "./OAuthSuccess";
 export { default as ProtectedRoute } from "./ProtectedRoute";
+export { default as NoticePage } from "./NoticePage";
+export { default as FaqPage } from "./FaqPage";
+export { AuthProvider, useAuth } from "./AuthContext";

--- a/src/features/user/styles/Login.module.css
+++ b/src/features/user/styles/Login.module.css
@@ -115,6 +115,78 @@
   z-index: 1;
 }
 
+/* 정지 안내 전체 박스 */
+.suspendedBox {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  padding: 24px;
+  text-align: center;
+}
+
+/* 제목 */
+.suspendedBox h2 {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin-bottom: 12px;
+}
+
+/* 설명 문구 */
+.suspendedBox p {
+  font-size: 0.9rem;
+  color: #555;
+  margin-bottom: 8px;
+  line-height: 1.5;
+}
+
+/* 이메일 박스 */
+.emailBox {
+  margin: 16px 0;
+  padding: 10px 14px;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  font-family: monospace;
+  font-size: 0.85rem;
+  background-color: #f9f9f9;
+  color: #222;
+}
+
+/* 공통 버튼 스타일 */
+.suspendedBox button {
+  width: 100%;
+  max-width: 280px;
+  padding: 10px 0;
+  margin-top: 8px;
+  border-radius: 6px;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+/* 이메일 복사 버튼 */
+.suspendedBox button:first-of-type {
+  background-color: #222;
+  color: #fff;
+  border: none;
+}
+
+.suspendedBox button:first-of-type:hover {
+  background-color: #444;
+}
+
+/* 돌아가기 버튼 */
+.suspendedBox button:last-of-type {
+  background-color: transparent;
+  color: #555;
+  border: 1px solid #ccc;
+}
+
+.suspendedBox button:last-of-type:hover {
+  background-color: #f2f2f2;
+}
+
 /* 뭉실뭉실 구름 1 */
 .cloud1 {
   position: absolute;

--- a/src/features/user/styles/UserSetting.module.css
+++ b/src/features/user/styles/UserSetting.module.css
@@ -82,6 +82,21 @@
   font-weight: 700;
 }
 
+.restrictedBadge {
+  position: absolute;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 10px;
+  padding: 6px 12px;
+  background: #fdecea;
+  border: 2px solid #c62828;
+  border-radius: 20px;
+  color: #c62828;
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
 /* === Tabs === */
 .tabContainer {
   display: flex;
@@ -276,9 +291,22 @@
   background-color: #fff9f9 !important;
 }
 
+.inputRequired {
+  border: 1px solid #f59e0b;
+  background-color: #fffaf0;
+}
+
 .errorText {
   font-size: 0.7rem;
   color: #d32f2f;
+  margin-top: 4px;
+  font-weight: 700;
+  font-family: monospace;
+}
+
+.requiredText {
+  font-size: 0.7rem;
+  color: #f59e0b;
   margin-top: 4px;
   font-weight: 700;
   font-family: monospace;
@@ -350,15 +378,19 @@
 }
 
 .travelStyleBtn {
-  padding: 0.7rem 1rem;
-  border: 2px solid black;
-  background: white;
-  font-family: monospace;
-  font-weight: 700;
-  font-size: 0.85rem;
-  cursor: pointer;
-  transition: all 0.2s;
+  min-height: 40px;
+  padding: 8px 12px;
+  border: 2px solid #111;
+  background: #fff;
+  color: #111;
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.2;
   text-align: center;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  cursor: pointer;
 }
 
 .travelStyleBtn:hover {
@@ -377,23 +409,20 @@
 /* === Buttons === */
 .primaryButton {
   width: 100%;
-  padding: 1rem;
+  padding: 0.8rem 1rem;
   background: black;
   color: white;
-  font-size: 0.95rem;
+  font-size: 0.9rem;
   font-weight: 700;
   border: 3px solid black;
   cursor: pointer;
   transition: all 0.2s;
   font-family: monospace;
-  letter-spacing: 1px;
 }
 
 .primaryButton:hover:not(:disabled) {
   background: #fbbf24;
   color: black;
-  transform: translate(-3px, -3px);
-  box-shadow: 5px 5px 0 0 black;
 }
 
 .primaryButton:disabled {
@@ -404,7 +433,7 @@
 }
 
 .secondaryButton {
-  padding: 0.7rem 1rem;
+  padding: 0.8rem 1rem;
   font-size: 0.85rem;
   font-weight: 700;
   border: 2px solid black;
@@ -418,7 +447,6 @@
   background: black;
   color: white;
   transform: translate(-2px, -2px);
-  box-shadow: 3px 3px 0 0 black;
 }
 
 .saveButton {
@@ -478,6 +506,22 @@
 .accordionContent {
   margin-top: 1rem;
   animation: slideDown 0.3s ease-out;
+}
+
+.accountBlock {
+  margin-bottom: 1rem;
+}
+
+.subTitle {
+  font-size: 0.9rem;
+  font-weight: 800;
+  margin: 0 0 0.75rem 0;
+}
+
+.linkedAccounts {
+  margin-top: 0.75rem;
+  border-top: 1px solid #eee;
+  padding-top: 0.75rem;
 }
 
 @keyframes slideDown {
@@ -655,29 +699,28 @@
 .adultVerifyBox {
   background: #fff0f0;
   border: 2px solid black;
-  padding: 1.5rem;
+  padding: 1.25rem 1.4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
 }
 
 .verifyTitle {
   font-weight: 900;
-  margin-bottom: 0.5rem;
+  margin: 0;
   color: #d32f2f;
 }
 
 .verifyDesc {
   font-size: 0.85rem;
   line-height: 1.5;
-  margin-bottom: 1rem;
-}
-
-.confirmCheckboxArea {
-  margin-top: 0.8rem;
+  margin: 0;
 }
 
 .legalWarning {
   font-size: 0.75rem;
   color: #666;
-  margin-top: 1rem;
+  margin: 0 0 0.2rem 0;
   font-style: italic;
 }
 
@@ -739,7 +782,8 @@
 
 .supportBtn,
 .supportBtnPrimary {
-  padding: 0.8rem;
+  padding: 0.95rem;
+  min-height: 52px;
   border: 2px solid black;
   font-family: monospace;
   font-weight: 700;
@@ -785,7 +829,6 @@
   background: #d32f2f;
   color: white;
   transform: translate(-3px, -3px);
-  box-shadow: 5px 5px 0 0 #d32f2f;
 }
 
 /* === Report tab === */
@@ -866,6 +909,33 @@
 .noteText {
   font-size: 0.85rem;
   line-height: 1.6;
+}
+
+.pagination {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 12px;
+  margin-top: 16px;
+}
+
+.pageButton {
+  padding: 6px 12px;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  background: #fff;
+  cursor: pointer;
+  font-size: 0.85rem;
+}
+
+.pageButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.pageInfo {
+  font-size: 0.85rem;
+  font-weight: 700;
 }
 
 /* === Modal === */

--- a/src/types/trip.types.ts
+++ b/src/types/trip.types.ts
@@ -1,11 +1,12 @@
 // src/types/trip.types.ts
 
+import type { ProfileType } from "./auth.types";
+
 // ===================
 // Enums & Common
 // ===================
 export type TripStatus = "ACTIVE" | "ARCHIVED";
 export type TripVisibility = "PUBLIC" | "PRIVATE";
-export type ProfileType = "CUSTOM" | "AVATAR";
 
 // ===================
 // Response DTO


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #125

---

## 🎨 작업 내용 (What)

- 마이페이지 탭 구조 분리
- 사용자 정보 관리 로직 개선
- API 연동 추가
- 프로필 표시 로직 개선
- 계정 설정 기능 정리
- 성인 인증 및 탈퇴 모달 적용
- 신고 관리 탭 기능 정리

---

## 🧭 작업 목적 (Why)

기존 마이페이지는 하나의 컴포넌트에 다양한 기능이 혼재되어 있어  
가독성과 유지보수성이 떨어지는 문제가 있었다.

또한 사용자 정보, 인증, 신고 관리 등의 로직이 분리되지 않아  
기능 확장 시 코드 복잡도가 증가할 수 있는 구조였다.

이에 따라 탭 단위로 컴포넌트를 분리하고,  
사용자 상태 관리 및 API 연동 구조를 정리하여  
유지보수성과 확장성을 개선하였다.

---

## 🧩 변경 범위
- [ ] UI / Layout
- [x] 컴포넌트 구조
- [x] 상태 관리 로직
- [x] API 연동
- [ ] 스타일

---

## 🧪 테스트 방법

- [x] 로컬 실행 확인

- [x] 주요 시나리오 테스트
  - 마이페이지 진입 시 탭 정상 렌더링
  - 사용자 정보 수정 → 변경 감지 및 저장 버튼 노출
  - 입력값 유효성 검사 오류 정상 표시
  - 여행 스타일 목록 정상 조회
  - 성인 인증 버튼 클릭 → 모달 정상 동작
  - 계정 탈퇴 모달 정상 동작
  - 신고 관리 탭 → 신고 누적 및 제재 상태 조회 확인

- [x] 에러 콘솔 확인

---

## ⚠️ 참고 사항

- 사용자 정보 변경 감지 로직은 MyInfoTab 기준으로 동작
- 성인 인증 상태는 백엔드 응답 기준으로 처리 (fallback 로직 별도 고려 가능)
- 신고 관리 탭은 조회 전용이며, 이후 기능 확장 가능
- 탭 분리로 인해 파일 구조가 변경되었으므로 import 경로 확인 필요

---

## ✅ 체크리스트
- [x] main 브랜치 직접 push 하지 않음
- [x] feature 브랜치에서 작업함
- [x] 불필요한 console.log 제거
- [x] PR 단위가 과도하게 크지 않음