### PR TITLE
[FE] refactor: 여행 스타일 API 조회로 전환

### DIFF
--- a/src/features/mate/components/MateFilters.tsx
+++ b/src/features/mate/components/MateFilters.tsx
@@ -4,7 +4,8 @@ import "react-datepicker/dist/react-datepicker.css";
 import "../styles/datepicker.css";
 import "../styles/MateFilters.css";
 import { MapPin, Calendar, ChevronDown } from "lucide-react";
-import { ALL_TAGS, GENDER_OPTIONS, AGE_OPTIONS } from "../hooks/mate.constants";
+import { GENDER_OPTIONS, AGE_GROUP_OPTIONS } from "../hooks/mate.constants";
+import { getTravelStyles } from "../../../api/auth.api";
 
 interface MateFiltersProps {
   locationFilter: string;
@@ -35,6 +36,13 @@ export function MateFilters({
 }: MateFiltersProps) {
   const [showGenderDropdown, setShowGenderDropdown] = useState(false);
   const [showAgeDropdown, setShowAgeDropdown] = useState(false);
+  const [tags, setTags] = useState<string[]>([]);
+
+  useEffect(() => {
+    getTravelStyles()
+      .then((res) => setTags(res.data.map((s) => s.name)))
+      .catch(() => setTags([]));
+  }, []);
 
   useEffect(() => {
     const handleClickOutside = (e: MouseEvent): void => {
@@ -146,7 +154,7 @@ export function MateFilters({
 
           {showAgeDropdown && (
             <div className={`absolute top-full left-0 right-0 mt-1 bg-white z-50 overflow-hidden dropdown`}>
-              {AGE_OPTIONS.map((option, idx) => (
+              {AGE_GROUP_OPTIONS.map((option, idx) => (
                 <button
                   key={option}
                   type="button"
@@ -156,7 +164,7 @@ export function MateFilters({
                     setCurrentPage(1);
                   }}
                   className={`w-full px-4 py-2.5 text-left text-sm font-mono font-bold transition-colors ${
-                    idx !== AGE_OPTIONS.length - 1 ? "border-b border-black/10" : ""
+                    idx !== AGE_GROUP_OPTIONS.length - 1 ? "border-b border-black/10" : ""
                   } ${ageFilter === option ? "bgActive" : "bg-white text-black hover:bg-[#eee]"}`}
                 >
                   {option}
@@ -172,7 +180,7 @@ export function MateFilters({
       {/* Tags */}
       <div className="flex items-center gap-2 flex-wrap">
         <span className="text-xs font-bold text-black/50 uppercase mr-1">TAGS</span>
-        {ALL_TAGS.map((tag) => (
+        {tags.map((tag) => (
           <button
             key={tag}
             onClick={() => toggleTag(tag)}

--- a/src/features/mate/components/MatePostCard.tsx
+++ b/src/features/mate/components/MatePostCard.tsx
@@ -2,7 +2,6 @@ import type { MouseEvent } from "react";
 import { Heart, X, Eye, RotateCcw, Trash2 } from "lucide-react";
 import type { Post } from "../hooks/mate.types";
 import { 
-  getCurrentUserId,
   TRANSPORT_REVERSE_MAP,
   GENDER_PREFERENCE_REVERSE_MAP,
   AGE_GROUP_REVERSE_MAP

--- a/src/features/mate/hooks/mate.constants.ts
+++ b/src/features/mate/hooks/mate.constants.ts
@@ -1,13 +1,9 @@
 // mate.constants.ts
 export const POSTS_PER_PAGE = 5;
 
-export const ALL_TAGS = ["맛집탐방", "액티비티", "힐링", "문화탐방", "쇼핑", "자연", "사진", "야경"];
-
 // 프론트엔드 표시용 옵션들
 export const GENDER_OPTIONS = ["남성", "여성", "무관"];
-export const AGE_OPTIONS = ["전체", "20대", "30대", "40대", "50대+"];
 export const TRANSPORT_OPTIONS = ["비행기", "버스", "기차", "자차", "도보", "렌트카", "택시"];
-export const TRAVEL_TYPE_OPTIONS = ["맛집탐방", "액티비티", "힐링", "문화탐방", "쇼핑", "자연", "사진", "야경"];
 export const AGE_GROUP_OPTIONS = ["전체", "20대", "30대", "40대", "50대+"];
 
 // 백엔드 enum 매핑 (한글 -> 영문 enum)
@@ -72,37 +68,6 @@ export const getAgeGroupLabel = (value: string): string => {
   return AGE_GROUP_REVERSE_MAP[value] || value || "전체";
 };
 
-// // 공항 코드 매핑 (필요한 경우 사용)
-// export const AIRPORT_MAP: { [key: string]: string } = {
-//   ICN: "인천",
-//   GMP: "김포",
-//   PUS: "부산",
-//   CJU: "제주",
-//   SEL: "서울",
-// };
-
-// export const getAirportDisplay = (code: string): string => {
-//   return AIRPORT_MAP[code] || code;
-// };
-
-// 현재 사용자 정보 가져오기 (API에서 가져오는 것으로 변경 필요)
-export const getCurrentUserId = (): number => {
-  const userId = localStorage.getItem('userId');
-  return userId ? parseInt(userId) : 0;
-};
-
-export const CURRENT_USER_ID = getCurrentUserId();
-
-/**
- * 여행 기간 계산 (startDate와 endDate로부터 "N박 M일" 형식 생성)
- * @param startDate - 시작일 (YYYY-MM-DD 형식)
- * @param endDate - 종료일 (YYYY-MM-DD 형식)
- * @returns "N박 M일" 형식의 문자열
- * 
- * @example
- * calculateDuration("2024-03-15", "2024-03-20") // "5박 6일"
- * calculateDuration("2024-03-15", "2024-03-15") // "당일치기"
- */
 export const calculateDuration = (startDate: string, endDate: string): string => {
   try {
     const start = new Date(startDate);
@@ -137,12 +102,6 @@ export const calculateDuration = (startDate: string, endDate: string): string =>
   }
 };
 
-/**
- * 여행 기간을 일수로만 반환
- * @param startDate - 시작일 (YYYY-MM-DD 형식)
- * @param endDate - 종료일 (YYYY-MM-DD 형식)
- * @returns 일수
- */
 export const calculateDays = (startDate: string, endDate: string): number => {
   try {
     const start = new Date(startDate);


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #140
---
## 🎨 작업 내용 (What)
- `mate.constants.ts`에서 하드코딩된 `ALL_TAGS` 상수 삭제
- 태그 사용처에서 `getTravelStyles()` API 호출로 전환
- `AGE_OPTIONS` → `AGE_GROUP_OPTIONS`로 통일 (중복 상수 제거)
---
## 🧭 작업 목적 (Why)
프론트엔드에 하드코딩된 태그 목록을 백엔드 API 단일 소스로 관리하여, 태그 추가/변경 시 프론트 재배포 없이 반영 가능하도록 개선
---
## 🧩 변경 범위
- [ ] UI / Layout
- [x] 컴포넌트 구조
- [x] 상태 관리 로직
- [x] API 연동
- [ ] 스타일
---
## 🧪 테스트 방법
- [ ] 로컬 실행 확인
- [ ] 메이트 필터에서 태그 목록 정상 렌더링 확인
- [ ] 게시글 작성/수정 폼에서 태그 선택 동작 확인
- [ ] API 실패 시 빈 태그 목록 처리 확인
- [ ] 에러 콘솔 확인
---
## ⚠️ 참고 사항
- 기존 `getTravelStyles()` API(`/users/styles`)를 그대로 사용
- 기능 변경 없이 데이터 소스만 상수 → API로 전환
---
## ✅ 체크리스트
- [ ] main 브랜치 직접 push 하지 않음
- [ ] feature 브랜치에서 작업함
- [ ] 불필요한 console.log 제거
- [ ] PR 단위가 과도하게 크지 않음