### PR TITLE
[FE] refactor: MateDetail 훅 호출 위치를 early return 위로 이동 및 불필요한 useUserProfile 제거

### DIFF
--- a/src/features/mate/pages/MateDetail.tsx
+++ b/src/features/mate/pages/MateDetail.tsx
@@ -8,7 +8,6 @@ import { useAuth } from "../../user/pages/AuthContext";
 import { isPostExpired } from "../hooks/mate.util";
 import { useAccessGuard } from "../../../shared/hooks";
 import { ActionPromptModal } from "../../../shared/components";
-import { useUserProfile } from "../../user/hooks";
 import "../styles/MateDetail.css";
 import { getAccessToken } from "../../../api/api";
 
@@ -28,6 +27,26 @@ export default function MateDetail() {
   const { userId } = useAuth();
   const isAuthor = post?.author?.id === userId;
   const token = getAccessToken();
+
+  const {
+    showLoginModal,
+    showAdultModal,
+    closeLoginModal,
+    closeAdultModal,
+    moveToLogin,
+    moveToMypageForVerification,
+    requireLogin,
+    requireAdultVerified,
+  } = useAccessGuard();
+
+  const handleApplyClick = () => {
+    if (requireAdultVerified()) setShowApplyForm(true);
+  };
+
+  const handleLikeClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    if (requireLogin()) onLikeClick(e);
+  };  
 
   useEffect(() => {
     const loadPost = async () => {
@@ -151,29 +170,6 @@ export default function MateDetail() {
   const isLiked = post.liked || false;
   const hasApplied = post.hasApplied || false;
   const isExpire = isPostExpired(post);
-
-  const { profile } = useUserProfile();
-
-  const {
-    showLoginModal,
-    showAdultModal,
-    closeLoginModal,
-    closeAdultModal,
-    moveToLogin,
-    moveToMypageForVerification,
-    requireLogin,
-    requireAdultVerified,
-  } = useAccessGuard(profile);
-
-  const handleApplyClick = () => {
-    if (requireAdultVerified()) setShowApplyForm(true);
-  };
-
-  const handleLikeClick = (e: React.MouseEvent<HTMLButtonElement>) => {
-    e.stopPropagation();
-    if (requireLogin()) onLikeClick(e);
-  };  
-
 
   return (
     <>


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #137
- Closes #138 

---

## 🎨 작업 내용 (What)
- `useAccessGuard`, `handleApplyClick`, `handleLikeClick` 호출 위치를 early return 위로 이동
- 불필요한 `useUserProfile` import 및 호출 삭제
- `useAccessGuard` 내부에서 `getMyInfo()`를 자체 fetch하도록 수정하여 인자 없이 호출

---

## 🧭 작업 목적 (Why)
- 훅이 early return 아래에서 호출되어 렌더링마다 훅 개수가 달라지면서 React Rules of Hooks 위반 크래시 발생
- `useUserProfile`은 UserSettings 전용 훅으로, profile 하나를 위해 호출하면 30개 이상의 내부 훅과 불필요한 API 호출이 동반됨

---

## 🧩 변경 범위
- [ ] UI / Layout
- [x] 컴포넌트 구조
- [x] 상태 관리 로직
- [ ] API 연동
- [ ] 스타일

---

## 🧪 테스트 방법
- [x] 로컬 실행 확인
- [x] 주요 화면 렌더링 확인
- [x] 에러 콘솔 확인
- [ ] `/mate/:postId` 진입 시 `Rendered more hooks` 에러 없이 정상 렌더링
- [ ] 비로그인 상태에서 좋아요 클릭 시 로그인 모달 표시
- [ ] 비로그인 / 미인증 상태에서 Apply Now 클릭 시 가드 모달 정상 동작
- [ ] 로그인 + 인증 완료 상태에서 좋아요, 신청하기 정상 동작

---

## ⚠️ 참고 사항
- `useAccessGuard` 내부에 `useEffect`로 `getMyInfo()` fetch 로직이 추가되어, 외부에서 profile을 전달할 필요 없음
- `AuthContext`는 변경하지 않음

---

## ✅ 체크리스트
- [x] main 브랜치 직접 push 하지 않음
- [x] feature 브랜치에서 작업함
- [x] 불필요한 console.log 제거
- [x] PR 단위가 과도하게 크지 않음