### PR TITLE
[FE] refactor: 여행 스타일 API import 구조 정리 및 중복 참조 제거

### DIFF
--- a/src/features/travelStory/components/FilterSection.tsx
+++ b/src/features/travelStory/components/FilterSection.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
-import { getTags } from '../../../api/travelTags.api';
-import type { Tag } from '../../../api/travelTags.api';
+import { getTravelStyles } from "../../../api/auth.api";
+import type { TravelStyleOption } from "../../../types/auth.types";
 import '../styles/travelStory.css';
 import '../styles/FilterSection.css';
 
@@ -85,7 +85,7 @@ function CustomSelect({
 }
 
 function FilterSection({ filters, setFilters }: FilterSectionProps) {
-  const [travelStyles, setTravelStyles] = useState<Tag[]>([]);
+  const [travelStyles, setTravelStyles] = useState<TravelStyleOption[]>([]);
   const [isLoading, setIsLoading] = useState(true);
 
   // 태그 목록 로드 (실패 시 하드코딩된 기본값으로 fallback)
@@ -93,7 +93,7 @@ function FilterSection({ filters, setFilters }: FilterSectionProps) {
     const fetchTags = async () => {
       try {
         setIsLoading(true);
-        const response = await getTags();
+        const response = await getTravelStyles();
         setTravelStyles(response.data);
       } catch (error) {
         setTravelStyles([

--- a/src/features/travelStory/pages/WritePage.tsx
+++ b/src/features/travelStory/pages/WritePage.tsx
@@ -1,8 +1,8 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import ConfirmModal from '../components/modals/ConfirmModal';
 import { useImageUpload } from '../hooks/useImageUpload';
-import { getTags } from '../../../api/travelTags.api';
-import type { Tag } from '../../../api/travelTags.api';
+import { getTravelStyles } from "../../../api/auth.api";
+import type { TravelStyleOption } from "../../../types/auth.types";
 import '../styles/travelStory.css';
 import '../styles/WritePage.css';
 
@@ -167,7 +167,7 @@ function WritePage({
   const [confirmAction, setConfirmAction] = useState<'back' | null>(null);
   const [activeHeading, setActiveHeading] = useState<'h2' | 'h3' | null>(null);
   const [activeList, setActiveList] = useState<'ol' | 'ul' | null>(null);
-  const [travelStyles, setTravelStyles] = useState<Tag[]>([]);
+  const [travelStyles, setTravelStyles] = useState<TravelStyleOption[]>([]);
   const [selectedTags, setSelectedTags] = useState<number[]>([]);
   const [duration, setDuration] = useState(editingStory?.duration || currentDraft?.duration || '선택하세요');
   const [departureDate, setDepartureDate] = useState(editingStory?.departureDate || currentDraft?.departureDate || '');  // 여기
@@ -217,7 +217,7 @@ function WritePage({
   useEffect(() => {
     const fetchTags = async () => {
       try {
-        const response = await getTags();
+        const response = await getTravelStyles();
         setTravelStyles(response.data);
       } catch (error) {
         setTravelStyles([


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #158 
- Closes #159

---

## 🎨 작업 내용 (What)
<!-- 이번 PR에서 변경한 UI / 기능을 요약 -->

- 삭제된 `travelTags.api.ts` import 참조 제거
- 여행 스타일 API import 구조를 `auth.api.ts` 기반으로 통일
- `TravelStyleOption` 타입 import 경로 정리
- 여행 스토리 관련 Vite import resolve 오류 수정

---

## 🧭 작업 목적 (Why)
<!-- 왜 이 작업이 필요한지, 어떤 문제를 해결하는지 -->

중복 API 파일 제거 이후 남아있던 import 참조로 인해 Vite pre-transform 오류가 발생하고 있었습니다.

현재 사용 중인 여행 스타일 API 구조로 import 경로를 통일하여 불필요한 중복 참조를 제거하고, 여행 스토리 관련 화면이 정상 렌더링되도록 수정합니다.

---

## 🧩 변경 범위
- [ ] UI / Layout
- [x] 컴포넌트 구조
- [ ] 상태 관리 로직
- [x] API 연동
- [ ] 스타일

---

## 🧪 테스트 방법
- [x] 로컬 실행 확인
- [x] 주요 화면 렌더링 확인
- [x] 에러 콘솔 확인

---

## ⚠️ 참고 사항
<!-- 리뷰어가 알아야 할 내용 -->

- `travelTags.api.ts` 삭제 이후 남아있던 import 구문을 정리했습니다.
- 기능 변경 없이 import 경로 및 타입 참조 구조만 수정했습니다.
- 자동 import 정렬로 인해 일부 import 순서가 변경되었습니다.

---

## ✅ 체크리스트
- [x] main 브랜치 직접 push 하지 않음
- [x] feature 브랜치에서 작업함
- [x] 불필요한 console.log 제거
- [x] PR 단위가 과도하게 크지 않음