### PR TITLE
[FE] refactor: 공용 안내 모달 구조 개선 및 alert 제거

### DIFF
--- a/src/shared/components/ActionPromptModal.tsx
+++ b/src/shared/components/ActionPromptModal.tsx
@@ -1,3 +1,6 @@
+// src/shared/components/ActionPromptModal.tsx
+
+import type { ReactNode } from "react";
 import "../styles/ActionPromptModal.css";
 
 interface ActionPromptModalProps {
@@ -7,8 +10,10 @@ interface ActionPromptModalProps {
   description: string;
   cancelText?: string;
   confirmText?: string;
+  hideCancel?: boolean;
   onClose: () => void;
   onConfirm: () => void;
+  children?: ReactNode;
 }
 
 export function ActionPromptModal({
@@ -18,48 +23,48 @@ export function ActionPromptModal({
   description,
   cancelText = "닫기",
   confirmText = "확인",
+  hideCancel = false,
   onClose,
   onConfirm,
+  children,
 }: ActionPromptModalProps) {
   if (!open) return null;
 
   return (
     <div
-      className="modal-overlay active"
+      className="action-prompt-overlay active"
       onMouseDown={(e) => {
         if (e.target === e.currentTarget) onClose();
       }}
     >
       <div
-        className="modal-window detail-window"
+        className="action-prompt-window"
         onMouseDown={(e) => e.stopPropagation()}
       >
-        <div className="modal-header">
-          <span className="mh-title">{title}</span>
+        <div className="action-prompt-header">
+          <span className="action-prompt-title">{title}</span>
         </div>
 
-        <div
-          className="modal-body"
-          style={{ textAlign: "center", padding: "48px 32px" }}
-        >
-          <p className="text-xl font-black uppercase tracking-tight mb-2">
-            {headline}
-          </p>
-          <p className="text-sm text-black/50 font-bold mb-8">{description}</p>
+        <div className="action-prompt-body">
+          <p className="action-prompt-headline">{headline}</p>
+          <p className="action-prompt-description">{description}</p>
 
-          <div className="flex gap-4 justify-center">
-            <button
-              onClick={onClose}
-              className="px-6 py-3 border-3 border-black bg-white font-black uppercase text-sm hover:bg-[#eee] transition-all"
-              style={{ border: "3px solid #000" }}
-              type="button"
-            >
-              {cancelText}
-            </button>
+          {children && <div className="action-prompt-extra">{children}</div>}
+
+          <div className="action-prompt-buttons">
+            {!hideCancel && (
+              <button
+                onClick={onClose}
+                className="action-prompt-cancel-btn"
+                type="button"
+              >
+                {cancelText}
+              </button>
+            )}
 
             <button
               onClick={onConfirm}
-              className="px-6 py-3 font-black uppercase text-sm transition-all button bgBlackHoverable"
+              className="action-prompt-confirm-btn"
               type="button"
             >
               {confirmText}

--- a/src/shared/hooks/useAccessGuard.ts
+++ b/src/shared/hooks/useAccessGuard.ts
@@ -14,6 +14,7 @@ export function useAccessGuard(profile?: AccessGuardProfile | null) {
 
   const [showLoginModal, setShowLoginModal] = useState(false);
   const [showAdultModal, setShowAdultModal] = useState(false);
+  const [showUnderageModal, setShowUnderageModal] = useState(false);
 
   const closeLoginModal = useCallback(() => {
     setShowLoginModal(false);
@@ -21,6 +22,10 @@ export function useAccessGuard(profile?: AccessGuardProfile | null) {
 
   const closeAdultModal = useCallback(() => {
     setShowAdultModal(false);
+  }, []);
+
+  const closeUnderageModal = useCallback(() => {
+    setShowUnderageModal(false);
   }, []);
 
   const moveToLogin = useCallback(() => {
@@ -51,7 +56,7 @@ export function useAccessGuard(profile?: AccessGuardProfile | null) {
 
     // 미성년자 먼저 차단
     if (profile?.ageVerificationStatus === "UNDERAGE") {
-      alert("만 19세 미만은 이용할 수 없습니다.");
+      setShowUnderageModal(true);
       return false;
     }
 
@@ -67,8 +72,10 @@ export function useAccessGuard(profile?: AccessGuardProfile | null) {
   return {
     showLoginModal,
     showAdultModal,
+    showUnderageModal,
     closeLoginModal,
     closeAdultModal,
+    closeUnderageModal,
     moveToLogin,
     moveToMypageForVerification,
     requireLogin,

--- a/src/shared/styles/ActionPromptModal.css
+++ b/src/shared/styles/ActionPromptModal.css
@@ -1,185 +1,123 @@
-/* ========== 외부 구조 (workspace 스타일) ========== */
-.modal-overlay {
+.action-prompt-overlay {
   position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: rgba(0, 0, 0, 0.5);
-  display: none;
+  inset: 0;
+  z-index: 9999;
+  background: rgba(0, 0, 0, 0.55);
+  display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 9999;
+  padding: 22px;
+  box-sizing: border-box;
 }
 
-.modal-overlay.active {
-  display: flex;
-}
-
-.modal-window {
-  background: white;
-  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.1);
-  overflow: hidden;
+.action-prompt-window {
+  width: min(500px, 92vw);
   max-height: 90vh;
+  background: #fff;
+  border: 2px solid #000;
+  box-shadow: 7px 7px 0 rgba(0, 0, 0, 0.5);
+  overflow: hidden;
+}
+
+.action-prompt-header {
+  background: linear-gradient(#111, #000);
+  color: #fff;
+  padding: 14px 18px;
+}
+
+.action-prompt-title {
+  font-family: var(--font-mono);
+  font-size: 16px;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+}
+
+.action-prompt-body {
+  background: #fff;
+  padding: 40px 32px;
+  text-align: center;
+  font-family: var(--font-mono);
+}
+
+.action-prompt-headline {
+  margin: 0 0 10px;
+  font-size: 20px;
+  font-weight: 900;
+}
+
+.action-prompt-description {
+  margin: 0 0 32px;
+  color: #222;
+  font-size: 14px;
+  font-weight: 700;
+  line-height: 1.6;
+}
+
+.action-prompt-extra {
+  margin-bottom: 20px;
   display: flex;
   flex-direction: column;
-}
-
-.write-window {
-  width: 90%;
-  max-width: 800px;
-}
-
-.sent-window {
-  width: 90%;
-  max-width: 700px;
-}
-
-.received-window {
-  width: 90%;
-  max-width: 900px;
-}
-
-.detail-window {
-  width: 90%;
-  max-width: 500px;
-}
-
-.modal-header {
-  display: flex;
-  justify-content: space-between;
   align-items: center;
-  padding: 20px 24px;
-  background: #000;
-  color: #fff;
-  border-bottom: 2px solid #000;
 }
 
-.mh-title {
-  font-family: "Share Tech Mono", monospace;
-  font-size: 18px;
-  font-weight: bold;
+.action-prompt-buttons {
+  display: flex;
+  gap: 16px;
+  justify-content: center;
 }
 
-.mh-close {
-  background: none;
-  border: 2px solid #fff;
-  color: #fff;
-  padding: 6px 12px;
-  font-family: "Share Tech Mono", monospace;
-  font-weight: bold;
+.action-prompt-cancel-btn,
+.action-prompt-confirm-btn {
+  min-width: 100px;
+  border: 2px solid #000;
+  padding: 10px 20px;
+  font-weight: 900;
+  font-size: 14px;
   cursor: pointer;
-  transition: 0.2s;
+  font-family: var(--font-mono);
+  transition:
+    transform 0.12s ease,
+    box-shadow 0.12s ease;
 }
 
-.mh-close:hover {
+.action-prompt-cancel-btn {
   background: #fff;
   color: #000;
 }
 
-/* ========== 내부 컨텐츠 (원래 neobrutalism 디자인) ========== */
-.modal-body {
-  padding: 24px;
-  overflow-y: auto;
-  background: #fff;
-  font-family: var(--font-mono);
+.action-prompt-confirm-btn {
+  background: #000;
+  color: #fff;
 }
 
-/* Neobrutalism 스타일 유지 */
-.modal {
-  border: 3px solid #000;
+.action-prompt-cancel-btn:hover,
+.action-prompt-confirm-btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 2px 2px 0 rgba(0, 0, 0, 0.5);
 }
 
-.header {
-  border-bottom: 3px solid #000;
+.action-prompt-cancel-btn:active,
+.action-prompt-confirm-btn:active {
+  transform: translateY(0);
+  box-shadow: none;
 }
 
-.infoBox {
+.modal-input {
+  width: 100%;
+  max-width: 360px;
+  padding: 14px 16px;
   border: 2px solid #000;
+  background-color: #fff;
+  font-family: var(--font-mono);
+  font-size: 16px;
+  font-weight: 800;
+  text-align: center;
+  outline: none;
 }
 
-.infoBoxLarge {
-  border: 3px solid #000;
-}
-
-.button {
-  border: 3px solid #000;
-  box-shadow: 4px 4px 0px rgba(0, 0, 0, 1);
-}
-
-.card {
-  border: 3px solid #000;
-}
-
-.cardApproved {
-  box-shadow: 0 0 0 4px #22c55e;
-}
-
-.cardRejected {
-  box-shadow: 0 0 0 4px #ef4444;
-}
-
-.bgBlack {
-  background-color: #000 !important;
-  color: #fff !important;
-}
-
-.bgBlackHoverable {
-  background-color: #000 !important;
-  color: #fff !important;
-}
-
-.bgBlackHoverable:hover {
-  background-color: #fff !important;
-  color: #000 !important;
-}
-
-.bgWhiteHoverable:hover {
-  background-color: #000 !important;
-  color: #fff !important;
-}
-
-.bgGreen {
-  background-color: #22c55e !important;
-  color: #fff !important;
-}
-
-.bgRed {
-  background-color: #ef4444 !important;
-  color: #fff !important;
-}
-
-.overlay {
-  background-color: rgba(0, 0, 0, 0.5);
-}
-
-.badge {
-  background-color: #000 !important;
-  color: #fff !important;
-}
-
-@keyframes shake {
-  0%,
-  100% {
-    transform: translateX(0);
-  }
-  20% {
-    transform: translateX(-8px);
-  }
-  40% {
-    transform: translateX(8px);
-  }
-  60% {
-    transform: translateX(-5px);
-  }
-  80% {
-    transform: translateX(5px);
-  }
-}
-
-.animate-shake {
-  animation: shake 0.4s cubic-bezier(0.36, 0.07, 0.19, 0.97) both;
-  transform: translate3d(0, 0, 0);
-  backface-visibility: hidden;
-  perspective: 1000px;
+.modal-error-text {
+  margin-top: 8px;
+  color: #ef4444;
+  font-size: 0.8rem;
+  font-weight: bold;
 }

--- a/src/shared/styles/Layout.css
+++ b/src/shared/styles/Layout.css
@@ -19,15 +19,6 @@ main {
   min-height: calc(100vh - 70px);
 }
 
-@keyframes fadeIn {
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
-}
-
 .section-header {
   margin-bottom: 40px;
   border-bottom: 2px solid #000;
@@ -48,94 +39,6 @@ main {
   font-size: 14px;
   color: #666;
   font-weight: 500;
-}
-
-/* 공통 버튼 스타일 */
-.btn-sm {
-  font-size: 12px;
-  font-weight: bold;
-  padding: 5px 10px;
-  border: 1px solid #000;
-  background: #fff;
-}
-.btn-sm:hover {
-  background: #000;
-  color: #fff;
-}
-
-/* === [공통 컴포넌트: 카드 & 태그] === */
-/* Mate.html과 MyTrips.html에서 공유하는 티켓 형태의 카드 */
-.mate-ticket {
-  background: #fff;
-  border: 2px solid #000;
-  display: flex;
-  align-items: center;
-  transition: 0.2s;
-  cursor: pointer;
-}
-.mate-ticket:hover {
-  box-shadow: var(--shadow-hard);
-  transform: translateX(-3px);
-}
-
-.mt-side {
-  background: #111;
-  color: #fff;
-  width: 100px;
-  padding: 20px 0;
-  text-align: center;
-  font-family: var(--font-mono);
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-}
-.mt-side span:first-child {
-  font-size: 14px;
-  opacity: 0.7;
-}
-.mt-side span:last-child {
-  font-size: 28px;
-  font-weight: bold;
-  line-height: 1.1;
-}
-
-.mt-center {
-  flex: 1;
-  padding: 20px;
-}
-
-.tag-wrap {
-  margin-bottom: 8px;
-}
-
-/* 태그 스타일 (Mate, MyTrips, Workspace 등에서 사용) */
-.sys-tag {
-  font-size: 12px;
-  font-weight: bold;
-  border: 1px solid #000;
-  padding: 2px 6px;
-  margin-right: 5px;
-  background: #f0f0f0;
-  font-family: var(--font-mono);
-}
-
-.mt-tit {
-  font-size: 18px;
-  font-weight: 800;
-  margin-bottom: 4px;
-  margin-top: 0;
-}
-.mt-txt {
-  font-size: 14px;
-  color: #666;
-  margin: 0;
-}
-
-.mt-end {
-  padding: 20px;
-  border-left: 2px dashed #000;
-  text-align: center;
-  min-width: 120px;
 }
 
 /* === [공통 모달 베이스 (Modal)] === */
@@ -203,4 +106,13 @@ main {
   padding: 0;
   position: relative;
   overflow-y: auto;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #144

---

## 🎨 작업 내용 (What)

- ActionPromptModal 공용 모달 구조 개선
- hideCancel, children 옵션 추가 및 공용 스타일 정리
- useAccessGuard 내 alert 제거 및 상태 기반 모달 처리 적용
- 공용 모달 기반 로그인 안내 흐름 적용

---

## 🧭 작업 목적 (Why)

브라우저 기본 alert/confirm 대신 공용 ActionPromptModal 기반 UI를 사용하여
사용자 안내 흐름을 통일하고 유지보수성을 개선하기 위함입니다.

또한 로그인 접근 제한 시 상태 기반 모달 흐름으로 변경하여
일관된 사용자 경험을 제공하도록 개선했습니다.

---

## 🧩 변경 범위
- [ ] UI / Layout
- [x] 컴포넌트 구조
- [x] 상태 관리 로직
- [ ] API 연동
- [x] 스타일

---

## 🧪 테스트 방법
- [x] 로컬 실행 확인
- [x] 주요 화면 렌더링 확인
- [x] 에러 콘솔 확인

---

## ⚠️ 참고 사항

- 기존 alert/confirm 기반 안내를 ActionPromptModal 기반 상태 관리 방식으로 변경했습니다.
- 기존 페이지 이동 및 로그인 흐름은 유지됩니다.

---

## ✅ 체크리스트
- [x] main 브랜치 직접 push 하지 않음
- [x] feature 브랜치에서 작업함
- [x] 불필요한 console.log 제거
- [x] PR 단위가 과도하게 크지 않음