### PR TITLE
[FE] refactor: 내부 라우팅 Link 적용

### DIFF
--- a/src/shared/components/Header.tsx
+++ b/src/shared/components/Header.tsx
@@ -1,6 +1,6 @@
 // src/shared/components/Header.tsx
 
-import { useNavigate } from "react-router-dom";
+import { useNavigate, Link } from "react-router-dom";
 import { logout } from "../../api/auth.api";
 import { useAuth } from "../../features/user/pages/AuthContext";
 import { useAccessGuard } from "../hooks/useAccessGuard";
@@ -121,8 +121,12 @@ export default function Header() {
               COMMUNITY ▼
             </button>
             <div className="dropdown-menu">
-              <a href="/travelstory">{">>"} DATA LOGS</a>
-              <a href="/mate">{">>"} MATE FINDER</a>
+              <Link to="/travelstory" className="dropdown-item-link">
+                {">>"} DATA LOGS
+              </Link>
+              <Link to="/mate" className="dropdown-item-link">
+                {">>"} MATE FINDER
+              </Link>
             </div>
           </li>
 


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #150

---

## 🎨 작업 내용 (What)

- Header 내부 네비게이션 링크를 react-router-dom Link 기반으로 변경
- 내부 페이지 이동 시 브라우저 새로고침 제거
- Header 내부 라우팅 흐름 정리

---

## 🧭 작업 목적 (Why)

브라우저 기본 a 태그 이동 대신
react-router-dom Link 기반 내부 라우팅으로 변경하여
SPA 환경에 맞는 페이지 이동 흐름을 유지하기 위함입니다.

또한 내부 페이지 이동 시 전체 새로고침을 방지하여
사용자 경험 및 라우팅 일관성을 개선했습니다.

---

## 🧩 변경 범위
- [ ] UI / Layout
- [x] 컴포넌트 구조
- [ ] 상태 관리 로직
- [ ] API 연동
- [ ] 스타일

---

## 🧪 테스트 방법
- [x] 로컬 실행 확인
- [x] Header 내부 링크 이동 확인
- [x] 페이지 새로고침 없이 이동 확인
- [x] 에러 콘솔 확인

---

## ⚠️ 참고 사항

- 내부 네비게이션 링크를 a 태그에서 Link 컴포넌트로 변경했습니다.
- 기존 페이지 이동 흐름 및 UI 동작은 유지됩니다.

---

## ✅ 체크리스트
- [x] main 브랜치 직접 push 하지 않음
- [x] feature 브랜치에서 작업함
- [x] 불필요한 console.log 제거
- [x] PR 단위가 과도하게 크지 않음