### PR TITLE
[FE] refactor: 인증 및 사용자 설정 안내 모달 적용

### DIFF
--- a/src/features/user/components/ReportManagementTab.tsx
+++ b/src/features/user/components/ReportManagementTab.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { getMyReportHistory } from "../../../api/report.api";
 import type { MyReportHistoryResponse } from "../../../types";
 import styles from "../styles/UserSetting.module.css";
+import { ActionPromptModal } from "../../../shared/components/ActionPromptModal";
 
 const locationLabel = {
   COMMENT: "댓글",
@@ -16,6 +17,12 @@ export default function ReportManagementTab() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
   const [page, setPage] = useState(0);
+
+  const [emailModal, setEmailModal] = useState({
+    open: false,
+    headline: "",
+    description: "",
+  });
 
   useEffect(() => {
     const loadReportHistory = async () => {
@@ -38,6 +45,25 @@ export default function ReportManagementTab() {
   }, [page]);
 
   const reports = reportHistory?.reports ?? [];
+
+  const handleCopySupportEmail = async () => {
+    const email = import.meta.env.VITE_SUPPORT_EMAIL;
+
+    try {
+      await navigator.clipboard.writeText(email);
+      setEmailModal({
+        open: true,
+        headline: "문의 이메일이 복사되었습니다.",
+        description: email,
+      });
+    } catch {
+      setEmailModal({
+        open: true,
+        headline: "문의 이메일을 확인해주세요.",
+        description: email,
+      });
+    }
+  };
 
   return (
     <>
@@ -159,20 +185,26 @@ export default function ReportManagementTab() {
           type="button"
           className={styles.secondaryButton}
           style={{ width: "100%" }}
-          onClick={async () => {
-            const email = import.meta.env.VITE_SUPPORT_EMAIL;
-
-            try {
-              await navigator.clipboard.writeText(email);
-              alert(`문의 이메일이 복사되었습니다.\n${email}`);
-            } catch {
-              alert(`문의 이메일: ${email}`);
-            }
-          }}
+          onClick={handleCopySupportEmail}
         >
           신고 관련 이메일 문의하기
         </button>
       </section>
+
+      <ActionPromptModal
+        open={emailModal.open}
+        title="문의 이메일 안내"
+        headline={emailModal.headline}
+        description={emailModal.description}
+        hideCancel
+        confirmText="확인"
+        onClose={() =>
+          setEmailModal({ open: false, headline: "", description: "" })
+        }
+        onConfirm={() =>
+          setEmailModal({ open: false, headline: "", description: "" })
+        }
+      />
     </>
   );
 }

--- a/src/features/user/hooks/useUserSetting.ts
+++ b/src/features/user/hooks/useUserSetting.ts
@@ -187,6 +187,8 @@ export function useUserProfile() {
   }, [profile, originalProfile]);
 
   useEffect(() => {
+    if (!authReady || !isAuthenticated) return;
+
     getTravelStyles()
       .then((res) => {
         setTravelStyleOptions(res.data.map((style) => style.name));
@@ -194,7 +196,7 @@ export function useUserProfile() {
       .catch((error) => {
         console.error("여행 스타일 목록 조회 실패", error);
       });
-  }, []);
+  }, [authReady, isAuthenticated]);
 
   useEffect(() => {
     if (!authReady) return;

--- a/src/features/user/pages/AuthContext.tsx
+++ b/src/features/user/pages/AuthContext.tsx
@@ -42,6 +42,12 @@ const LOGOUT_SYNC_KEY = "logout-event";
 
 const AuthContext = createContext<AuthContextType | null>(null);
 
+const PUBLIC_PATHS = ["/", "/login", "/travelstory", "/mate"];
+
+const isPublicPath = () => {
+  return PUBLIC_PATHS.some((path) => location.pathname === path);
+};
+
 export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [authReady, setAuthReady] = useState(false);
@@ -117,6 +123,10 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
         await checkSanction();
       }
 
+      if (!success && isPublicPath()) {
+        setLogoutMessage(null);
+      }
+
       setAuthReady(true);
     };
 
@@ -136,6 +146,12 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
       clearAuth();
 
       if (reason === "refresh-expired") {
+        if (isPublicPath()) {
+          setLogoutMessage(null);
+          return;
+        }
+
+        setLogoutHeadline("세션 만료");
         setLogoutMessage("세션이 만료되어 다시 로그인해주세요.");
         return;
       }

--- a/src/features/user/pages/Login.tsx
+++ b/src/features/user/pages/Login.tsx
@@ -6,11 +6,13 @@ import { TicketLayout } from "../components/common/TicketLayout";
 import { TicketInfo } from "../components/common/TicketInfo";
 import { LoginForm } from "../components/LoginForm";
 import { AccountSuspendedNotice } from "../components/AccountSuspendedNotice";
+import { ActionPromptModal } from "../../../shared/components/ActionPromptModal";
 
 const Login: React.FC = () => {
   const location = useLocation();
   const navigate = useNavigate();
   const [showSuspendedNotice, setShowSuspendedNotice] = useState(false);
+  const [showLoginFailModal, setShowLoginFailModal] = useState(false);
 
   useEffect(() => {
     const params = new URLSearchParams(location.search);
@@ -30,34 +32,47 @@ const Login: React.FC = () => {
       return;
     }
 
-    alert("로그인에 실패했습니다.");
+    setShowLoginFailModal(true);
     navigate("/login", { replace: true });
   }, [location.search, navigate]);
 
   return (
-    <TicketLayout
-      leftContent={
-        <TicketInfo
-          fromCode="OUT"
-          fromName="Offline"
-          toCode="IN"
-          toName="Online"
-          tagline="Social login only"
-        />
-      }
-      rightContent={
-        showSuspendedNotice ? (
-          <AccountSuspendedNotice
-            onBack={() => {
-              setShowSuspendedNotice(false);
-              navigate("/login", { replace: true });
-            }}
+    <>
+      <TicketLayout
+        leftContent={
+          <TicketInfo
+            fromCode="OUT"
+            fromName="Offline"
+            toCode="IN"
+            toName="Online"
+            tagline="Social login only"
           />
-        ) : (
-          <LoginForm />
-        )
-      }
-    />
+        }
+        rightContent={
+          showSuspendedNotice ? (
+            <AccountSuspendedNotice
+              onBack={() => {
+                setShowSuspendedNotice(false);
+                navigate("/login", { replace: true });
+              }}
+            />
+          ) : (
+            <LoginForm />
+          )
+        }
+      />
+
+      <ActionPromptModal
+        open={showLoginFailModal}
+        title="로그인 실패"
+        headline="로그인에 실패했습니다."
+        description="잠시 후 다시 시도해주세요."
+        hideCancel
+        confirmText="확인"
+        onClose={() => setShowLoginFailModal(false)}
+        onConfirm={() => setShowLoginFailModal(false)}
+      />
+    </>
   );
 };
 

--- a/src/features/user/pages/OAuthSuccess.tsx
+++ b/src/features/user/pages/OAuthSuccess.tsx
@@ -3,6 +3,7 @@
 import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { useAuth } from "./AuthContext";
+import styles from "../styles/Login.module.css";
 
 /**
  * OAuthSuccess 컴포넌트.
@@ -42,5 +43,10 @@ export default function OAuthSuccess() {
     run();
   }, [navigate, refreshAuth]);
 
-  return <p>로그인 처리 중입니다...</p>;
+  return (
+    <div className={styles.oauthLoading}>
+      <div className={styles.spinner}></div>
+      <p>로그인 처리 중입니다...</p>
+    </div>
+  );
 }

--- a/src/features/user/pages/UserSetting.tsx
+++ b/src/features/user/pages/UserSetting.tsx
@@ -27,6 +27,13 @@ export default function UserSettings() {
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [showBirthDateModal, setShowBirthDateModal] = useState(false);
 
+  const [saveConfirmModal, setSaveConfirmModal] = useState({
+    open: false,
+    description: "",
+  });
+
+  const [leaveConfirmModal, setLeaveConfirmModal] = useState(false);
+
   const [noticeModal, setNoticeModal] = useState<{
     open: boolean;
     title: string;
@@ -104,25 +111,9 @@ export default function UserSettings() {
     };
   }, [hasChanges]);
 
-  const handleSave = async () => {
-    if (!profile) return;
-
-    const willBeLocked: string[] = [];
-    if (!profile.nameLocked && profile.name) willBeLocked.push("이름");
-    if (!profile.genderLocked && profile.gender) willBeLocked.push("성별");
-    if (!profile.birthLocked && profile.birthDate) {
-      willBeLocked.push("생년월일");
-    }
-
-    if (willBeLocked.length > 0) {
-      const confirmMessage = `${willBeLocked.join(
-        ", ",
-      )} 정보는 저장 후 수정이 불가능합니다.\n정말 저장하시겠습니까?`;
-
-      if (!window.confirm(confirmMessage)) return;
-    }
-
+  const executeSave = async () => {
     const success = await saveProfile();
+
     if (success) {
       showNotice(
         "저장 완료",
@@ -136,6 +127,29 @@ export default function UserSettings() {
         "저장에 실패했습니다. 다시 시도해주세요.",
       );
     }
+  };
+
+  const handleSave = async () => {
+    if (!profile) return;
+
+    const willBeLocked: string[] = [];
+    if (!profile.nameLocked && profile.name) willBeLocked.push("이름");
+    if (!profile.genderLocked && profile.gender) willBeLocked.push("성별");
+    if (!profile.birthLocked && profile.birthDate) {
+      willBeLocked.push("생년월일");
+    }
+
+    if (willBeLocked.length > 0) {
+      setSaveConfirmModal({
+        open: true,
+        description: `${willBeLocked.join(
+          ", ",
+        )} 정보는 저장 후 수정이 불가능합니다. 정말 저장하시겠습니까?`,
+      });
+      return;
+    }
+
+    await executeSave();
   };
 
   const handleVerify = async () => {
@@ -185,20 +199,20 @@ export default function UserSettings() {
       setShowDeleteModal(false);
       navigate("/login", { replace: true });
     } catch (error: any) {
+      setShowDeleteModal(false);
+
       const message =
         error?.response?.data?.message ||
-        "회원 탈퇴에 실패했습니다. 잠시 후 다시 시도해주세요.";
+        "정산이 완료되지 않은 여행 또는 지출/입금 내역이 있어 회원 탈퇴를 진행할 수 없습니다.";
 
-      showNotice("탈퇴 실패", "회원 탈퇴에 실패했습니다", message);
+      showNotice("탈퇴 불가", "회원 탈퇴를 진행할 수 없습니다", message);
     }
   };
 
   const handleClose = () => {
     if (hasChanges) {
-      const confirmLeave = window.confirm(
-        "수정 중인 변경사항이 있습니다. 저장하지 않고 나가시겠습니까?",
-      );
-      if (!confirmLeave) return;
+      setLeaveConfirmModal(true);
+      return;
     }
 
     navigate(location.state?.closeTo ?? "/", { replace: true });
@@ -338,8 +352,37 @@ export default function UserSettings() {
         headline={noticeModal.headline}
         description={noticeModal.description}
         confirmText="확인"
+        hideCancel
         onClose={closeNotice}
         onConfirm={closeNotice}
+      />
+
+      <ActionPromptModal
+        open={saveConfirmModal.open}
+        title="저장 확인"
+        headline="저장 후 수정할 수 없는 정보가 있습니다"
+        description={saveConfirmModal.description}
+        cancelText="취소"
+        confirmText="저장"
+        onClose={() => setSaveConfirmModal({ open: false, description: "" })}
+        onConfirm={async () => {
+          setSaveConfirmModal({ open: false, description: "" });
+          await executeSave();
+        }}
+      />
+
+      <ActionPromptModal
+        open={leaveConfirmModal}
+        title="나가기 확인"
+        headline="저장하지 않은 변경사항이 있습니다"
+        description="수정 중인 변경사항이 있습니다. 저장하지 않고 나가시겠습니까?"
+        cancelText="취소"
+        confirmText="나가기"
+        onClose={() => setLeaveConfirmModal(false)}
+        onConfirm={() => {
+          setLeaveConfirmModal(false);
+          navigate(location.state?.closeTo ?? "/", { replace: true });
+        }}
       />
     </div>
   );

--- a/src/features/user/styles/Login.module.css
+++ b/src/features/user/styles/Login.module.css
@@ -213,6 +213,38 @@
   animation: float 10s ease-in-out infinite reverse;
 }
 
+.oauthLoading {
+  min-height: 100vh;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 16px;
+}
+
+.oauthLoading p {
+  font-size: 14px;
+  color: #555;
+  font-weight: 500;
+}
+
+.spinner {
+  width: 40px;
+  height: 40px;
+  border: 4px solid #eee;
+  border-top: 4px solid #4f46e5;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+/* 애니메이션 */
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 @keyframes float {
   0%,
   100% {


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #145

---

## 🎨 작업 내용 (What)

- 로그인 실패 안내를 ActionPromptModal 기반으로 변경
- 사용자 설정 저장/나가기 확인 모달 적용
- 신고 관리 이메일 안내 모달 적용
- AuthContext PUBLIC_PATHS 추가 및 인증 안내 흐름 개선
- OAuth 로그인 처리 로딩 화면 및 스타일 추가

---

## 🧭 작업 목적 (Why)

브라우저 기본 alert/confirm 기반 안내를 제거하고
공용 ActionPromptModal 기반 UI로 사용자 안내 흐름을 통일하기 위함입니다.

또한 OAuth 로그인 처리 중 로딩 화면과 인증 상태 흐름을 정리하여
사용자 경험 및 인증 흐름 가독성을 개선했습니다.

---

## 🧩 변경 범위
- [ ] UI / Layout
- [x] 컴포넌트 구조
- [x] 상태 관리 로직
- [ ] API 연동
- [x] 스타일

---

## 🧪 테스트 방법
- [x] 로컬 실행 확인
- [x] 주요 화면 렌더링 확인
- [x] 에러 콘솔 확인

---

## ⚠️ 참고 사항

- 기존 alert/confirm 기반 안내를 ActionPromptModal 기반 상태 관리 방식으로 변경했습니다.
- OAuth 로그인 처리 중 로딩 화면을 추가했습니다.
- PUBLIC_PATHS 추가로 비로그인 접근 허용 경로를 명확히 분리했습니다.

---

## ✅ 체크리스트
- [x] main 브랜치 직접 push 하지 않음
- [x] feature 브랜치에서 작업함
- [x] 불필요한 console.log 제거
- [x] PR 단위가 과도하게 크지 않음