### PR TITLE
[FE] fix: 공지사항 로직 개선 및 인증 구조 전환

### DIFF
--- a/src/features/workspace/components/expense/ExpenseView.tsx
+++ b/src/features/workspace/components/expense/ExpenseView.tsx
@@ -55,6 +55,8 @@ const ExpenseView: React.FC<Props> = ({ store, onOpenSettleDetail }) => {
     personalPercent,
     members,
     ownerUserId,
+    currentUserId,
+    isOwner,
     isBootstrapLoading,
     bootstrapError,
     isPreviewLoading,
@@ -99,9 +101,6 @@ const ExpenseView: React.FC<Props> = ({ store, onOpenSettleDetail }) => {
     String(filterDate).startsWith("CALRANGE:");
 
   const isRecentDateActive = (date: string) => filterDate === `DATE:${date}`;
-
-  const currentUserId = Number(localStorage.getItem("userId"));
-  const isOwner = currentUserId === ownerUserId;
 
   const myMemberNickname =
     members.find((member) => member.userId === currentUserId)?.nickname ?? null;

--- a/src/features/workspace/components/expense/modal/ExpenseModal.tsx
+++ b/src/features/workspace/components/expense/modal/ExpenseModal.tsx
@@ -1,11 +1,10 @@
 // src/features/workspace/components/modals/ExpenseModal.tsx
 
 import { useEffect, useMemo, useRef, useState } from "react";
-import { useParams } from "react-router-dom";
 import "./../../../styles/expModal.css";
 import { requestExpenseOcrWithPreview } from "../../../../../api/ocr.api";
 import BaseModal from "../../../../../shared/components/BaseModal";
-
+import { useTripContext } from "../../../hooks/useTripContext";
 import type { UseExpensesStore } from "../../../hooks/useExpenses";
 import type {
   ExpenseItem,
@@ -90,8 +89,7 @@ const calcEqualSplit = (
 };
 
 const ExpenseModal: React.FC<Props> = ({ store }) => {
-  const { tripId: tripIdParam } = useParams<{ tripId: string }>();
-  const tripId = Number(tripIdParam);
+  const { tripId } = useTripContext();
 
   const {
     isExpenseModalOpen,

--- a/src/features/workspace/components/layout/WorkspaceSidebar.tsx
+++ b/src/features/workspace/components/layout/WorkspaceSidebar.tsx
@@ -2,8 +2,11 @@
 import React from "react";
 import "../../styles/sidebar.css";
 import { useWorkspaceCore } from "../../hooks/useWorkspaceCore";
+import { useTripContext } from "../../hooks/useTripContext";
 
 const WorkspaceSidebar: React.FC = () => {
+  const { isOwner } = useTripContext();
+
   const {
     dateLogs,
     noticeGroups,
@@ -36,7 +39,9 @@ const WorkspaceSidebar: React.FC = () => {
 
   const calcNightsDays = (start: string, end: string) => {
     if (!start || !end) return "-";
-    const diff = Math.round((new Date(end).getTime() - new Date(start).getTime()) / 86400000);
+    const diff = Math.round(
+      (new Date(end).getTime() - new Date(start).getTime()) / 86400000,
+    );
     if (diff <= 0) return "당일치기";
     return `${diff}박 ${diff + 1}일`;
   };
@@ -139,12 +144,14 @@ const WorkspaceSidebar: React.FC = () => {
           }}
         >
           <span>&gt;&gt; NOTICES</span>
-          <button
-            className="btn-add-mini"
-            onClick={() => void addNoticeGroup()}
-          >
-            [+]
-          </button>
+          {isOwner && (
+            <button
+              className="btn-add-mini"
+              onClick={() => void addNoticeGroup()}
+            >
+              [+]
+            </button>
+          )}
         </div>
 
         <div id="notice-log-list">
@@ -174,7 +181,7 @@ const WorkspaceSidebar: React.FC = () => {
                   {group.name}
                 </a>
 
-                {!group.isDefault && (
+                {isOwner && !group.isDefault && (
                   <div className="ws-item-controls">
                     <span onClick={() => void renameNoticeGroup(group.groupId)}>
                       ✎
@@ -193,8 +200,12 @@ const WorkspaceSidebar: React.FC = () => {
       <div className="ws-info-area">
         <div className="info-group">
           <div className="info-label">TRIP DURATION</div>
-          <div className="info-val">{formatDateRange(trip.startDate, trip.endDate)}</div>
-          <div className="info-sub">{calcNightsDays(trip.startDate, trip.endDate)}</div>
+          <div className="info-val">
+            {formatDateRange(trip.startDate, trip.endDate)}
+          </div>
+          <div className="info-sub">
+            {calcNightsDays(trip.startDate, trip.endDate)}
+          </div>
         </div>
 
         <div className="info-group">
@@ -204,10 +215,20 @@ const WorkspaceSidebar: React.FC = () => {
               <div
                 key={m.memberId}
                 className="mem-icon"
-                style={m.avatarColor ? { background: m.avatarColor } : undefined}
+                style={
+                  m.profileType === "CUSTOM"
+                    ? { background: "transparent" }
+                    : m.avatarColor
+                      ? { background: m.avatarColor }
+                      : undefined
+                }
                 title={m.nickname}
               >
-                {m.avatarEmoji || m.nickname.charAt(0).toUpperCase()}
+                {m.profileType === "CUSTOM" && m.profileImage ? (
+                  <img src={m.profileImage} alt={m.nickname} />
+                ) : (
+                  m.avatarEmoji || m.nickname.charAt(0).toUpperCase()
+                )}
               </div>
             ))}
           </div>

--- a/src/features/workspace/components/notice/NoticeView.tsx
+++ b/src/features/workspace/components/notice/NoticeView.tsx
@@ -2,6 +2,7 @@
 
 import React from "react";
 import type { NoticeItem } from "../../hooks/useNotices";
+import { useTripContext } from "../../hooks/useTripContext";
 
 interface Props {
   notices: NoticeItem[];
@@ -20,6 +21,8 @@ const NoticeView: React.FC<Props> = ({
   onDelete,
   onTogglePin,
 }) => {
+  const { isOwner } = useTripContext();
+
   return (
     <>
       <div
@@ -49,7 +52,10 @@ const NoticeView: React.FC<Props> = ({
         </button>
       </div>
 
-      <div className="notice-container" id="notice-list-container">
+      <div
+        className={`notice-container ${!isLoading && notices.length === 0 ? "empty" : ""}`}
+        id="notice-list-container"
+      >
         {isLoading ? (
           <div
             style={{
@@ -62,15 +68,10 @@ const NoticeView: React.FC<Props> = ({
             공지사항을 불러오는 중입니다.
           </div>
         ) : notices.length === 0 ? (
-          <div
-            style={{
-              padding: "40px 20px",
-              textAlign: "center",
-              color: "#777",
-              fontWeight: 500,
-            }}
-          >
-            등록된 공지사항이 없습니다.
+          <div className="notice-empty">
+            <i className="fa-regular fa-note-sticky"></i>
+            <p>등록된 공지사항이 없습니다.</p>
+            <span>새로운 공지를 추가해보세요.</span>
           </div>
         ) : (
           notices.map((notice) => (
@@ -81,8 +82,20 @@ const NoticeView: React.FC<Props> = ({
               }`}
             >
               <div
-                className={`nc-pin-btn ${notice.isPinned ? "active" : ""}`}
-                onClick={() => void onTogglePin(notice.id)}
+                className={`nc-pin-btn ${notice.isPinned ? "active" : ""} ${
+                  notice.isPinned && !isOwner ? "disabled" : ""
+                }`}
+                onClick={() => {
+                  if (notice.isPinned && !isOwner) return;
+                  void onTogglePin(notice.id);
+                }}
+                title={
+                  notice.isPinned
+                    ? isOwner
+                      ? "핀 해제"
+                      : "핀 해제는 소유주만 가능합니다"
+                    : "핀 고정"
+                }
               >
                 <i className="fa-solid fa-thumbtack"></i>
               </div>
@@ -100,12 +113,15 @@ const NoticeView: React.FC<Props> = ({
                 >
                   EDIT
                 </span>
-                <span
-                  className="nc-btn del"
-                  onClick={() => void onDelete(notice.id)}
-                >
-                  DELETE
-                </span>
+
+                {isOwner && (
+                  <span
+                    className="nc-btn del"
+                    onClick={() => void onDelete(notice.id)}
+                  >
+                    DELETE
+                  </span>
+                )}
               </div>
             </div>
           ))

--- a/src/features/workspace/hooks/useExpenses.ts
+++ b/src/features/workspace/hooks/useExpenses.ts
@@ -77,7 +77,8 @@ import type {
 export type UseExpensesStore = ReturnType<typeof useExpenses>;
 
 export const useExpenses = () => {
-  const { tripId, ownerUserId, tripDetail } = useTripContext();
+  const { tripId, ownerUserId, tripDetail, isOwner, currentUserId } =
+    useTripContext();
 
   const [expenses, setExpenses] = useState<ExpenseItem[]>([]);
   const [filterDate, setFilterDate] = useState<string>("ALL");
@@ -723,6 +724,8 @@ export const useExpenses = () => {
 
     members,
     ownerUserId,
+    currentUserId,
+    isOwner,
 
     sharedPercent,
     personalPercent,

--- a/src/features/workspace/hooks/useNotices.ts
+++ b/src/features/workspace/hooks/useNotices.ts
@@ -1,7 +1,6 @@
 // src/features/workspace/hooks/useNotices.ts
 import { useEffect, useMemo, useState } from "react";
-import { useParams } from "react-router-dom";
-
+import { useTripContext } from "./useTripContext";
 import {
   createNoticeItem,
   deleteNoticeItem,
@@ -103,8 +102,7 @@ const mapNoticeItem = (item: NoticeItemResponse): NoticeItem => ({
 });
 
 export const useNotices = (): UseNoticesStore => {
-  const params = useParams<{ tripId: string }>();
-  const tripId = Number(params.tripId);
+  const { tripId } = useTripContext();
 
   const { currentNoticeGroupId, reloadNoticeGroups } = useWorkspaceCore();
 

--- a/src/features/workspace/hooks/useVouchers.ts
+++ b/src/features/workspace/hooks/useVouchers.ts
@@ -28,6 +28,7 @@ const buildFileUrl = (fileUrl: string) => {
 
 export const useVouchers = () => {
   const { tripId } = useTripContext();
+
   const [vouchers, setVouchers] = useState<VoucherResponse[]>([]);
   const [loading, setLoading] = useState(false);
 

--- a/src/features/workspace/hooks/useWorkspaceCore.tsx
+++ b/src/features/workspace/hooks/useWorkspaceCore.tsx
@@ -10,7 +10,10 @@ import {
   renameNoticeGroup as renameNoticeGroupApi,
 } from "../../../api/notice.api";
 
-import { getTripDetail, updateTrip as updateTripApi } from "../../../api/trip.api";
+import {
+  getTripDetail,
+  updateTrip as updateTripApi,
+} from "../../../api/trip.api";
 import type { TripMemberResponse } from "../../../types/trip.types";
 import type { NoticeGroupResponse } from "../../../types/notice.types";
 
@@ -61,17 +64,20 @@ interface WorkspaceCoreState {
 }
 
 const LS_TRIP_DATA = "tripData";
-const LS_CURRENT_NOTICE_GROUP_ID = "tripmoa_current_notice_group_id";
 const DEFAULT_DAY_LABEL = "DAY ALL";
 
 const normalizeName = (name: string) => name.trim().toLowerCase();
 
 const sortNoticeGroups = (groups: NoticeGroupResponse[]) =>
   [...groups].sort((a, b) =>
-    a.sortOrder !== b.sortOrder ? a.sortOrder - b.sortOrder : a.groupId - b.groupId
+    a.sortOrder !== b.sortOrder
+      ? a.sortOrder - b.sortOrder
+      : a.groupId - b.groupId,
   );
 
-const pickFallbackNoticeGroupId = (groups: NoticeGroupResponse[]): number | null => {
+const pickFallbackNoticeGroupId = (
+  groups: NoticeGroupResponse[],
+): number | null => {
   if (groups.length === 0) return null;
   return groups.find((g) => g.isDefault)?.groupId ?? groups[0].groupId;
 };
@@ -87,44 +93,29 @@ const useWorkspaceCoreInternal = (): WorkspaceCoreState => {
 
   const [activeView, setActiveView] = useState<WorkspaceViewType>("timeline");
   const [currentDay, setCurrentDay] = useState<string>(DEFAULT_DAY_LABEL);
-  const [currentNoticeGroupId, setCurrentNoticeGroupId] = useState<number | null>(null);
+  const [currentNoticeGroupId, setCurrentNoticeGroupId] = useState<
+    number | null
+  >(null);
   const [hideRight, setHideRight] = useState<boolean>(false);
 
   const [trip, setTrip] = useState<TripInfo>(() => {
     try {
       const saved = localStorage.getItem(LS_TRIP_DATA);
       if (saved) return JSON.parse(saved) as TripInfo;
-    } catch { /* 파싱 실패 무시 */ }
+    } catch {
+      /* 파싱 실패 무시 */
+    }
     return { title: "", startDate: "", endDate: "" };
   });
   const [tripMembers, setTripMembers] = useState<TripMemberResponse[]>([]);
   const [isTripLoading, setIsTripLoading] = useState(false);
 
-  const currentNoticeStorageKey = useMemo(
-    () => `${LS_CURRENT_NOTICE_GROUP_ID}_${Number.isFinite(tripId) ? tripId : "unknown"}`,
-    [tripId]
-  );
-
   const currentNoticeGroup = useMemo(() => {
     if (currentNoticeGroupId == null) return "";
-    return noticeGroups.find((g) => g.groupId === currentNoticeGroupId)?.name ?? "";
+    return (
+      noticeGroups.find((g) => g.groupId === currentNoticeGroupId)?.name ?? ""
+    );
   }, [noticeGroups, currentNoticeGroupId]);
-
-  // 공지 선택값 로드/저장 (localStorage 유지 — 공지는 서버 기반이라 선택값 정도는 OK)
-  useEffect(() => {
-    const stored = localStorage.getItem(currentNoticeStorageKey);
-    if (!stored) { setCurrentNoticeGroupId(null); return; }
-    const parsed = Number(stored);
-    setCurrentNoticeGroupId(Number.isFinite(parsed) ? parsed : null);
-  }, [currentNoticeStorageKey]);
-
-  useEffect(() => {
-    if (currentNoticeGroupId == null) {
-      localStorage.removeItem(currentNoticeStorageKey);
-      return;
-    }
-    localStorage.setItem(currentNoticeStorageKey, String(currentNoticeGroupId));
-  }, [currentNoticeGroupId, currentNoticeStorageKey]);
 
   // 여행 정보 API 조회
   useEffect(() => {
@@ -133,12 +124,18 @@ const useWorkspaceCoreInternal = (): WorkspaceCoreState => {
     getTripDetail(tripId)
       .then((res) => {
         const d = res.data;
-        const t: TripInfo = { title: d.title, startDate: d.tripStartDate, endDate: d.tripEndDate };
+        const t: TripInfo = {
+          title: d.title,
+          startDate: d.tripStartDate,
+          endDate: d.tripEndDate,
+        };
         setTrip(t);
         setTripMembers(d.members ?? []);
         localStorage.setItem(LS_TRIP_DATA, JSON.stringify(t));
       })
-      .catch(() => { /* localStorage fallback 유지 */ })
+      .catch(() => {
+        /* localStorage fallback 유지 */
+      })
       .finally(() => setIsTripLoading(false));
   }, [tripId]);
 
@@ -160,7 +157,10 @@ const useWorkspaceCoreInternal = (): WorkspaceCoreState => {
 
   // 공지 그룹 조회
   const reloadNoticeGroups = async () => {
-    if (!Number.isFinite(tripId) || tripId <= 0) { setNoticeGroups([]); return; }
+    if (!Number.isFinite(tripId) || tripId <= 0) {
+      setNoticeGroups([]);
+      return;
+    }
     setIsNoticeGroupsLoading(true);
     try {
       const response = await getNoticeGroups(tripId);
@@ -172,10 +172,15 @@ const useWorkspaceCoreInternal = (): WorkspaceCoreState => {
     }
   };
 
-  useEffect(() => { void reloadNoticeGroups(); }, [tripId]);
+  useEffect(() => {
+    void reloadNoticeGroups();
+  }, [tripId]);
 
   useEffect(() => {
-    if (noticeGroups.length === 0) { setCurrentNoticeGroupId(null); return; }
+    if (noticeGroups.length === 0) {
+      setCurrentNoticeGroupId(null);
+      return;
+    }
     const exists = noticeGroups.some((g) => g.groupId === currentNoticeGroupId);
     if (exists) return;
     setCurrentNoticeGroupId(pickFallbackNoticeGroupId(noticeGroups));
@@ -184,11 +189,17 @@ const useWorkspaceCoreInternal = (): WorkspaceCoreState => {
   const selectTab = (title: string, view: WorkspaceViewType) => {
     setActiveView(view);
     setHideRight(false);
-    if (view === "timeline") { setCurrentDay(title); return; }
+    if (view === "timeline") {
+      setCurrentDay(title);
+      return;
+    }
     if (view === "notice") {
-      const matched = noticeGroups.find((g) => normalizeName(g.name) === normalizeName(title));
+      const matched = noticeGroups.find(
+        (g) => normalizeName(g.name) === normalizeName(title),
+      );
       if (matched) setCurrentNoticeGroupId(matched.groupId);
-      else if (currentNoticeGroupId == null) setCurrentNoticeGroupId(pickFallbackNoticeGroupId(noticeGroups));
+      else if (currentNoticeGroupId == null)
+        setCurrentNoticeGroupId(pickFallbackNoticeGroupId(noticeGroups));
       return;
     }
   };
@@ -201,7 +212,10 @@ const useWorkspaceCoreInternal = (): WorkspaceCoreState => {
 
   // ── dateLogs 관련 ─────────────────────────────────────────
   const addDateLog = () => {
-    const name = prompt("추가할 일정 이름을 입력하세요.", `DAY ${dateLogs.length + 1}`);
+    const name = prompt(
+      "추가할 일정 이름을 입력하세요.",
+      `DAY ${dateLogs.length + 1}`,
+    );
     if (!name?.trim()) return;
     setDateLogs((prev) => [...prev, name.trim()]);
   };
@@ -211,7 +225,9 @@ const useWorkspaceCoreInternal = (): WorkspaceCoreState => {
     if (current == null) return;
     const newName = prompt("이름을 변경하세요:", current);
     if (!newName?.trim()) return;
-    setDateLogs((prev) => prev.map((d, i) => (i === index ? newName.trim() : d)));
+    setDateLogs((prev) =>
+      prev.map((d, i) => (i === index ? newName.trim() : d)),
+    );
   };
 
   const deleteDateLog = (index: number) => {
@@ -239,15 +255,22 @@ const useWorkspaceCoreInternal = (): WorkspaceCoreState => {
       if (name === null) return;
       const trimmed = name.trim();
       if (!trimmed) return;
-      if (noticeGroups.some((g) => normalizeName(g.name) === normalizeName(trimmed))) {
-        alert("이미 존재하는 이름입니다."); continue;
+      if (
+        noticeGroups.some(
+          (g) => normalizeName(g.name) === normalizeName(trimmed),
+        )
+      ) {
+        alert("이미 존재하는 이름입니다.");
+        continue;
       }
       try {
         const response = await createNoticeGroupApi(tripId, { name: trimmed });
         await reloadNoticeGroups();
         setCurrentNoticeGroupId(response.data.groupId);
         setActiveView("notice");
-      } catch { alert("공지 그룹 생성에 실패했습니다."); }
+      } catch {
+        alert("공지 그룹 생성에 실패했습니다.");
+      }
       return;
     }
   };
@@ -262,11 +285,22 @@ const useWorkspaceCoreInternal = (): WorkspaceCoreState => {
       if (newName === null) return;
       const trimmed = newName.trim();
       if (!trimmed || trimmed === target.name) return;
-      if (noticeGroups.some((g) => g.groupId !== groupId && normalizeName(g.name) === normalizeName(trimmed))) {
-        alert("이미 존재하는 이름입니다."); continue;
+      if (
+        noticeGroups.some(
+          (g) =>
+            g.groupId !== groupId &&
+            normalizeName(g.name) === normalizeName(trimmed),
+        )
+      ) {
+        alert("이미 존재하는 이름입니다.");
+        continue;
       }
-      try { await renameNoticeGroupApi(tripId, groupId, { name: trimmed }); await reloadNoticeGroups(); }
-      catch { alert("공지 그룹 이름 수정에 실패했습니다."); }
+      try {
+        await renameNoticeGroupApi(tripId, groupId, { name: trimmed });
+        await reloadNoticeGroups();
+      } catch {
+        alert("공지 그룹 이름 수정에 실패했습니다.");
+      }
       return;
     }
   };
@@ -276,43 +310,83 @@ const useWorkspaceCoreInternal = (): WorkspaceCoreState => {
     const target = noticeGroups.find((g) => g.groupId === groupId);
     if (!target || target.isDefault) return;
     if (!confirm("정말 삭제하시겠습니까?")) return;
-    try { await deleteNoticeGroupApi(tripId, groupId); await reloadNoticeGroups(); }
-    catch { alert("공지 그룹 삭제에 실패했습니다."); }
+    try {
+      await deleteNoticeGroupApi(tripId, groupId);
+      await reloadNoticeGroups();
+    } catch {
+      alert("공지 그룹 삭제에 실패했습니다.");
+    }
   };
 
   const renameItem = (type: "date" | "notice", index: number) => {
-    if (type === "date") { renameDateLog(index); return; }
+    if (type === "date") {
+      renameDateLog(index);
+      return;
+    }
     const target = noticeGroups[index];
     if (target) void renameNoticeGroup(target.groupId);
   };
 
   const deleteItem = (type: "date" | "notice", index: number) => {
-    if (type === "date") { deleteDateLog(index); return; }
+    if (type === "date") {
+      deleteDateLog(index);
+      return;
+    }
     const target = noticeGroups[index];
     if (target) void deleteNoticeGroup(target.groupId);
   };
 
   return {
-    dateLogs, noticeGroups, activeView, currentDay,
-    currentNoticeGroupId, currentNoticeGroup, hideRight, isNoticeGroupsLoading,
-    trip, tripMembers, isTripLoading, updateTripData,
-    selectTab, selectNoticeGroup, reloadNoticeGroups,
-    addDateLog, renameDateLog, deleteDateLog, syncDateLogs,
-    addNoticeGroup, renameNoticeGroup, deleteNoticeGroup,
-    renameItem, deleteItem, setHideRight, setActiveView,
+    dateLogs,
+    noticeGroups,
+    activeView,
+    currentDay,
+    currentNoticeGroupId,
+    currentNoticeGroup,
+    hideRight,
+    isNoticeGroupsLoading,
+    trip,
+    tripMembers,
+    isTripLoading,
+    updateTripData,
+    selectTab,
+    selectNoticeGroup,
+    reloadNoticeGroups,
+    addDateLog,
+    renameDateLog,
+    deleteDateLog,
+    syncDateLogs,
+    addNoticeGroup,
+    renameNoticeGroup,
+    deleteNoticeGroup,
+    renameItem,
+    deleteItem,
+    setHideRight,
+    setActiveView,
   };
 };
 
 const WorkspaceCoreContext = createContext<WorkspaceCoreState | null>(null);
 
-export const WorkspaceCoreProvider = ({ children }: { children: ReactNode }) => {
+export const WorkspaceCoreProvider = ({
+  children,
+}: {
+  children: ReactNode;
+}) => {
   const core = useWorkspaceCoreInternal();
   const value = useMemo(() => core, [core]);
-  return <WorkspaceCoreContext.Provider value={value}>{children}</WorkspaceCoreContext.Provider>;
+  return (
+    <WorkspaceCoreContext.Provider value={value}>
+      {children}
+    </WorkspaceCoreContext.Provider>
+  );
 };
 
 export const useWorkspaceCore = (): WorkspaceCoreState => {
   const ctx = useContext(WorkspaceCoreContext);
-  if (!ctx) throw new Error("useWorkspaceCore must be used within WorkspaceCoreProvider");
+  if (!ctx)
+    throw new Error(
+      "useWorkspaceCore must be used within WorkspaceCoreProvider",
+    );
   return ctx;
 };

--- a/src/features/workspace/styles/center.css
+++ b/src/features/workspace/styles/center.css
@@ -1382,12 +1382,16 @@
   box-shadow: 2px 2px 0px #000;
 }
 
+.nc-pin-btn.disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
 .nc-pin-btn i {
   font-size: 14px;
   transform: rotate(25deg);
 }
 
-/* pinned 상태일 때 태그가 버튼과 겹치지 않도록 */
 .notice-card .nc-tag {
   margin-right: 52px;
 }
@@ -1424,6 +1428,43 @@
 }
 .notice-card.green {
   background: #e8f5e9;
+}
+
+.notice-container.empty {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 400px;
+}
+
+.notice-empty {
+  flex: 1;
+  min-height: 420px;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  transform: translateY(-40px);
+  color: #9ca3af;
+  text-align: center;
+}
+
+.notice-empty i {
+  font-size: 42px;
+  margin-bottom: 14px;
+  color: #c7cbd1;
+}
+
+.notice-empty p {
+  margin: 0 0 8px;
+  font-size: 15px;
+  font-weight: 700;
+}
+
+.notice-empty span {
+  font-size: 13px;
+  color: #b0b5bd;
 }
 
 .ws-body {

--- a/src/features/workspace/styles/sidebar.css
+++ b/src/features/workspace/styles/sidebar.css
@@ -132,12 +132,12 @@
 
 .member-row {
   display: flex;
-  gap: -8px;
 }
 .mem-icon {
   width: 32px;
   height: 32px;
-  border: 2px solid #fff;
+  box-sizing: border-box;
+  border: none;
   outline: 2px solid #000;
   border-radius: 50%;
   background: #eee;
@@ -148,9 +148,18 @@
   font-weight: bold;
   font-size: 12px;
   margin-right: 8px;
-  background-size: cover;
   cursor: pointer;
   transition: 0.2s;
+  overflow: hidden;
+  padding: 0;
+}
+
+.mem-icon img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  border-radius: 50%;
 }
 .mem-icon:hover {
   transform: translateY(-3px);


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #122

---

## 🎨 작업 내용 (What)

- 공지사항 그룹 localStorage 사용 제거
- 공지사항 권한 체크 로직 추가
- 공지사항 빈 상태 UI 추가
- 인증 구조 개선

---

## 🧭 작업 목적 (Why)

공지사항 그룹 데이터를 localStorage로 관리하면서  
계정 전환, 로그아웃 이후에도 이전 데이터가 남는 문제가 발생했다.

또한 인증 상태를 localStorage 기반으로 처리하면서  
세션 불일치 및 데이터 동기화 문제가 발생할 가능성이 있었다.

이에 따라 인증 구조를 메모리 기반으로 전환하고,  
공지사항 상태를 서버 기준으로 관리하도록 개선하여  
데이터 일관성과 사용자 경험을 함께 개선하였다.

---

## 🧩 변경 범위
- [x] UI / Layout
- [ ] 컴포넌트 구조
- [x] 상태 관리 로직
- [x] API 연동
- [x] 스타일

---

## 🧪 테스트 방법

- [x] 로컬 실행 확인

- [x] 주요 시나리오 테스트
  - 로그아웃 후 공지사항 그룹 데이터 초기화 확인
  - 다른 계정 로그인 시 공지사항 데이터 정상 로드
  - 권한 없는 사용자 → 관리 버튼 미노출 확인
  - 공지사항이 없을 경우 빈 상태 UI 표시 확인

- [x] 에러 콘솔 확인

---

## ⚠️ 참고 사항

- 인증 구조 변경으로 인해 accessToken은 메모리에서만 관리됨
- 기존 localStorage 기반 공지사항 그룹 데이터는 더 이상 사용하지 않음
- 공지사항 상태는 서버 기준으로 동기화되므로 클라이언트 캐싱 최소화 필요

---

## ✅ 체크리스트
- [x] main 브랜치 직접 push 하지 않음
- [x] feature 브랜치에서 작업함
- [x] 불필요한 console.log 제거
- [x] PR 단위가 과도하게 크지 않음