### PR TITLE
[FE] refactor: 인증 프로필 상태 동기화 구조 개선

### DIFF
--- a/src/features/myTrips/hooks/useMyTrips.ts
+++ b/src/features/myTrips/hooks/useMyTrips.ts
@@ -8,8 +8,7 @@ import {
   getInvitedTrips,
   getMyTrips,
 } from "../../../api/trip.api";
-import { getMyInfo } from "../../../api/auth.api";
-import type { UserResponse } from "../../../types/auth.types";
+import { useAuth } from "../../user/pages/AuthContext";
 import type {
   MyTripSummaryResponse,
   TripCreateRequest,
@@ -61,10 +60,9 @@ export const useMyTrips = () => {
   const [trips, setTrips] = useState<MyTripSummaryResponse[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [currentUser, setCurrentUser] = useState<UserResponse | null>(null);
-
   const [formData, setFormData] = useState<TripCreateFormState>(INITIAL_FORM);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const { profile: currentUser } = useAuth();
 
   const resetForm = useCallback(() => {
     setFormData(INITIAL_FORM);
@@ -95,19 +93,6 @@ export const useMyTrips = () => {
   useEffect(() => {
     fetchTrips(filter);
   }, [filter, fetchTrips]);
-
-  useEffect(() => {
-    const loadMyInfo = async () => {
-      try {
-        const response = await getMyInfo();
-        setCurrentUser(response.data);
-      } catch (infoError) {
-        console.error("내 정보 조회 실패:", infoError);
-      }
-    };
-
-    loadMyInfo();
-  }, []);
 
   const removeTrip = useCallback(
     async (tripId: number) => {

--- a/src/features/user/hooks/useUserSetting.ts
+++ b/src/features/user/hooks/useUserSetting.ts
@@ -144,7 +144,13 @@ const mapUserResponseToProfile = (data: UserResponse): UserProfile => {
 export function useUserProfile() {
   const navigate = useNavigate();
   const fileInputRef = useRef<HTMLInputElement | null>(null);
-  const { isAuthenticated, authReady, clearAuth } = useAuth();
+
+  const {
+    isAuthenticated,
+    authReady,
+    clearAuth,
+    setProfile: setAuthProfile,
+  } = useAuth();
 
   const [profile, setProfile] = useState<UserProfile | null>(null);
   const [hasChanges, setHasChanges] = useState(false);
@@ -252,6 +258,7 @@ export function useUserProfile() {
       const mapped = mapUserResponseToProfile(refreshed.data);
       setProfile(mapped);
       setOriginalProfile(mapped);
+      setAuthProfile(refreshed.data);
 
       return true;
     } catch {

--- a/src/features/user/pages/AuthContext.tsx
+++ b/src/features/user/pages/AuthContext.tsx
@@ -16,13 +16,16 @@ import {
   notifyAuthLogout,
 } from "../../../api/api";
 import { getMySanctionStatus } from "../../../api/sanction.api";
-import { ActionPromptModal } from "../../../shared/components/ActionPromptModal";
 import { markWarningPopupRead } from "../../../api/sanction.api";
+import type { UserResponse } from "../../../types/auth.types";
+import { ActionPromptModal } from "../../../shared/components/ActionPromptModal";
 
 type AuthContextType = {
   isAuthenticated: boolean;
   authReady: boolean;
   userId: number | null;
+  profile: UserResponse | null;
+  setProfile: (profile: UserResponse | null) => void;
   logoutMessage: string | null;
   setAuthenticated: (value: boolean) => void;
   setUserId: (id: number | null) => void;
@@ -43,6 +46,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [authReady, setAuthReady] = useState(false);
   const [userId, setUserId] = useState<number | null>(null);
+  const [profile, setProfile] = useState<UserResponse | null>(null);
   const [logoutMessage, setLogoutMessage] = useState<string | null>(null);
   const didBootstrap = useRef(false);
   const [warningMessage, setWarningMessage] = useState<string | null>(null);
@@ -56,6 +60,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     clearAuthState();
     setIsAuthenticated(false);
     setUserId(null);
+    setProfile(null);
   }, []);
 
   const clearLogoutMessage = useCallback(() => {
@@ -76,6 +81,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     try {
       const response = await getMyInfo();
       setUserId(response.data.id);
+      setProfile(response.data);
       setIsAuthenticated(true);
       return true;
     } catch {
@@ -208,6 +214,8 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
         isAuthenticated,
         authReady,
         userId,
+        profile,
+        setProfile,
         logoutMessage,
         setUserId,
         setAuthenticated: setIsAuthenticated,

--- a/src/shared/components/Header.tsx
+++ b/src/shared/components/Header.tsx
@@ -3,22 +3,13 @@
 import { useNavigate } from "react-router-dom";
 import { logout } from "../../api/auth.api";
 import { useAuth } from "../../features/user/pages/AuthContext";
-import { useUserProfile } from "../../features/user/hooks/useUserSetting";
 import { useAccessGuard } from "../hooks/useAccessGuard";
 import { ActionPromptModal } from "./ActionPromptModal";
 
 function HeaderProfileMenu() {
   const navigate = useNavigate();
-  const { profile } = useUserProfile();
+  const { profile } = useAuth();
 
-  const fallbackProfile = {
-    profileType: "AVATAR" as const,
-    avatarEmoji: "😊",
-    avatarColor: "#FFE5E5",
-    profileImage: "",
-  };
-
-  const displayProfile = profile ?? fallbackProfile;
   const handleLogout = async () => {
     await logout();
     navigate("/", { replace: true });
@@ -30,6 +21,10 @@ function HeaderProfileMenu() {
     });
   };
 
+  if (!profile) {
+    return <div style={{ width: "40px", height: "40px" }} />;
+  }
+
   return (
     <>
       <button className="nav-item btn-profile" type="button">
@@ -37,19 +32,18 @@ function HeaderProfileMenu() {
           className="profile-circle"
           style={{
             background:
-              displayProfile.profileType === "CUSTOM"
+              profile.profileType === "CUSTOM"
                 ? "transparent"
-                : displayProfile.avatarColor || "#FFE5E5",
+                : profile.avatarColor || "#FFE5E5",
             overflow: "hidden",
             display: "flex",
             alignItems: "center",
             justifyContent: "center",
           }}
         >
-          {displayProfile.profileType === "CUSTOM" &&
-          displayProfile.profileImage ? (
+          {profile.profileType === "CUSTOM" && profile.profileImage ? (
             <img
-              src={displayProfile.profileImage}
+              src={profile.profileImage}
               alt="Profile"
               style={{
                 width: "100%",
@@ -59,7 +53,7 @@ function HeaderProfileMenu() {
             />
           ) : (
             <span style={{ fontSize: "1.2rem" }}>
-              {displayProfile.avatarEmoji || "😊"}
+              {profile.avatarEmoji || "😊"}
             </span>
           )}
         </div>


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #124

---

## 🎨 작업 내용 (What)
- AuthContext에 로그인 사용자 `profile` 상태 추가 및 전역 관리 구조 도입
- Header에서 `useUserProfile` 제거하고 `useAuth().profile` 기반으로 프로필 표시하도록 변경
- 페이지 이동 시 Header 프로필이 기본값으로 깜빡이던 문제 제거
- 마이페이지에서 프로필 수정 후 Header에 즉시 반영되도록 Context 동기화 처리
- `useMyTrips`에서 `getMyInfo` 호출 제거하고 AuthContext 기반으로 현재 사용자 정보 사용하도록 수정
- 사용자 프로필 데이터 사용 역할 분리 (내 프로필 vs 여행 멤버 프로필)

---

## 🧭 작업 목적 (Why)
- 페이지 이동 시 Header 프로필이 fallback → 실제 프로필로 변경되며 발생하는 UI 깜빡임 문제 해결
- 동일한 사용자 정보를 여러 곳에서 중복 호출하던 구조 개선
- 프로필 수정 후 UI에 즉시 반영되지 않던 상태 불일치 문제 해결
- 인증 사용자 정보 관리 책임을 AuthContext로 일원화하여 유지보수성 향상

---

## 🧩 변경 범위
- [ ] UI / Layout
- [x] 컴포넌트 구조
- [x] 상태 관리 로직
- [x] API 연동
- [ ] 스타일

---

## 🧪 테스트 방법
- [x] 로컬 실행 확인
- [x] 주요 화면 렌더링 확인
- [x] 에러 콘솔 확인

### 추가 확인
- [x] 페이지 이동 시 Header 프로필 깜빡임 없는지 확인
- [x] 마이페이지에서 프로필 수정 후 Header 즉시 반영되는지 확인
- [x] 여행 목록/워크스페이스에서 멤버 프로필 정상 표시 확인

---

## ⚠️ 참고 사항
- AuthContext에서 사용자 profile을 전역 상태로 관리하도록 구조 변경됨
- Header 및 일부 훅에서 기존 `useUserProfile` 의존성 제거
- 마이페이지에서는 여전히 로컬 상태(`useUserProfile`)를 사용하며, 저장 시에만 Context와 동기화
- 여행 멤버 프로필은 기존 API 응답(`trip.members`)을 그대로 사용 (Context 미사용)

---

## ✅ 체크리스트
- [x] main 브랜치 직접 push 하지 않음
- [x] feature 브랜치에서 작업함
- [x] 불필요한 console.log 제거
- [x] PR 단위가 과도하게 크지 않음